### PR TITLE
fix(dedup): deterministic [routed] marking via post-synthesis script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ claude-memory-system/
 │   ├── transcript_ops.py      # Transcript parsing and extraction (split from indexing)
 │   ├── decay.py                # Age-based decay for long-term memory
 │   ├── project_manager.py      # Project lifecycle management library
-│   └── devtools.py             # Repo-local dev diagnostics (not installed)
+│   └── devtools.py             # Dev diagnostics + mark-routed dedup migration
 ├── skills/                     # /remember, /synthesize, /recall, /settings, /projects
 ├── tests/                      # Unit tests
 └── templates/                  # Memory file templates + default settings.json
@@ -66,7 +66,7 @@ Session transcript → /synthesize Phase 1 → Daily summary (Actions, Decisions
 **Learning types:** `gotcha`, `pitfall`, `pattern`
 **Lesson types:** `insight`, `tip`, `workaround`
 
-**Routed entries:** Entries promoted to long-term memory during synthesis are prefixed with `[routed]` in the daily file (e.g., `- [routed][scope/type] Description`). These are skipped during short-term memory loading to avoid duplication with LTM.
+**Routed entries:** Entries that exist in both daily files and LTM are prefixed with `[routed]` (e.g., `- [routed][scope/type] Description`) and skipped at load time. Marking is handled deterministically by `devtools.py mark-routed` (runs post-synthesis), not by the synthesis subagent.
 
 **Filtering:** Tags determine which short-term memory tier content appears in:
 - `[global/*]` → Global Short-Term Memory (loaded every session)

--- a/docs/plans/2026-02-18-programmatic-dedup.md
+++ b/docs/plans/2026-02-18-programmatic-dedup.md
@@ -1,0 +1,391 @@
+# Programmatic Dedup at Load Time — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a programmatic fallback in `filter_daily_content()` that skips STM entries matching LTM entries, regardless of whether synthesis marked them `[routed]`.
+
+**Architecture:** Extract LTM entry lines after loading LTM content in `main()`, pass them through `load_daily_summaries()` and `load_project_history()` into `filter_daily_content()`, which runs `is_routed_match()` on non-`[routed]` entries. Pre-marked `[routed]` entries remain the fast path (skip match check entirely).
+
+**Tech Stack:** Python 3.9+, existing `is_routed_match()` / `extract_entry_keywords()` helpers in `memory_utils.py`.
+
+---
+
+### Task 1: Add `extract_ltm_entries()` helper to `memory_utils.py`
+
+**Files:**
+- Modify: `scripts/memory_utils.py` (after `is_routed_match()`, ~line 607)
+- Test: `tests/test_memory_utils.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/test_memory_utils.py` after the `TestRoutedMatching` class:
+
+```python
+class TestExtractLtmEntries:
+    def test_extracts_dated_entries(self):
+        content = """# Long-Term Memory
+## Key Learnings
+- (2026-02-15) [pattern] Some pattern here
+- (2026-02-12) [gotcha] Some gotcha here
+"""
+        entries = extract_ltm_entries(content)
+        assert len(entries) == 2
+        assert "Some pattern here" in entries[0]
+
+    def test_skips_non_entry_lines(self):
+        content = """## Key Learnings
+<!-- Subject to 30-day decay -->
+Some paragraph text.
+- (2026-02-15) [pattern] Real entry
+"""
+        entries = extract_ltm_entries(content)
+        assert len(entries) == 1
+
+    def test_empty_content(self):
+        assert extract_ltm_entries("") == []
+
+    def test_handles_pinned_entries(self):
+        content = """## Pinned
+- (2026-01-28) [pattern] Pinned entry
+## Key Learnings
+- (2026-02-15) [gotcha] Learning entry
+"""
+        entries = extract_ltm_entries(content)
+        assert len(entries) == 2
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_memory_utils.py::TestExtractLtmEntries -v`
+Expected: FAIL with ImportError (extract_ltm_entries not defined)
+
+**Step 3: Write minimal implementation**
+
+Add to `scripts/memory_utils.py` after `is_routed_match()` (~line 607):
+
+```python
+def extract_ltm_entries(content: str) -> list[str]:
+    """
+    Extract all dated entry lines from LTM content.
+
+    Matches lines starting with "- (YYYY-MM-DD)" pattern.
+    Returns list of raw entry lines for use with is_routed_match().
+    """
+    if not content:
+        return []
+    return [line for line in content.splitlines() if re.match(r"^\s*-\s*\(", line)]
+```
+
+Also add the import in `tests/test_memory_utils.py`:
+```python
+from memory_utils import extract_ltm_entries  # add to existing imports
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/test_memory_utils.py::TestExtractLtmEntries -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add scripts/memory_utils.py tests/test_memory_utils.py
+git commit -m "feat(dedup): add extract_ltm_entries helper"
+```
+
+---
+
+### Task 2: Add programmatic dedup to `filter_daily_content()`
+
+**Files:**
+- Modify: `scripts/memory_utils.py:456-546` (`filter_daily_content()`)
+- Test: `tests/test_memory_utils.py`
+
+**Step 1: Write the failing tests**
+
+Add to `TestFilterDailyContent` class in `tests/test_memory_utils.py`:
+
+```python
+    def test_programmatic_dedup_skips_ltm_matches(self):
+        content = """# 2026-02-01
+## Learnings
+- [global/pattern] ETL schedule awareness REBUILDDATAWAREHOUSE runs 6 PM CT
+- [global/gotcha] Something unique not in LTM
+"""
+        ltm_entries = [
+            "- (2026-01-28) [pattern] ETL schedule awareness REBUILDDATAWAREHOUSE runs 6 PM CT"
+        ]
+        result = filter_daily_content(content, "global", ltm_entries=ltm_entries)
+        assert "ETL schedule" not in result
+        assert "Something unique" in result
+
+    def test_programmatic_dedup_no_ltm_entries_passes_all(self):
+        content = """# 2026-02-01
+## Learnings
+- [global/pattern] Some pattern
+"""
+        result = filter_daily_content(content, "global", ltm_entries=None)
+        assert "Some pattern" in result
+
+    def test_programmatic_dedup_routed_prefix_skips_match_check(self):
+        """[routed] entries are already skipped; they don't need LTM match check."""
+        content = """# 2026-02-01
+## Learnings
+- [routed][global/pattern] Already marked
+- [global/gotcha] Not in LTM at all
+"""
+        ltm_entries = [
+            "- (2026-02-01) [pattern] Already marked"
+        ]
+        result = filter_daily_content(content, "global", ltm_entries=ltm_entries)
+        assert "[routed]" not in result
+        assert "Not in LTM at all" in result
+
+    def test_programmatic_dedup_empty_section_after_dedup_hidden(self):
+        """Section with all entries deduped should not appear in output."""
+        content = """# 2026-02-01
+## Learnings
+- [global/pattern] Exact match with LTM entry
+## Actions
+- [global/implement] Did something
+"""
+        ltm_entries = [
+            "- (2026-02-01) [pattern] Exact match with LTM entry"
+        ]
+        result = filter_daily_content(content, "global", ltm_entries=ltm_entries)
+        assert "## Learnings" not in result
+        assert "## Actions" in result
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_memory_utils.py::TestFilterDailyContent::test_programmatic_dedup_skips_ltm_matches -v`
+Expected: FAIL (filter_daily_content doesn't accept ltm_entries parameter yet)
+
+**Step 3: Modify `filter_daily_content()` implementation**
+
+Change the function signature at line ~456:
+
+```python
+def filter_daily_content(content: str, scope: str, ltm_entries: list[str] | None = None) -> str:
+```
+
+Add the dedup check after the scope match succeeds (inside the `if match:` block, ~line 521). The existing code is:
+
+```python
+            match = TAG_PATTERN.match(line)
+            if match:
+                entry_scope = match.group(1).lower()
+                if entry_scope == scope.lower():
+                    section_lines.append(line)
+                    section_has_content = True
+```
+
+Change to:
+
+```python
+            match = TAG_PATTERN.match(line)
+            if match:
+                entry_scope = match.group(1).lower()
+                if entry_scope == scope.lower():
+                    # Programmatic dedup: skip entries that match LTM
+                    if ltm_entries and any(
+                        is_routed_match(line, ltm) for ltm in ltm_entries
+                    ):
+                        continue
+                    section_lines.append(line)
+                    section_has_content = True
+```
+
+**Step 4: Run all filter_daily_content tests**
+
+Run: `python3 -m pytest tests/test_memory_utils.py::TestFilterDailyContent -v`
+Expected: ALL PASS
+
+**Step 5: Commit**
+
+```bash
+git add scripts/memory_utils.py tests/test_memory_utils.py
+git commit -m "feat(dedup): add programmatic LTM dedup fallback in filter_daily_content"
+```
+
+---
+
+### Task 3: Thread `ltm_entries` through loading functions
+
+**Files:**
+- Modify: `scripts/load_memory.py:138-207` (`load_daily_summaries()`, `load_project_history()`)
+- Test: `tests/test_load_memory.py`
+
+**Step 1: Write the failing tests**
+
+Add tests to `tests/test_load_memory.py` (check existing test structure first):
+
+```python
+class TestProgrammaticDedup:
+    def test_load_daily_summaries_passes_ltm_entries(self):
+        """load_daily_summaries should forward ltm_entries to filter_daily_content."""
+        # Create a daily file with an entry that matches LTM
+        with tempfile.TemporaryDirectory() as tmpdir:
+            daily_dir = Path(tmpdir) / "daily"
+            daily_dir.mkdir()
+            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            (daily_dir / f"{today}.md").write_text(
+                f"# {today}\n## Learnings\n- [global/pattern] ETL schedule REBUILDDATAWAREHOUSE runs 6 PM CT\n"
+            )
+            ltm_entries = [
+                "- (2026-01-28) [pattern] ETL schedule REBUILDDATAWAREHOUSE runs 6 PM CT"
+            ]
+            with mock.patch("load_memory.get_daily_dir", return_value=daily_dir), \
+                 mock.patch("load_memory.get_working_days", return_value=[today]):
+                summaries, _ = load_daily_summaries(1, scope="global", ltm_entries=ltm_entries)
+                # Entry should be deduped — no content returned
+                assert len(summaries) == 0
+
+    def test_load_daily_summaries_without_ltm_entries(self):
+        """Without ltm_entries, all matching-scope entries pass through."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            daily_dir = Path(tmpdir) / "daily"
+            daily_dir.mkdir()
+            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            (daily_dir / f"{today}.md").write_text(
+                f"# {today}\n## Learnings\n- [global/pattern] Some pattern\n"
+            )
+            with mock.patch("load_memory.get_daily_dir", return_value=daily_dir), \
+                 mock.patch("load_memory.get_working_days", return_value=[today]):
+                summaries, _ = load_daily_summaries(1, scope="global")
+                assert len(summaries) == 1
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_load_memory.py::TestProgrammaticDedup -v`
+Expected: FAIL (ltm_entries parameter not accepted)
+
+**Step 3: Add `ltm_entries` parameter to both functions**
+
+In `scripts/load_memory.py`, modify `load_daily_summaries()`:
+
+```python
+def load_daily_summaries(
+    days_limit: int, scope: str = "global", ltm_entries: list[str] | None = None
+) -> tuple[list[tuple[str, str]], int]:
+```
+
+And thread it through to the call at line ~158:
+```python
+                filtered_content = filter_daily_content(raw_content, scope, ltm_entries=ltm_entries)
+```
+
+Similarly modify `load_project_history()`:
+
+```python
+def load_project_history(
+    project: dict, days_limit: int, ltm_entries: list[str] | None = None
+) -> tuple[list[tuple[str, str]], int]:
+```
+
+And thread at line ~196:
+```python
+            filtered_content = filter_daily_content(raw_content, project_name, ltm_entries=ltm_entries)
+```
+
+**Step 4: Run tests**
+
+Run: `python3 -m pytest tests/test_load_memory.py -v`
+Expected: ALL PASS
+
+**Step 5: Commit**
+
+```bash
+git add scripts/load_memory.py tests/test_load_memory.py
+git commit -m "feat(dedup): thread ltm_entries through daily/project loading functions"
+```
+
+---
+
+### Task 4: Wire up in `main()` — collect LTM entries, pass to loaders
+
+**Files:**
+- Modify: `scripts/load_memory.py:424-579` (`main()`)
+- No new tests (integration-level wiring)
+
+**Step 1: Add `extract_ltm_entries` import**
+
+Add to the existing imports from `memory_utils` at line ~30:
+
+```python
+from memory_utils import (
+    ...
+    extract_ltm_entries,
+    ...
+)
+```
+
+**Step 2: Collect LTM entries after loading LTM content**
+
+After line ~528 (after global LTM is loaded and printed), add:
+
+```python
+    # Collect LTM entries for programmatic dedup of short-term memory
+    all_ltm_entries = extract_ltm_entries(global_content)
+```
+
+After line ~545 (after project LTM is loaded and printed), add to the project block:
+
+```python
+            if project_content:
+                all_ltm_entries.extend(extract_ltm_entries(project_content))
+```
+
+**Step 3: Pass LTM entries to short-term loaders**
+
+Change line ~549:
+```python
+    global_summaries, global_daily_bytes = load_daily_summaries(
+        short_term_days, scope="global", ltm_entries=all_ltm_entries
+    )
+```
+
+Change line ~562:
+```python
+        project_history, history_bytes = load_project_history(
+            current_project, project_days, ltm_entries=all_ltm_entries
+        )
+```
+
+**Step 4: Run full test suite**
+
+Run: `python3 -m pytest tests/ -q`
+Expected: ALL PASS
+
+**Step 5: Run token_usage.py to verify improvement**
+
+Run: `python3 scripts/token_usage.py`
+Expected: project STM tokens should decrease (entries matching LTM now filtered at load time)
+
+**Step 6: Verify no routed entries in output**
+
+Run: `echo '{"session_id": "test"}' | python3 scripts/load_memory.py 2>/dev/null | grep -c "\[routed\]"`
+Expected: 0 (excluding synthesis prompt text — grep the memory sections only)
+
+**Step 7: Commit**
+
+```bash
+git add scripts/load_memory.py
+git commit -m "feat(dedup): wire programmatic LTM dedup into main() loading flow"
+```
+
+---
+
+### Task 5: Update ticket acceptance criteria
+
+**Files:**
+- Modify: `docs/tickets/routed-dedup-incomplete.md`
+
+Mark acceptance criteria as checked and close the ticket.
+
+```bash
+git add docs/tickets/routed-dedup-incomplete.md
+git commit -m "docs: mark routed-dedup ticket acceptance criteria complete"
+```

--- a/docs/tickets/2026-02-18-routed-dedup-incomplete.md
+++ b/docs/tickets/2026-02-18-routed-dedup-incomplete.md
@@ -1,0 +1,75 @@
+# Ticket: [routed] dedup filtering implemented but inconsistently applied
+
+**Date:** 2026-02-18
+**Priority:** Medium
+**Component:** synthesis, load_memory.py
+**Related:** docs/plans/2026-02-12-routed-dedup-design.md, docs/plans/2026-02-12-routed-dedup-implementation.md
+
+## Problem
+
+The `[routed]` dedup system (designed 2026-02-12) is partially implemented:
+
+- `filter_daily_content()` correctly skips `[routed]` entries at load time (Task 1 done)
+- Keyword matching helpers (`extract_entry_keywords`, `is_routed_match`) exist (Task 3 helpers done)
+- Synthesis prompt includes `[routed]` marking instructions (Task 2 done)
+
+But synthesis is **not consistently marking entries** as `[routed]`. Measured on 2026-02-18 for the `investing` project (5 short-term working days):
+
+| Day | Routed | Unrouted | Total |
+|-----|--------|----------|-------|
+| 2026-02-14 | 0 | 0 | 0 (no investing entries) |
+| 2026-02-15 | 3 | 39 | 42 |
+| 2026-02-16 | 0 | 34 | 34 |
+| 2026-02-17 | 3 | 24 | 27 |
+| 2026-02-18 | 8 | 13 | 21 |
+
+Only 14 of 124 investing entries are marked `[routed]` (11%). Many entries exist in both the daily file AND the project long-term memory file, loading duplicate content into every session.
+
+## Impact
+
+- ~3,145 duplicate tokens loaded per session (estimated)
+- Project short-term at 5,544 tokens (106% of 5,250 limit), would drop to ~2,400 with proper dedup
+- 3 of 4 memory components over their individual limits (global LTM 105%, project LTM 101%, project STM 106%)
+- Total memory at 96% of budget, growing
+
+## Root Cause
+
+The synthesis subagent receives the `[routed]` instruction but doesn't reliably follow it. Likely reasons:
+
+1. **Instruction buried in long prompt** — the `[routed]` marking instruction competes with many other synthesis instructions for attention
+2. **No enforcement** — marking is purely instruction-based with no programmatic verification
+3. **One-time migration never run** — the `devtools.py mark-routed` command exists but was never executed against the daily files, so the backlog of unmarked entries persists
+
+## Proposed Fix
+
+### Option A: Run migration + reinforce prompt (low effort)
+
+1. Run `python3 scripts/devtools.py mark-routed` to retroactively mark existing duplicates
+2. Move the `[routed]` instruction higher in the synthesis prompt (before routing instructions, not after)
+3. Add a post-synthesis verification step: after synthesis writes daily files, scan for entries that match LTM and mark any the subagent missed
+
+### Option B: Programmatic dedup at load time (medium effort, more robust)
+
+Instead of relying on the synthesis subagent to mark entries, filter duplicates programmatically when loading short-term memory:
+
+1. At load time, collect all LTM entry keywords
+2. For each STM entry, run `is_routed_match()` against LTM entries
+3. Skip matches (same as `[routed]` filtering, but computed live)
+4. Keep `[routed]` markers as an optimization hint (skip the match check for pre-marked entries)
+
+Trade-off: adds ~50-100ms to session startup but eliminates dependence on subagent compliance.
+
+### Option C: Hybrid (recommended)
+
+1. Run the one-time migration now (Option A step 1)
+2. Add programmatic dedup as a fallback at load time (Option B)
+3. Keep synthesis `[routed]` marking as a fast path (pre-marked entries skip the match check)
+
+This gives immediate relief (migration), long-term robustness (programmatic fallback), and performance (pre-marked fast path).
+
+## Acceptance Criteria
+
+- [ ] `python3 scripts/token_usage.py` shows project STM under 5,250 token limit
+- [ ] `echo '{"session_id": "test"}' | python3 scripts/load_memory.py 2>/dev/null | grep -c "\[routed\]"` returns 0 (no routed entries in output, excluding synthesis prompt text)
+- [ ] Entries that exist in both LTM and daily files are not loaded twice
+- [ ] Full test suite passes

--- a/install.py
+++ b/install.py
@@ -146,6 +146,7 @@ def link_scripts(script_dir: Path) -> None:
         "transcript_ops.py",  # Transcript parsing and extraction (split from indexing)
         "project_manager.py",  # Project lifecycle management
         "decay.py",  # Age-based decay for long-term memory
+        "devtools.py",  # Dev diagnostics and mark-routed migration
         "token_usage.py",  # Token usage calculation for /settings
     ]
 

--- a/scripts/devtools.py
+++ b/scripts/devtools.py
@@ -268,15 +268,15 @@ def cmd_mark_routed(args: argparse.Namespace) -> int:
         file_marked = 0
         new_lines = []
 
-        in_learnings_or_lessons = False
+        in_routable_section = False
         for line in lines:
-            # Track if we're in a Learnings or Lessons section
+            # Track if we're in a routable section
             if line.startswith("## "):
                 section = line.strip("# ").strip()
-                in_learnings_or_lessons = section in ("Learnings", "Lessons")
+                in_routable_section = section in ("Actions", "Decisions", "Learnings", "Lessons")
 
-            # Only check entries in Learnings/Lessons sections
-            if (in_learnings_or_lessons
+            # Only check entries in routable sections
+            if (in_routable_section
                     and re.match(r"^\s*-\s*\[(?!routed)", line)  # tagged entry, not already routed
                     and any(is_routed_match(line, ltm) for ltm in ltm_entries)):
                 new_lines.append(re.sub(r"^(\s*-\s*)", r"\1[routed]", line))
@@ -295,6 +295,43 @@ def cmd_mark_routed(args: argparse.Namespace) -> int:
 
     action = "Would mark" if dry_run else "Marked"
     print(f"\n{action} {total_marked} entries across all daily files")
+
+    # 3. Deduplicate within each LTM file
+    ltm_files = []
+    if global_ltm.exists():
+        ltm_files.append(global_ltm)
+    if project_dir.exists():
+        ltm_files.extend(project_dir.glob("*-long-term-memory.md"))
+
+    total_deduped = 0
+    for ltm_file in ltm_files:
+        lines = ltm_file.read_text(encoding="utf-8").splitlines()
+        seen_entries: set[str] = set()
+        new_lines = []
+        file_deduped = 0
+
+        for line in lines:
+            # Only dedup dated entry lines
+            if re.match(r"^\s*-\s*\(", line):
+                normalized = line.strip()
+                if normalized in seen_entries:
+                    file_deduped += 1
+                    continue
+                seen_entries.add(normalized)
+            new_lines.append(line)
+
+        if file_deduped:
+            if dry_run:
+                print(f"  {ltm_file.name}: would remove {file_deduped} duplicate entries")
+            else:
+                ltm_file.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+                print(f"  {ltm_file.name}: removed {file_deduped} duplicate entries")
+            total_deduped += file_deduped
+
+    if total_deduped:
+        action = "Would remove" if dry_run else "Removed"
+        print(f"\n{action} {total_deduped} duplicate LTM entries")
+
     return 0
 
 

--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -276,11 +276,6 @@ Destinations: `[global/*]` → `~/.claude/memory/global-long-term-memory.md`, `[
 Only use registered project names for routing: ''' + project_names_str + '''
 Format: `(YYYY-MM-DD) [type] Description` (remove scope from tag, file is already scoped). Check for duplicates before adding.
 
-**Dedup marking:** When you route an entry from the daily summary to long-term memory, prefix that entry in the daily file with `[routed]`. Example:
-Before: `- [claude-memory-system/gotcha] Missing import crashed indexing`
-After routing to LTM: `- [routed][claude-memory-system/gotcha] Missing import crashed indexing`
-This prevents the entry from loading twice (once from LTM, once from short-term). Only prefix entries you actually route — leave non-routed entries unchanged.
-
 Create missing project files from template at `~/.claude/memory/templates/project-long-term-memory.md`.
 
 **Global LTM auto-pinned maintenance:** The global LTM has auto-pinned sections (About Me, Current Projects, Technical Environment, Patterns & Preferences) containing factual profile info. When transcripts show clear evidence of change — a project completed or cancelled, a new tool adopted, a workflow changed — update or remove the relevant entry. Be conservative: only update when clearly stale, not speculatively.
@@ -363,7 +358,7 @@ CRITICAL: Do NOT make separate Edit calls per learning. Collect all items first,
 Run ALL of this in a **single Bash call**:
 ```bash
 {mark_captured_lines}
-python3 $HOME/.claude/scripts/decay.py && python3 -c "from datetime import datetime, timezone; from pathlib import Path; Path.home().joinpath('.claude/memory/.last-synthesis').write_text(datetime.now(timezone.utc).isoformat())"
+python3 $HOME/.claude/scripts/devtools.py mark-routed && python3 $HOME/.claude/scripts/decay.py && python3 -c "from datetime import datetime, timezone; from pathlib import Path; Path.home().joinpath('.claude/memory/.last-synthesis').write_text(datetime.now(timezone.utc).isoformat())"
 ```
 
 Return a summary: "Processed N days. Created/updated daily summaries for [dates]. Routed X items to long-term memory (list them). Archived Y old items."'''
@@ -415,7 +410,7 @@ CRITICAL: Do NOT make separate Edit calls per learning — batch all items into 
 
 Run ALL of this in a **single Bash call** — mark captured, remove temp files, run decay, and update timestamp:
 ```bash
-python3 $HOME/.claude/scripts/indexing.py mark-captured --sidecar /tmp/memory-extract-YYYY-MM-DD-$$.sessions && rm /tmp/memory-extract-YYYY-MM-DD-$$.txt /tmp/memory-extract-YYYY-MM-DD-$$.sessions && python3 $HOME/.claude/scripts/decay.py && python3 -c "from datetime import datetime, timezone; from pathlib import Path; Path.home().joinpath('.claude/memory/.last-synthesis').write_text(datetime.now(timezone.utc).isoformat())"
+python3 $HOME/.claude/scripts/indexing.py mark-captured --sidecar /tmp/memory-extract-YYYY-MM-DD-$$.sessions && rm /tmp/memory-extract-YYYY-MM-DD-$$.txt /tmp/memory-extract-YYYY-MM-DD-$$.sessions && python3 $HOME/.claude/scripts/devtools.py mark-routed && python3 $HOME/.claude/scripts/decay.py && python3 -c "from datetime import datetime, timezone; from pathlib import Path; Path.home().joinpath('.claude/memory/.last-synthesis').write_text(datetime.now(timezone.utc).isoformat())"
 ```
 
 Return a summary: "Processed N days. Created/updated daily summaries for [dates]. Routed X items to long-term memory (list them). Archived Y old items."'''

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -509,6 +509,10 @@ def filter_daily_content(content: str, scope: str) -> str:
 
         # If we're in a section, process the line
         if current_section:
+            # Skip HTML comments (template hints, not useful at load time)
+            if re.match(r"^\s*<!--.*-->\s*$", line):
+                continue
+
             # Skip entries marked as routed to LTM
             if re.match(r"^\s*-\s*\[routed\]", line):
                 continue

--- a/tests/test_load_memory.py
+++ b/tests/test_load_memory.py
@@ -342,13 +342,17 @@ class TestLoadProjectHistory:
 
 
 class TestSynthesisPromptRoutedMarker:
-    """Verify synthesis prompt instructs subagent to prefix routed entries."""
+    """Verify [routed] marking is handled by post-synthesis mark-routed script, not subagent."""
 
-    def test_prompt_contains_routed_instruction(self):
-        """The synthesis prompt must tell the subagent to prefix routed entries."""
+    def test_prompt_does_not_contain_routed_instruction(self):
+        """Subagent should NOT be told to mark [routed] — devtools.py mark-routed handles it."""
         prompt = _build_synthesis_prompt("", ["2026-02-01"])
-        assert "[routed]" in prompt
-        assert "prefix" in prompt.lower() or "mark" in prompt.lower()
+        assert "Dedup marking" not in prompt
+
+    def test_prompt_contains_mark_routed_in_cleanup(self):
+        """Step 3 bash command should run mark-routed after synthesis."""
+        prompt = _build_synthesis_prompt("", ["2026-02-01"])
+        assert "devtools.py mark-routed" in prompt
 
 
 if __name__ == "__main__":

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -362,6 +362,28 @@ class TestFilterDailyContent:
         result = filter_daily_content(content, "global")
         assert "[Global/implement]" in result
 
+    def test_html_comments_stripped(self):
+        content = """# 2026-02-01
+## Actions
+<!-- What was done. Tag [scope/action]. -->
+- [global/implement] Set up new hooks
+"""
+        result = filter_daily_content(content, "global")
+        assert "<!--" not in result
+        assert "[global/implement]" in result
+
+    def test_html_comments_dont_count_as_content(self):
+        """Section with only comments and no entries should not appear."""
+        content = """# 2026-02-01
+## Actions
+<!-- What was done. Tag [scope/action]. -->
+## Learnings
+- [global/pattern] Some pattern
+"""
+        result = filter_daily_content(content, "global")
+        assert "## Actions" not in result
+        assert "## Learnings" in result
+
     def test_routed_entries_skipped(self):
         content = """# 2026-02-01
 ## Learnings


### PR DESCRIPTION
## Summary
- Replace unreliable subagent `[routed]` marking (~30% compliance) with deterministic `devtools.py mark-routed` run as post-synthesis cleanup
- Expand mark-routed to scan all 4 daily file sections (was Learnings/Lessons only) and deduplicate within LTM files
- Strip HTML comments from daily files at load time to save ~100-150 tokens/session
- Install devtools.py to `~/.claude/scripts/` so synthesis subagent can invoke it

## Impact
- Migration run: 184 daily entries marked, 9 LTM duplicates removed
- Token savings: ~1,490 tokens/session, all components now under budget
- Global LTM: 5,247 → 4,902 (was 105% of limit, now 98%)
- Project STM: 3,322 → 2,192 (42% of limit)

## Test plan
- [x] 238 unit tests passing
- [x] `mark-routed --dry-run` previews correctly before applying
- [x] `token_usage.py` shows all components under budget
- [x] Ruff lint passes on all modified files

Co-Authored-By: Claude <noreply@anthropic.com>