### PR TITLE
feat(quality): improve LTM dedup, routing, and validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,8 +139,8 @@ Use `/settings` skill to view/modify. Key settings in `~/.claude/memory/settings
 | Setting | Default | Notes |
 |---------|---------|-------|
 | `globalShortTerm.workingDays` | 2 | Days of global daily summaries |
-| `projectShortTerm.workingDays` | 7 | Days of project history |
-| `*LongTerm.tokenLimit` | 5,000 | Fixed limit per long-term file |
+| `projectShortTerm.workingDays` | 5 | Days of project history |
+| `*LongTerm.tokenLimit` | 3,000 | Fixed limit per long-term file |
 | `synthesis.intervalHours` | 2 | Hours between auto-synthesis |
 | `synthesis.model` | sonnet | Model for synthesis subagent |
 | `synthesis.background` | true | Run auto-synthesis in background |

--- a/scripts/devtools.py
+++ b/scripts/devtools.py
@@ -296,7 +296,7 @@ def cmd_mark_routed(args: argparse.Namespace) -> int:
     action = "Would mark" if dry_run else "Marked"
     print(f"\n{action} {total_marked} entries across all daily files")
 
-    # 3. Deduplicate within each LTM file
+    # 3. Deduplicate within each LTM file (exact match + keyword similarity)
     ltm_files = []
     if global_ltm.exists():
         ltm_files.append(global_ltm)
@@ -306,7 +306,8 @@ def cmd_mark_routed(args: argparse.Namespace) -> int:
     total_deduped = 0
     for ltm_file in ltm_files:
         lines = ltm_file.read_text(encoding="utf-8").splitlines()
-        seen_entries: set[str] = set()
+        seen_exact: set[str] = set()
+        seen_keyword_entries: list[str] = []
         new_lines = []
         file_deduped = 0
 
@@ -314,10 +315,19 @@ def cmd_mark_routed(args: argparse.Namespace) -> int:
             # Only dedup dated entry lines
             if re.match(r"^\s*-\s*\(", line):
                 normalized = line.strip()
-                if normalized in seen_entries:
+                # Exact match dedup
+                if normalized in seen_exact:
                     file_deduped += 1
                     continue
-                seen_entries.add(normalized)
+                # Keyword similarity dedup (catches near-duplicates)
+                # 0.7 threshold: below this, domain vocabulary overlap causes false positives
+                if any(is_routed_match(normalized, seen, threshold=0.7) for seen in seen_keyword_entries):
+                    if dry_run:
+                        print(f"    near-dup: {normalized[:80]}...")
+                    file_deduped += 1
+                    continue
+                seen_exact.add(normalized)
+                seen_keyword_entries.append(normalized)
             new_lines.append(line)
 
         if file_deduped:
@@ -332,6 +342,97 @@ def cmd_mark_routed(args: argparse.Namespace) -> int:
         action = "Would remove" if dry_run else "Removed"
         print(f"\n{action} {total_deduped} duplicate LTM entries")
 
+    return 0
+
+
+def cmd_validate_ltm(args: argparse.Namespace) -> int:
+    """Validate LTM files for duplicates, misrouted entries, and entry count."""
+    import re
+
+    sys.path.insert(0, str(REPO_DIR / "scripts"))
+    from memory_utils import (
+        get_global_memory_file,
+        get_project_memory_dir,
+        get_projects_index_file,
+        is_routed_match,
+        load_json_file,
+    )
+
+    issues: list[str] = []
+
+    # Load registered project names
+    projects_index = load_json_file(get_projects_index_file(), {})
+    registered_projects = {
+        data.get("name", "")
+        for data in projects_index.get("projects", {}).values()
+        if data.get("name")
+    }
+
+    # Collect all LTM files
+    ltm_files: list[tuple[str, Path]] = []
+    global_ltm = get_global_memory_file()
+    if global_ltm.exists():
+        ltm_files.append(("global", global_ltm))
+
+    project_dir = get_project_memory_dir()
+    if project_dir.exists():
+        for pfile in project_dir.glob("*-long-term-memory.md"):
+            # Extract project name from filename
+            pname = pfile.stem.replace("-long-term-memory", "")
+            ltm_files.append((pname, pfile))
+
+    for scope, ltm_file in ltm_files:
+        lines = ltm_file.read_text(encoding="utf-8").splitlines()
+        entries: list[str] = []
+        entry_count = 0
+
+        for line in lines:
+            if re.match(r"^\s*-\s*\(", line):
+                normalized = line.strip()
+                entry_count += 1
+                # Check exact duplicates
+                if normalized in entries:
+                    issues.append(f"[{scope}] EXACT DUP: {normalized[:80]}...")
+                else:
+                    # Check near-duplicates (0.7 threshold avoids domain vocabulary false positives)
+                    for existing in entries:
+                        if is_routed_match(normalized, existing, threshold=0.7):
+                            issues.append(
+                                f"[{scope}] NEAR DUP:\n"
+                                f"  kept: {existing[:80]}...\n"
+                                f"  dup:  {normalized[:80]}..."
+                            )
+                            break
+                entries.append(normalized)
+
+        # Check entry count in decay-eligible sections
+        in_decay_section = False
+        decay_count = 0
+        for line in lines:
+            if line.startswith("## "):
+                section = line.strip("# ").strip()
+                in_decay_section = section in (
+                    "Key Actions", "Key Decisions", "Key Learnings", "Key Lessons"
+                )
+            elif in_decay_section and re.match(r"^\s*-\s*\(", line):
+                decay_count += 1
+
+        if decay_count > 40:
+            issues.append(f"[{scope}] HIGH ENTRY COUNT: {decay_count} entries in decay sections (consider pruning)")
+
+        # Check unregistered project files
+        if scope != "global" and scope not in registered_projects:
+            issues.append(f"[{scope}] UNREGISTERED PROJECT: {ltm_file.name} has no match in projects-index.json")
+
+        print(f"  {ltm_file.name}: {entry_count} entries ({decay_count} in decay sections)")
+
+    if issues:
+        print(f"\n{len(issues)} issue(s) found:")
+        for issue in issues:
+            print(f"  - {issue}")
+        return 1
+
+    print("\nNo issues found.")
     return 0
 
 
@@ -355,6 +456,9 @@ def main() -> int:
     mr = sub.add_parser("mark-routed", help="Mark daily entries that exist in LTM with [routed] prefix")
     mr.add_argument("--dry-run", action="store_true", help="Preview changes without modifying files")
     mr.set_defaults(func=cmd_mark_routed)
+
+    vl = sub.add_parser("validate-ltm", help="Validate LTM files for duplicates and issues")
+    vl.set_defaults(func=cmd_validate_ltm)
 
     args = parser.parse_args()
     if not args.command:

--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -266,15 +266,23 @@ Never use multiple Edit calls on daily files.
 
 **Tag format:** `[scope/type]` where scope is `global` or one of these registered project names: ''' + project_names_str + '''
 **IMPORTANT:** Only use the project names listed above. Do NOT invent new project names from context.
-**Scope rule:** Use `global` ONLY for learnings that apply across multiple projects (SQL patterns, MCP behavior, Claude Code tool usage, general dev practices). If a learning is specific to one project's codebase, architecture, or workflow, use that project's name even if the concept seems general.
+**Scope rule:** Use `global` ONLY for learnings that apply across ALL projects — general dev practices, SQL patterns, OS/tool behavior, Claude Code mechanics. If a learning arose while working on a specific project (debugging that project's code, that project's architecture, tools used primarily for that project), it belongs to that project even if the concept seems general. When in doubt, use the project name — project scope is almost always correct.
 **Compactness:** Final solutions only, one learning per concept, omit routine details.
 
 **Long-term routing (be HIGHLY selective):**
-Route TO long-term memory ONLY: fundamental patterns, hard-won lessons, safety-critical info, non-obvious gotchas, architecture decisions with lasting impact.
+Route daily entries to corresponding LTM sections:
+- Daily `## Actions` → LTM `## Key Actions` (multi-day implementations, novel integrations, reusable setups)
+- Daily `## Decisions` → LTM `## Key Decisions` (architecture choices, design tradeoffs, scope decisions with lasting impact)
+- Daily `## Learnings` → LTM `## Key Learnings` (non-obvious gotchas, proven patterns, hard-won lessons)
+- Daily `## Lessons` → LTM `## Key Lessons` (mental models, useful commands, workarounds)
 Do NOT route: routine implementation, version-specific fixes, one-time configs, easily re-discoverable things, learnings that might not hold up over time.
 Destinations: `[global/*]` → `~/.claude/memory/global-long-term-memory.md`, `[{project-name}/*]` → `~/.claude/memory/project-memory/{project-name}-long-term-memory.md`
 Only use registered project names for routing: ''' + project_names_str + '''
