### PR TITLE
refactor(install): directory-level skill symlinks, fix frontmatter typo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Session transcript → /synthesize Phase 1 → Daily summary (Actions, Decisions
 
 ### Adding a Skill
 1. Create `skills/<name>/SKILL.md` with frontmatter
-2. Update `install.py`: add to `create_directories()` and `link_skills()`
+2. Update `install.py`: add to `skills` list in `link_skills()`
 3. Update `uninstall.py`: add to cleanup instructions
 
 ### Adding a Script

--- a/install.py
+++ b/install.py
@@ -115,11 +115,7 @@ def create_directories() -> None:
         get_memory_dir() / ".backups",
         get_claude_dir() / "scripts",
         get_claude_dir() / "hooks",
-        get_claude_dir() / "skills" / "remember",
-        get_claude_dir() / "skills" / "synthesize",
-        get_claude_dir() / "skills" / "recall",
-        get_claude_dir() / "skills" / "settings",
-        get_claude_dir() / "skills" / "projects",
+        get_claude_dir() / "skills",
     ]
 
     for dir_path in dirs:
@@ -191,20 +187,22 @@ def link_hooks(script_dir: Path) -> None:
 
 
 def link_skills(script_dir: Path) -> None:
-    """Symlink skill files to ~/.claude/skills/."""
+    """Symlink skill directories to ~/.claude/skills/."""
     skills_dir = get_claude_dir() / "skills"
 
     skills = ["remember", "synthesize", "recall", "settings", "projects"]
 
     for skill in skills:
         src_dir = script_dir / "skills" / skill
-        dest_dir = skills_dir / skill
+        dest = skills_dir / skill
 
         if src_dir.exists():
-            src_skill = src_dir / "SKILL.md"
-            if src_skill.exists():
-                dest_dir.mkdir(parents=True, exist_ok=True)
-                link_file(src_skill, dest_dir / "SKILL.md")
+            # Remove existing dir or symlink, then symlink the whole directory
+            if dest.is_symlink():
+                dest.unlink()
+            elif dest.is_dir():
+                shutil.rmtree(dest)
+            dest.symlink_to(src_dir)
 
     print("Linked skills to ~/.claude/skills/")
 

--- a/skills/projects/SKILL.md
+++ b/skills/projects/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: projects
 description: Manage Claude Code projects - list status, move/rename, merge orphans, cleanup stale data
-user-invocable: true
+user-invokable: true
 ---
 
 # Project Management

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: recall
 description: Search through all historical daily memory files to find information from past sessions. Use when user asks about past work, decisions, discussions, or topics that might have relevant history.
-user-invocable: true
+user-invokable: true
 ---
 
 # Recall Skill

--- a/skills/remember/SKILL.md
+++ b/skills/remember/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: remember
 description: Save important notes directly to long-term memory's Pinned section. Use when user wants to explicitly preserve something permanently.
-user-invocable: true
+user-invokable: true
 ---
 
 # Remember Skill

--- a/skills/settings/SKILL.md
+++ b/skills/settings/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: settings
 description: View and modify memory system settings, check token usage
-user-invocable: true
+user-invokable: true
 ---
 
 <command-name>settings</command-name>

--- a/skills/synthesize/SKILL.md
+++ b/skills/synthesize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: synthesize
 description: Process raw session transcripts into daily summaries and update long-term memory with patterns and insights. Run during first session of the day, when prompted, or according to a set schedule.
-user-invocable: true
+user-invokable: true
 ---
 
 # Synthesize Skill


### PR DESCRIPTION
## Summary
- Symlink entire skill directories instead of just SKILL.md files, preventing orphan file accumulation (e.g., stale scripts in synthesize/)
- Fix `user-invocable` → `user-invokable` in all 5 skill frontmatters to match Claude Code's schema
- Update CLAUDE.md "Adding a Skill" instructions to reflect simplified workflow

## Test plan
- [x] `python3 -m pytest tests/ -v` — 255 passed
- [x] `python3 install.py` — skills correctly symlinked as directories
- [x] Verified `ls -la ~/.claude/skills/` shows directory-level symlinks

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>