-Format: `(YYYY-MM-DD) [type] Description` (remove scope from tag, file is already scoped). Check for duplicates before adding.
+Format: `(YYYY-MM-DD) [type] Description` (remove scope from tag, file is already scoped).
+
+**DEDUP REQUIREMENT:** In Step 1 you read the LTM files. Before adding ANY entry, check your Step 1 reads for existing entries that cover the same concept — even if worded differently. If an existing entry covers the topic, do NOT add a near-duplicate. Only add entries that represent genuinely new knowledge.
+
+**GRANULARITY CAP:** Maximum 5 routed entries per target LTM file per synthesis run. If you have more, consolidate related items (e.g., multiple gotchas from one debugging session → one summary entry). Prefer fewer, denser entries over many granular ones.
 
 Create missing project files from template at `~/.claude/memory/templates/project-long-term-memory.md`.
 
@@ -358,7 +366,7 @@ CRITICAL: Do NOT make separate Edit calls per learning. Collect all items first,
 Run ALL of this in a **single Bash call**:
 ```bash
 {mark_captured_lines}
-python3 $HOME/.claude/scripts/devtools.py mark-routed && python3 $HOME/.claude/scripts/decay.py && python3 -c "from datetime import datetime, timezone; from pathlib import Path; Path.home().joinpath('.claude/memory/.last-synthesis').write_text(datetime.now(timezone.utc).isoformat())"
+python3 $HOME/.claude/scripts/devtools.py mark-routed && python3 $HOME/.claude/scripts/devtools.py validate-ltm; python3 $HOME/.claude/scripts/decay.py && python3 -c "from datetime import datetime, timezone; from pathlib import Path; Path.home().joinpath('.claude/memory/.last-synthesis').write_text(datetime.now(timezone.utc).isoformat())"
 ```
 
 Return a summary: "Processed N days. Created/updated daily summaries for [dates]. Routed X items to long-term memory (list them). Archived Y old items."'''
@@ -410,7 +418,7 @@ CRITICAL: Do NOT make separate Edit calls per learning — batch all items into 
 
 Run ALL of this in a **single Bash call** — mark captured, remove temp files, run decay, and update timestamp:
 ```bash
-python3 $HOME/.claude/scripts/indexing.py mark-captured --sidecar /tmp/memory-extract-YYYY-MM-DD-$$.sessions && rm /tmp/memory-extract-YYYY-MM-DD-$$.txt /tmp/memory-extract-YYYY-MM-DD-$$.sessions && python3 $HOME/.claude/scripts/devtools.py mark-routed && python3 $HOME/.claude/scripts/decay.py && python3 -c "from datetime import datetime, timezone; from pathlib import Path; Path.home().joinpath('.claude/memory/.last-synthesis').write_text(datetime.now(timezone.utc).isoformat())"
+python3 $HOME/.claude/scripts/indexing.py mark-captured --sidecar /tmp/memory-extract-YYYY-MM-DD-$$.sessions && rm /tmp/memory-extract-YYYY-MM-DD-$$.txt /tmp/memory-extract-YYYY-MM-DD-$$.sessions && python3 $HOME/.claude/scripts/devtools.py mark-routed && python3 $HOME/.claude/scripts/devtools.py validate-ltm; python3 $HOME/.claude/scripts/decay.py && python3 -c "from datetime import datetime, timezone; from pathlib import Path; Path.home().joinpath('.claude/memory/.last-synthesis').write_text(datetime.now(timezone.utc).isoformat())"
 ```
 
 Return a summary: "Processed N days. Created/updated daily summaries for [dates]. Routed X items to long-term memory (list them). Archived Y old items."'''

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -117,14 +117,14 @@ DEFAULT_SETTINGS = {
         # tokenLimit calculated: workingDays × SHORT_TERM_TOKENS_PER_DAY
     },
     "globalLongTerm": {
-        "tokenLimit": 5000,
+        "tokenLimit": 3000,
     },
     "projectShortTerm": {
-        "workingDays": 7,
+        "workingDays": 5,
         # tokenLimit calculated: workingDays × SHORT_TERM_TOKENS_PER_DAY
     },
     "projectLongTerm": {
-        "tokenLimit": 5000,
+        "tokenLimit": 3000,
     },
     "projectSettings": {
         "includeSubdirectories": False,

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -6,15 +6,15 @@
     "_comment": "Global short-term filtered to [global/*] tags - tokenLimit: workingDays × 750"
   },
   "globalLongTerm": {
-    "tokenLimit": 5000,
+    "tokenLimit": 3000,
     "_comment": "global-long-term-memory.md - user profile, patterns, preferences"
   },
   "projectShortTerm": {
-    "workingDays": 7,
+    "workingDays": 5,
     "_comment": "Project short-term filtered to [project/*] tags - tokenLimit: workingDays × 750"
   },
   "projectLongTerm": {
-    "tokenLimit": 5000,
+    "tokenLimit": 3000,
     "_comment": "project-memory/{project}-long-term-memory.md - project-specific learnings"
   },
   "projectSettings": {
@@ -37,20 +37,20 @@
     "estimation": "1 token ≈ 4 characters. File bytes / 4 = rough token count",
     "formula": "Short-term limits = workingDays × 750 (based on ~400-600 observed after scope filtering)",
     "fixedLimits": {
-      "globalLongTerm": 5000,
-      "projectLongTerm": 5000
+      "globalLongTerm": 3000,
+      "projectLongTerm": 3000
     },
     "calculatedLimits": {
       "globalShortTerm": "2 days × 750 = 1500",
-      "projectShortTerm": "7 days × 750 = 5250",
-      "total": "5000 + 1500 + 5000 + 5250 = 16750"
+      "projectShortTerm": "5 days × 750 = 3750",
+      "total": "3000 + 1500 + 3000 + 3750 = 11250"
     }
   },
   "_defaults": {
     "globalShortTerm.workingDays": 2,
-    "globalLongTerm.tokenLimit": 5000,
-    "projectShortTerm.workingDays": 7,
-    "projectLongTerm.tokenLimit": 5000,
+    "globalLongTerm.tokenLimit": 3000,
+    "projectShortTerm.workingDays": 5,
+    "projectLongTerm.tokenLimit": 3000,
     "projectSettings.includeSubdirectories": false,
     "synthesis.intervalHours": 2,
     "synthesis.model": "sonnet",

--- a/tests/test_devtools.py
+++ b/tests/test_devtools.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""
+Unit tests for devtools.py — keyword dedup and validate-ltm.
+
+Run with: python -m pytest tests/test_devtools.py -v
+"""
+
+import argparse
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Add scripts directory to path
+scripts_dir = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(scripts_dir))
+
+from memory_utils import (  # noqa: E402
+    extract_entry_keywords,
+    is_routed_match,
+)
+
+# ── Keyword dedup: real-world near-duplicates from the audit ──
+
+
+class TestKeywordDedupRealWorldCases:
+    """Test cases derived from actual duplicates found in global LTM audit."""
+
+    def test_happy_mcp_duplicate_different_backtick_style(self):
+        """Lines 82 and 90 were near-identical, differing only in backtick usage."""
+        entry1 = "- (2026-02-15) [gotcha] Happy's MCP tools only available when launched via `happy` CLI — sessions started directly with `claude` don't have access to mcp__happy__change_title or mobile interface tools"
+        entry2 = "- (2026-02-15) [gotcha] Happy's MCP tools only available when launched via `happy` CLI — sessions started directly with `claude` don't have access to `mcp__happy__change_title` or mobile interface tools"
+        assert is_routed_match(entry1, entry2, threshold=0.6) is True
+
+    def test_worktree_cwd_mismatch_triple_duplicate(self):
+        """Lines 84, 94, 104 — same concept, different path examples."""
+        entry1 = "- (2026-02-15) [gotcha] Running commands from wrong directory in worktree setups causes script/output mismatch — CWD was main repo but edits were in `.worktrees/`, so script used main's version instead of worktree's"
+        entry2 = "- (2026-02-15) [gotcha] Running commands from wrong directory in worktree setups causes script/output mismatch — CWD was main repo but edits were in worktree, so script used main's version instead of worktree's"
+        entry3 = "- (2026-02-15) [gotcha] Running commands from wrong directory in worktree setups causes script/output mismatch — CWD was main repo but edits were in `.worktrees/html-improvements/`, so `python3 skills/analyze/scripts/render_report.py` used main's version instead of worktree's"
+        assert is_routed_match(entry1, entry2, threshold=0.6) is True
+        assert is_routed_match(entry1, entry3, threshold=0.6) is True
+
+    def test_session_restart_overlapping(self):
+        """Lines 93 and 98 — overlapping 'restart required' learnings.
+
+        These share the concept but vocabulary differs enough that keyword
+        matching at 0.5 threshold doesn't catch it. This is a known
+        limitation — the entries share ~6 keywords out of ~13, ratio ~0.46.
+        At 0.4 threshold they match, demonstrating the concept overlap exists.
+        """
+        entry1 = "- (2026-02-14) [gotcha] Hook changes (pretooluse-allow-safe.sh, settings.json permissions) require session restart or `/clear` to take effect"
+        entry2 = "- (2026-02-13) [gotcha] Settings changes don't apply to current session — requires restart or `/clear` to reload permissions/MCP configs"
+        # Below 0.5 threshold — vocabulary too different despite conceptual overlap
+        assert is_routed_match(entry1, entry2, threshold=0.5) is False
+        # At 0.4 threshold, the shared keywords are enough
+        assert is_routed_match(entry1, entry2, threshold=0.4) is True
+
+    def test_different_concepts_not_matched(self):
+        """Ensure genuinely different entries are NOT matched."""
+        entry1 = "- (2026-02-16) [pattern] Happy architecture: wraps `claude` CLI with system prompt injection"
+        entry2 = "- (2026-02-17) [pattern] Git merge strategies: squash (clean, one commit, loses granularity)"
+        assert is_routed_match(entry1, entry2, threshold=0.6) is False
+
+    def test_similar_topic_different_aspect_not_matched(self):
+        """Two entries about git but different topics should NOT match."""
+        entry1 = "- (2026-02-17) [pattern] Git merge strategies: squash, rebase, merge commit"
+        entry2 = "- (2026-02-17) [pattern] Worktree workflow: branch from latest main, one per worktree"
+        assert is_routed_match(entry1, entry2, threshold=0.6) is False
+
+
+class TestKeywordDedupEdgeCases:
+    """Edge cases for the keyword matching algorithm."""
+
+    def test_empty_entries(self):
+        assert is_routed_match("", "", threshold=0.5) is False
+        assert is_routed_match("- some text", "", threshold=0.5) is False
+
+    def test_only_stopwords(self):
+        """Entries with only stopwords should not match anything."""
+        entry1 = "- (2026-01-01) [tip] the is are was were"
+        entry2 = "- (2026-01-01) [tip] a an the for with"
+        # After removing stopwords and short tokens, keywords are empty
+        assert is_routed_match(entry1, entry2, threshold=0.5) is False
+
+    def test_single_keyword_overlap(self):
+        """Short entries with one shared keyword — should depend on threshold."""
+        entry1 = "- (2026-01-01) [gotcha] SQLAlchemy needs commit"
+        entry2 = "- (2026-01-01) [gotcha] SQLAlchemy requires flush"
+        # Both have "sqlalchemy", one has "commit", other has "flush"+"requires"
+        assert "sqlalchemy" in extract_entry_keywords(entry1)
+        assert "sqlalchemy" in extract_entry_keywords(entry2)
+        # Low overlap ratio — only "sqlalchemy"+"needs"/"requires" overlap
+        # Should not match at 0.6 threshold
+        assert is_routed_match(entry1, entry2, threshold=0.6) is False
+
+    def test_threshold_boundary(self):
+        """Exact threshold boundary behavior."""
+        entry1 = "- [tip] alpha bravo charlie delta"
+        entry2 = "- [tip] alpha bravo echo foxtrot"
+        # {alpha, bravo, charlie, delta} vs {alpha, bravo, echo, foxtrot}
+        # overlap = 2 (alpha, bravo), smaller = 4, ratio = 0.5
+        assert is_routed_match(entry1, entry2, threshold=0.5) is True
+        assert is_routed_match(entry1, entry2, threshold=0.6) is False
+
+    def test_routed_prefix_stripped(self):
+        """[routed] prefix should not affect matching."""
+        entry1 = "- [routed][global/gotcha] MCP servers can be disabled per-project"
+        entry2 = "- (2026-01-22) [gotcha] MCP servers can be disabled per-project"
+        assert is_routed_match(entry1, entry2, threshold=0.6) is True
+
+
+# ── mark-routed keyword dedup integration ──
+
+
+class TestMarkRoutedKeywordDedup:
+    """Test that cmd_mark_routed removes near-duplicates within LTM files."""
+
+    def _make_ltm_file(self, tmpdir, filename, content):
+        p = Path(tmpdir) / filename
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_exact_duplicates_removed(self):
+        """Exact duplicate lines within LTM should be removed."""
+        content = """# Test
+## Key Learnings
+
+- (2026-02-15) [gotcha] First entry about something
+- (2026-02-15) [gotcha] First entry about something
+- (2026-02-16) [pattern] Different entry
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ltm = self._make_ltm_file(tmpdir, "global-long-term-memory.md", content)
+
+            with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
+                 mock.patch("memory_utils.get_project_memory_dir", return_value=Path(tmpdir) / "project-memory"), \
+                 mock.patch("memory_utils.get_daily_dir", return_value=Path(tmpdir) / "daily"):
+                # Create empty dirs so they exist
+                (Path(tmpdir) / "project-memory").mkdir()
+                (Path(tmpdir) / "daily").mkdir()
+
+                from devtools import cmd_mark_routed
+                args = argparse.Namespace(dry_run=False)
+                cmd_mark_routed(args)
+
+                result = ltm.read_text(encoding="utf-8")
+                # Should only have one copy of the duplicate
+                assert result.count("First entry about something") == 1
+                assert "Different entry" in result
+
+    def test_near_duplicates_removed(self):
+        """Near-duplicate lines (high keyword overlap above 0.7) should be removed."""
+        content = """# Test
+## Key Learnings
+
+- (2026-02-15) [gotcha] Running commands from wrong directory in worktree setups causes script and output mismatch with main repo version
+- (2026-02-15) [gotcha] Running commands from wrong directory in worktree setups causes script and output mismatch using worktree edits instead
+- (2026-02-16) [pattern] Something completely unrelated about databases
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ltm = self._make_ltm_file(tmpdir, "global-long-term-memory.md", content)
+
+            with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
+                 mock.patch("memory_utils.get_project_memory_dir", return_value=Path(tmpdir) / "project-memory"), \
+                 mock.patch("memory_utils.get_daily_dir", return_value=Path(tmpdir) / "daily"):
+                (Path(tmpdir) / "project-memory").mkdir()
+                (Path(tmpdir) / "daily").mkdir()
+
+                from devtools import cmd_mark_routed
+                args = argparse.Namespace(dry_run=False)
+                cmd_mark_routed(args)
+
+                result = ltm.read_text(encoding="utf-8")
+                # First entry kept, near-dup removed, unrelated kept
+                lines = [ln for ln in result.splitlines() if ln.startswith("- (")]
+                assert len(lines) == 2
+                assert "main repo" in lines[0]
+                assert "databases" in lines[1]
+
+    def test_different_entries_kept(self):
+        """Genuinely different entries should all be kept."""
+        content = """# Test
+## Key Learnings
+
+- (2026-02-15) [gotcha] Happy MCP transport reuse error
+- (2026-02-16) [pattern] Git merge strategies and rebase workflow
+- (2026-02-17) [tip] WSL2 idle timeout configuration
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ltm = self._make_ltm_file(tmpdir, "global-long-term-memory.md", content)
+
+            with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
+                 mock.patch("memory_utils.get_project_memory_dir", return_value=Path(tmpdir) / "project-memory"), \
+                 mock.patch("memory_utils.get_daily_dir", return_value=Path(tmpdir) / "daily"):
+                (Path(tmpdir) / "project-memory").mkdir()
+                (Path(tmpdir) / "daily").mkdir()
+
+                from devtools import cmd_mark_routed
+                args = argparse.Namespace(dry_run=False)
+                cmd_mark_routed(args)
+
+                result = ltm.read_text(encoding="utf-8")
+                lines = [ln for ln in result.splitlines() if ln.startswith("- (")]
+                assert len(lines) == 3
+
+    def test_dry_run_does_not_modify(self):
+        """Dry run should not modify the file."""
+        content = """# Test
+## Key Learnings
+
+- (2026-02-15) [gotcha] First entry about something
+- (2026-02-15) [gotcha] First entry about something
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ltm = self._make_ltm_file(tmpdir, "global-long-term-memory.md", content)
+            original = ltm.read_text(encoding="utf-8")
+
+            with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
+                 mock.patch("memory_utils.get_project_memory_dir", return_value=Path(tmpdir) / "project-memory"), \
+                 mock.patch("memory_utils.get_daily_dir", return_value=Path(tmpdir) / "daily"):
+                (Path(tmpdir) / "project-memory").mkdir()
+                (Path(tmpdir) / "daily").mkdir()
+
+                from devtools import cmd_mark_routed
+                args = argparse.Namespace(dry_run=True)
+                cmd_mark_routed(args)
+
+                assert ltm.read_text(encoding="utf-8") == original
+
+
+# ── validate-ltm integration ──
+
+
+class TestValidateLtm:
+    """Test the validate-ltm command."""
+
+    def test_clean_file_no_issues(self):
+        """A clean LTM file should report no issues."""
+        content = """# Test
+## Key Learnings
+
+- (2026-02-15) [gotcha] MCP resource handlers block server initialization if slow
+- (2026-02-16) [pattern] Git merge strategies include squash rebase and merge commit
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ltm = Path(tmpdir) / "global-long-term-memory.md"
+            ltm.write_text(content, encoding="utf-8")
+            project_dir = Path(tmpdir) / "project-memory"
+            project_dir.mkdir()
+            index_file = Path(tmpdir) / "projects-index.json"
+            index_file.write_text('{"projects": {}}', encoding="utf-8")
+
+            with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
+                 mock.patch("memory_utils.get_project_memory_dir", return_value=project_dir), \
+                 mock.patch("memory_utils.get_projects_index_file", return_value=index_file):
+                from devtools import cmd_validate_ltm
+                args = argparse.Namespace()
+                result = cmd_validate_ltm(args)
+                assert result == 0
+
+    def test_exact_duplicate_detected(self):
+        content = """# Test
+## Key Learnings
+
+- (2026-02-15) [gotcha] Same entry here
+- (2026-02-15) [gotcha] Same entry here
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ltm = Path(tmpdir) / "global-long-term-memory.md"
+            ltm.write_text(content, encoding="utf-8")
+            project_dir = Path(tmpdir) / "project-memory"
+            project_dir.mkdir()
+            index_file = Path(tmpdir) / "projects-index.json"
+            index_file.write_text('{"projects": {}}', encoding="utf-8")
+
+            with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
+                 mock.patch("memory_utils.get_project_memory_dir", return_value=project_dir), \
+                 mock.patch("memory_utils.get_projects_index_file", return_value=index_file):
+                from devtools import cmd_validate_ltm
+                args = argparse.Namespace()
+                result = cmd_validate_ltm(args)
+                assert result == 1  # Issues found
+
+    def test_unregistered_project_detected(self):
+        content = """# Test
+## Key Learnings
+
+- (2026-02-15) [gotcha] Some entry
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ltm = Path(tmpdir) / "global-long-term-memory.md"
+            ltm.write_text("# Empty\n", encoding="utf-8")
+            project_dir = Path(tmpdir) / "project-memory"
+            project_dir.mkdir()
+            # Create a project file that's NOT in the index
+            orphan = project_dir / "fake-project-long-term-memory.md"
+            orphan.write_text(content, encoding="utf-8")
+            index_file = Path(tmpdir) / "projects-index.json"
+            index_file.write_text('{"projects": {}}', encoding="utf-8")
+
+            with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
+                 mock.patch("memory_utils.get_project_memory_dir", return_value=project_dir), \
+                 mock.patch("memory_utils.get_projects_index_file", return_value=index_file):
+                from devtools import cmd_validate_ltm
+                args = argparse.Namespace()
+                result = cmd_validate_ltm(args)
+                assert result == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -78,7 +78,7 @@ class TestLoadSettings:
             mock_sf.return_value = Path("/nonexistent/settings.json")
             settings = load_settings()
             assert settings["globalShortTerm"]["tokenLimit"] == 2 * SHORT_TERM_TOKENS_PER_DAY
-            assert settings["projectShortTerm"]["tokenLimit"] == 7 * SHORT_TERM_TOKENS_PER_DAY
+            assert settings["projectShortTerm"]["tokenLimit"] == DEFAULT_SETTINGS["projectShortTerm"]["workingDays"] * SHORT_TERM_TOKENS_PER_DAY
 
     def test_total_budget_calculation(self):
         with mock.patch("memory_utils.get_settings_file") as mock_sf:


### PR DESCRIPTION
## Summary
- Upgrade LTM dedup from exact-match to keyword similarity matching (0.7 threshold), validated against real data to eliminate false positives from shared domain vocabulary
- Add `validate-ltm` command and tighten synthesis prompt with explicit section mapping, dedup requirement, and granularity cap (max 5 entries/file/run)
- Reduce default LTM limits from 5,000→3,000 tokens and project STM from 7→5 working days

## Test plan
- [x] 255 tests passing (17 new for keyword dedup + validate-ltm)
- [x] Dry-run mark-routed against real LTM files: 4 true positives, 0 false positives at 0.7 threshold
- [x] Verified 0.6 threshold produced 9 false positives from domain vocabulary overlap — confirmed 0.7 is correct
- [x] validate-ltm detects exact dups, near-dups, unregistered project files, high entry counts
- [x] Token usage verified: 7,284/11,250 (53%) after cleanup + new limits

Co-Authored-By: Claude <noreply@anthropic.com>