### PR TITLE
refactor(tests): DRY cleanup and pytest best practices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,10 @@ Session transcript → /synthesize Phase 1 → Daily summary (Actions, Decisions
 
 Test conventions:
 - Class per function/feature: `class TestFunctionName`
-- Use `tempfile.TemporaryDirectory` for filesystem isolation
+- Use pytest `tmp_path` fixture for filesystem isolation (not `tempfile`)
 - Use `unittest.mock.patch` to mock path helpers (`get_projects_dir`, etc.)
+- Use `@pytest.mark.parametrize` for input/output variations instead of separate test methods
+- Put shared factories in `tests/helpers.py`; path setup lives in `tests/conftest.py`
 - Test happy path, edge cases, and error conditions
 - Never hardcode configurable values — import constants (`DEFAULT_AGE_DAYS`, `DEFAULT_SETTINGS`, etc.) and make test data relative to them (e.g., `timedelta(days=DEFAULT_AGE_DAYS * 2)` not `timedelta(days=60)`)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Shared test configuration — path setup for all test modules."""
+
+import sys
+from pathlib import Path
+
+# Add scripts and tests directories to path for all test modules
+sys.path.insert(0, str(Path(__file__).parent))  # tests/ (for helpers)
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))  # scripts/

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,44 @@
+"""Shared test factories and utilities."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from indexing import SessionInfo  # noqa: I001
+
+
+def make_session_info(
+    session_id="test-session",
+    transcript_path=None,
+    file_size=2000,
+    project_path=None,
+    created=None,
+    file_mtime=None,
+):
+    """Factory for creating SessionInfo test objects."""
+    return SessionInfo(
+        session_id=session_id,
+        transcript_path=transcript_path or Path("/tmp/test.jsonl"),
+        project_hash="test-hash",
+        file_mtime=file_mtime or datetime.now(timezone.utc),
+        file_size=file_size,
+        project_path=project_path,
+        created=created,
+    )
+
+
+def make_jsonl_line(role, content):
+    """Create a single JSONL transcript line."""
+    return json.dumps({
+        "type": role,
+        "message": {"role": role, "content": content},
+    })
+
+
+def make_jsonl_content(messages):
+    """Create JSONL content from list of (role, text) tuples."""
+    lines = [
+        json.dumps({"type": role, "message": {"role": role, "content": text}})
+        for role, text in messages
+    ]
+    return "\n".join(lines) + "\n"

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -5,19 +5,13 @@ Unit tests for decay.py
 Run with: python -m pytest tests/test_decay.py -v
 """
 
-import sys
-import tempfile
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
-# Add scripts directory to path
-scripts_dir = Path(__file__).parent.parent / "scripts"
-sys.path.insert(0, str(scripts_dir))
-
-from decay import (
+from decay import (  # noqa: I001
     ARCHIVE_HEADER_PATTERN,
     DATE_PATTERN,
     DEFAULT_AGE_DAYS,
@@ -40,24 +34,14 @@ from decay import (
 # =============================================================================
 
 
-class TestParseLearningDate:
-    def test_valid_date(self):
-        line = "- (2026-01-15) [pattern] Some learning"
-        result = parse_learning_date(line)
-        assert result == date(2026, 1, 15)
-
-    def test_no_date(self):
-        line = "- [pattern] No date here"
-        assert parse_learning_date(line) is None
-
-    def test_invalid_date(self):
-        line = "- (2026-13-45) [pattern] Invalid date"
-        assert parse_learning_date(line) is None
-
-    def test_date_in_middle(self):
-        line = "- Some text (2026-06-15) more text"
-        result = parse_learning_date(line)
-        assert result == date(2026, 6, 15)
+@pytest.mark.parametrize("line,expected", [
+    ("- (2026-01-15) [pattern] Some learning", date(2026, 1, 15)),
+    ("- [pattern] No date here", None),
+    ("- (2026-13-45) [pattern] Invalid date", None),
+    ("- Some text (2026-06-15) more text", date(2026, 6, 15)),
+])
+def test_parse_learning_date(line, expected):
+    assert parse_learning_date(line) == expected
 
 
 class TestDatePattern:
@@ -87,26 +71,30 @@ class TestArchiveHeaderPattern:
 # =============================================================================
 
 
-class TestSectionClassification:
-    def test_protected_sections(self):
-        assert is_protected_section("## About Me")
-        assert is_protected_section("## Pinned")
-        assert is_protected_section("## Current Projects")
+@pytest.mark.parametrize("section", [
+    "## About Me", "## Pinned", "## Current Projects",
+])
+def test_protected_sections(section):
+    assert is_protected_section(section)
 
-    def test_non_protected(self):
-        assert not is_protected_section("## Key Learnings")
-        assert not is_protected_section("## Random")
 
-    def test_decay_eligible(self):
-        assert is_decay_eligible("## Key Actions")
-        assert is_decay_eligible("## Key Decisions")
-        assert is_decay_eligible("## Key Learnings")
-        assert is_decay_eligible("## Key Lessons")
+@pytest.mark.parametrize("section", ["## Key Learnings", "## Random"])
+def test_non_protected(section):
+    assert not is_protected_section(section)
 
-    def test_not_decay_eligible(self):
-        assert not is_decay_eligible("## About Me")
-        assert not is_decay_eligible("## Pinned")
-        assert not is_decay_eligible("## Random Section")
+
+@pytest.mark.parametrize("section", [
+    "## Key Actions", "## Key Decisions", "## Key Learnings", "## Key Lessons",
+])
+def test_decay_eligible(section):
+    assert is_decay_eligible(section)
+
+
+@pytest.mark.parametrize("section", [
+    "## About Me", "## Pinned", "## Random Section",
+])
+def test_not_decay_eligible(section):
+    assert not is_decay_eligible(section)
 
 
 # =============================================================================
@@ -328,12 +316,12 @@ class TestBuildProjectWorkDaysMap:
 
 
 class TestDecayFile:
-    def _make_memory_file(self, tmpdir: str, content: str) -> Path:
-        filepath = Path(tmpdir) / "test-memory.md"
+    def _make_memory_file(self, tmp_path, content):
+        filepath = tmp_path / "test-memory.md"
         filepath.write_text(content)
         return filepath
 
-    def test_decay_old_learning(self):
+    def test_decay_old_learning(self, tmp_path):
         old_date = (datetime.now(timezone.utc) - timedelta(days=DEFAULT_AGE_DAYS * 2)).strftime("%Y-%m-%d")
         content = f"""## Pinned
 - Permanent item
@@ -342,30 +330,28 @@ class TestDecayFile:
 <!-- Subject to decay -->
 - ({old_date}) [pattern] Old learning that should be archived
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            filepath = self._make_memory_file(tmpdir, content)
-            count, archived = decay_file(filepath, age_days=DEFAULT_AGE_DAYS)
-            assert count == 1
-            assert "Old learning" in archived[0]
+        filepath = self._make_memory_file(tmp_path, content)
+        count, archived = decay_file(filepath, age_days=DEFAULT_AGE_DAYS)
+        assert count == 1
+        assert "Old learning" in archived[0]
 
-            # Verify file was updated
-            new_content = filepath.read_text()
-            assert "Old learning" not in new_content
-            # Pinned section preserved
-            assert "Permanent item" in new_content
+        # Verify file was updated
+        new_content = filepath.read_text()
+        assert "Old learning" not in new_content
+        # Pinned section preserved
+        assert "Permanent item" in new_content
 
-    def test_keep_recent_learning(self):
+    def test_keep_recent_learning(self, tmp_path):
         recent_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         content = f"""## Key Learnings
 - ({recent_date}) [pattern] Recent learning
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            filepath = self._make_memory_file(tmpdir, content)
-            count, archived = decay_file(filepath, age_days=DEFAULT_AGE_DAYS)
-            assert count == 0
-            assert filepath.read_text() == content
+        filepath = self._make_memory_file(tmp_path, content)
+        count, archived = decay_file(filepath, age_days=DEFAULT_AGE_DAYS)
+        assert count == 0
+        assert filepath.read_text() == content
 
-    def test_pinned_section_protected(self):
+    def test_pinned_section_protected(self, tmp_path):
         old_date = (datetime.now(timezone.utc) - timedelta(days=DEFAULT_AGE_DAYS * 2)).strftime("%Y-%m-%d")
         content = f"""## Pinned
 - ({old_date}) [pattern] Old but pinned
@@ -373,40 +359,37 @@ class TestDecayFile:
 ## Key Learnings
 - ({old_date}) [pattern] Old and eligible
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            filepath = self._make_memory_file(tmpdir, content)
-            count, _ = decay_file(filepath, age_days=DEFAULT_AGE_DAYS)
-            assert count == 1  # Only the Key Learnings entry
-            new_content = filepath.read_text()
-            assert "Old but pinned" in new_content
+        filepath = self._make_memory_file(tmp_path, content)
+        count, _ = decay_file(filepath, age_days=DEFAULT_AGE_DAYS)
+        assert count == 1  # Only the Key Learnings entry
+        new_content = filepath.read_text()
+        assert "Old but pinned" in new_content
 
-    def test_undated_learning_protected(self):
+    def test_undated_learning_protected(self, tmp_path):
         content = """## Key Learnings
 - [pattern] No date means no decay
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            filepath = self._make_memory_file(tmpdir, content)
-            count, _ = decay_file(filepath, age_days=DEFAULT_AGE_DAYS)
-            assert count == 0
+        filepath = self._make_memory_file(tmp_path, content)
+        count, _ = decay_file(filepath, age_days=DEFAULT_AGE_DAYS)
+        assert count == 0
 
-    def test_dry_run_no_changes(self):
+    def test_dry_run_no_changes(self, tmp_path):
         old_date = (datetime.now(timezone.utc) - timedelta(days=DEFAULT_AGE_DAYS * 2)).strftime("%Y-%m-%d")
         content = f"""## Key Learnings
 - ({old_date}) [pattern] Should be archived
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            filepath = self._make_memory_file(tmpdir, content)
-            count, archived = decay_file(filepath, age_days=DEFAULT_AGE_DAYS, dry_run=True)
-            assert count == 1
-            # File should NOT be modified
-            assert filepath.read_text() == content
+        filepath = self._make_memory_file(tmp_path, content)
+        count, archived = decay_file(filepath, age_days=DEFAULT_AGE_DAYS, dry_run=True)
+        assert count == 1
+        # File should NOT be modified
+        assert filepath.read_text() == content
 
     def test_nonexistent_file(self):
         count, archived = decay_file(Path("/nonexistent/file.md"), age_days=DEFAULT_AGE_DAYS)
         assert count == 0
         assert archived == []
 
-    def test_multiple_sections_decayed(self):
+    def test_multiple_sections_decayed(self, tmp_path):
         old_date = (datetime.now(timezone.utc) - timedelta(days=DEFAULT_AGE_DAYS * 2)).strftime("%Y-%m-%d")
         content = f"""## Key Actions
 - ({old_date}) [implement] Old action
@@ -417,43 +400,40 @@ class TestDecayFile:
 ## Key Lessons
 - ({old_date}) [insight] Old lesson
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            filepath = self._make_memory_file(tmpdir, content)
-            count, _ = decay_file(filepath, age_days=DEFAULT_AGE_DAYS)
-            assert count == 3
+        filepath = self._make_memory_file(tmp_path, content)
+        count, _ = decay_file(filepath, age_days=DEFAULT_AGE_DAYS)
+        assert count == 3
 
-    def test_working_day_decay_keeps_entry_with_few_days(self):
+    def test_working_day_decay_keeps_entry_with_few_days(self, tmp_path):
         """Project file with few work days should keep old entries."""
         content = """## Key Learnings
 <!-- Subject to decay -->
 - (2025-06-01) [pattern] Old but few project work days
 """
         work_days = ["2025-07-01", "2025-10-01", "2026-01-15"]  # only 3 days after
-        with tempfile.TemporaryDirectory() as tmpdir:
-            filepath = self._make_memory_file(tmpdir, content)
-            count, _ = decay_file(
-                filepath, age_days=DEFAULT_AGE_DAYS,
-                project_work_days=work_days,
-                project_decay_threshold=DEFAULT_PROJECT_WORKING_DAYS,
-            )
-            assert count == 0
+        filepath = self._make_memory_file(tmp_path, content)
+        count, _ = decay_file(
+            filepath, age_days=DEFAULT_AGE_DAYS,
+            project_work_days=work_days,
+            project_decay_threshold=DEFAULT_PROJECT_WORKING_DAYS,
+        )
+        assert count == 0
 
-    def test_working_day_decay_archives_entry_with_many_days(self):
+    def test_working_day_decay_archives_entry_with_many_days(self, tmp_path):
         """Project file with enough work days should archive old entries."""
         content = """## Key Learnings
 <!-- Subject to decay -->
 - (2026-01-01) [pattern] Should be archived
 """
         work_days = [f"2026-01-{d:02d}" for d in range(2, 2 + DEFAULT_PROJECT_WORKING_DAYS + 3)]
-        with tempfile.TemporaryDirectory() as tmpdir:
-            filepath = self._make_memory_file(tmpdir, content)
-            count, archived = decay_file(
-                filepath, age_days=DEFAULT_AGE_DAYS,
-                project_work_days=work_days,
-                project_decay_threshold=DEFAULT_PROJECT_WORKING_DAYS,
-            )
-            assert count == 1
-            assert "Should be archived" in archived[0]
+        filepath = self._make_memory_file(tmp_path, content)
+        count, archived = decay_file(
+            filepath, age_days=DEFAULT_AGE_DAYS,
+            project_work_days=work_days,
+            project_decay_threshold=DEFAULT_PROJECT_WORKING_DAYS,
+        )
+        assert count == 1
+        assert "Should be archived" in archived[0]
 
 
 # =============================================================================
@@ -462,66 +442,61 @@ class TestDecayFile:
 
 
 class TestAppendToArchive:
-    def test_creates_new_archive(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch("decay.get_memory_dir") as mock_md:
-                mock_md.return_value = Path(tmpdir)
-                append_to_archive(["- (2026-01-01) [pattern] Test learning"])
-                archive = Path(tmpdir) / ".decay-archive.md"
-                assert archive.exists()
-                content = archive.read_text()
-                assert "Test learning" in content
-                assert "# Decay Archive" in content
+    def test_creates_new_archive(self, tmp_path):
+        with mock.patch("decay.get_memory_dir") as mock_md:
+            mock_md.return_value = tmp_path
+            append_to_archive(["- (2026-01-01) [pattern] Test learning"])
+            archive = tmp_path / ".decay-archive.md"
+            assert archive.exists()
+            content = archive.read_text()
+            assert "Test learning" in content
+            assert "# Decay Archive" in content
 
-    def test_appends_to_existing(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            archive = Path(tmpdir) / ".decay-archive.md"
-            archive.write_text("# Decay Archive\n\n## Archived 2026-01-01\nOld entry\n")
+    def test_appends_to_existing(self, tmp_path):
+        archive = tmp_path / ".decay-archive.md"
+        archive.write_text("# Decay Archive\n\n## Archived 2026-01-01\nOld entry\n")
 
-            with mock.patch("decay.get_memory_dir") as mock_md:
-                mock_md.return_value = Path(tmpdir)
-                append_to_archive(["- (2026-02-01) [pattern] New learning"])
-                content = archive.read_text()
-                assert "Old entry" in content
-                assert "New learning" in content
+        with mock.patch("decay.get_memory_dir") as mock_md:
+            mock_md.return_value = tmp_path
+            append_to_archive(["- (2026-02-01) [pattern] New learning"])
+            content = archive.read_text()
+            assert "Old entry" in content
+            assert "New learning" in content
 
-    def test_dry_run_no_file(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch("decay.get_memory_dir") as mock_md:
-                mock_md.return_value = Path(tmpdir)
-                append_to_archive(["- test"], dry_run=True)
-                assert not (Path(tmpdir) / ".decay-archive.md").exists()
+    def test_dry_run_no_file(self, tmp_path):
+        with mock.patch("decay.get_memory_dir") as mock_md:
+            mock_md.return_value = tmp_path
+            append_to_archive(["- test"], dry_run=True)
+            assert not (tmp_path / ".decay-archive.md").exists()
 
 
 class TestPurgeOldArchives:
-    def test_purge_old_sections(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            archive = Path(tmpdir) / ".decay-archive.md"
-            # Create archive with old and recent sections
-            old_date = (datetime.now(timezone.utc) - timedelta(days=DEFAULT_ARCHIVE_RETENTION_DAYS + 35)).strftime(
-                "%Y-%m-%d"
-            )
-            recent_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-            archive.write_text(
-                f"# Decay Archive\n\n"
-                f"## Archived {recent_date}\nRecent entry\n\n"
-                f"## Archived {old_date}\nOld entry\n"
-            )
+    def test_purge_old_sections(self, tmp_path):
+        archive = tmp_path / ".decay-archive.md"
+        # Create archive with old and recent sections
+        old_date = (datetime.now(timezone.utc) - timedelta(days=DEFAULT_ARCHIVE_RETENTION_DAYS + 35)).strftime(
+            "%Y-%m-%d"
+        )
+        recent_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        archive.write_text(
+            f"# Decay Archive\n\n"
+            f"## Archived {recent_date}\nRecent entry\n\n"
+            f"## Archived {old_date}\nOld entry\n"
+        )
 
-            with mock.patch("decay.get_memory_dir") as mock_md:
-                mock_md.return_value = Path(tmpdir)
-                purged = purge_old_archives(retention_days=DEFAULT_ARCHIVE_RETENTION_DAYS)
-                assert purged == 1
-                content = archive.read_text()
-                assert "Recent entry" in content
-                assert "Old entry" not in content
+        with mock.patch("decay.get_memory_dir") as mock_md:
+            mock_md.return_value = tmp_path
+            purged = purge_old_archives(retention_days=DEFAULT_ARCHIVE_RETENTION_DAYS)
+            assert purged == 1
+            content = archive.read_text()
+            assert "Recent entry" in content
+            assert "Old entry" not in content
 
-    def test_no_archive_file(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch("decay.get_memory_dir") as mock_md:
-                mock_md.return_value = Path(tmpdir)
-                purged = purge_old_archives(retention_days=DEFAULT_ARCHIVE_RETENTION_DAYS)
-                assert purged == 0
+    def test_no_archive_file(self, tmp_path):
+        with mock.patch("decay.get_memory_dir") as mock_md:
+            mock_md.return_value = tmp_path
+            purged = purge_old_archives(retention_days=DEFAULT_ARCHIVE_RETENTION_DAYS)
+            assert purged == 0
 
 
 if __name__ == "__main__":

--- a/tests/test_devtools.py
+++ b/tests/test_devtools.py
@@ -1,23 +1,12 @@
 #!/usr/bin/env python3
-"""
-Unit tests for devtools.py — keyword dedup and validate-ltm.
-
-Run with: python -m pytest tests/test_devtools.py -v
-"""
+"""Unit tests for devtools.py — keyword dedup and validate-ltm."""
 
 import argparse
-import sys
-import tempfile
-from pathlib import Path
 from unittest import mock
 
 import pytest
-
-# Add scripts directory to path
-scripts_dir = Path(__file__).parent.parent / "scripts"
-sys.path.insert(0, str(scripts_dir))
-
-from memory_utils import (  # noqa: E402
+from devtools import cmd_mark_routed, cmd_validate_ltm
+from memory_utils import (
     extract_entry_keywords,
     is_routed_match,
 )
@@ -88,11 +77,8 @@ class TestKeywordDedupEdgeCases:
         """Short entries with one shared keyword — should depend on threshold."""
         entry1 = "- (2026-01-01) [gotcha] SQLAlchemy needs commit"
         entry2 = "- (2026-01-01) [gotcha] SQLAlchemy requires flush"
-        # Both have "sqlalchemy", one has "commit", other has "flush"+"requires"
         assert "sqlalchemy" in extract_entry_keywords(entry1)
         assert "sqlalchemy" in extract_entry_keywords(entry2)
-        # Low overlap ratio — only "sqlalchemy"+"needs"/"requires" overlap
-        # Should not match at 0.6 threshold
         assert is_routed_match(entry1, entry2, threshold=0.6) is False
 
     def test_threshold_boundary(self):
@@ -117,12 +103,20 @@ class TestKeywordDedupEdgeCases:
 class TestMarkRoutedKeywordDedup:
     """Test that cmd_mark_routed removes near-duplicates within LTM files."""
 
-    def _make_ltm_file(self, tmpdir, filename, content):
-        p = Path(tmpdir) / filename
-        p.write_text(content, encoding="utf-8")
-        return p
+    def _run_mark_routed(self, tmp_path, ltm_content, dry_run=False):
+        """Write LTM content, run cmd_mark_routed, return result text."""
+        ltm = tmp_path / "global-long-term-memory.md"
+        ltm.write_text(ltm_content, encoding="utf-8")
+        (tmp_path / "project-memory").mkdir(exist_ok=True)
+        (tmp_path / "daily").mkdir(exist_ok=True)
+        with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
+             mock.patch("memory_utils.get_project_memory_dir", return_value=tmp_path / "project-memory"), \
+             mock.patch("memory_utils.get_daily_dir", return_value=tmp_path / "daily"):
+            args = argparse.Namespace(dry_run=dry_run)
+            cmd_mark_routed(args)
+        return ltm.read_text(encoding="utf-8")
 
-    def test_exact_duplicates_removed(self):
+    def test_exact_duplicates_removed(self, tmp_path):
         """Exact duplicate lines within LTM should be removed."""
         content = """# Test
 ## Key Learnings
@@ -131,26 +125,11 @@ class TestMarkRoutedKeywordDedup:
 - (2026-02-15) [gotcha] First entry about something
 - (2026-02-16) [pattern] Different entry
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ltm = self._make_ltm_file(tmpdir, "global-long-term-memory.md", content)
+        result = self._run_mark_routed(tmp_path, content)
+        assert result.count("First entry about something") == 1
+        assert "Different entry" in result
 
-            with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
-                 mock.patch("memory_utils.get_project_memory_dir", return_value=Path(tmpdir) / "project-memory"), \
-                 mock.patch("memory_utils.get_daily_dir", return_value=Path(tmpdir) / "daily"):
-                # Create empty dirs so they exist
-                (Path(tmpdir) / "project-memory").mkdir()
-                (Path(tmpdir) / "daily").mkdir()
-
-                from devtools import cmd_mark_routed
-                args = argparse.Namespace(dry_run=False)
-                cmd_mark_routed(args)
-
-                result = ltm.read_text(encoding="utf-8")
-                # Should only have one copy of the duplicate
-                assert result.count("First entry about something") == 1
-                assert "Different entry" in result
-
-    def test_near_duplicates_removed(self):
+    def test_near_duplicates_removed(self, tmp_path):
         """Near-duplicate lines (high keyword overlap above 0.7) should be removed."""
         content = """# Test
 ## Key Learnings
@@ -159,27 +138,13 @@ class TestMarkRoutedKeywordDedup:
 - (2026-02-15) [gotcha] Running commands from wrong directory in worktree setups causes script and output mismatch using worktree edits instead
 - (2026-02-16) [pattern] Something completely unrelated about databases
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ltm = self._make_ltm_file(tmpdir, "global-long-term-memory.md", content)
+        result = self._run_mark_routed(tmp_path, content)
+        lines = [ln for ln in result.splitlines() if ln.startswith("- (")]
+        assert len(lines) == 2
+        assert "main repo" in lines[0]
+        assert "databases" in lines[1]
 
-            with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
-                 mock.patch("memory_utils.get_project_memory_dir", return_value=Path(tmpdir) / "project-memory"), \
-                 mock.patch("memory_utils.get_daily_dir", return_value=Path(tmpdir) / "daily"):
-                (Path(tmpdir) / "project-memory").mkdir()
-                (Path(tmpdir) / "daily").mkdir()
-
-                from devtools import cmd_mark_routed
-                args = argparse.Namespace(dry_run=False)
-                cmd_mark_routed(args)
-
-                result = ltm.read_text(encoding="utf-8")
-                # First entry kept, near-dup removed, unrelated kept
-                lines = [ln for ln in result.splitlines() if ln.startswith("- (")]
-                assert len(lines) == 2
-                assert "main repo" in lines[0]
-                assert "databases" in lines[1]
-
-    def test_different_entries_kept(self):
+    def test_different_entries_kept(self, tmp_path):
         """Genuinely different entries should all be kept."""
         content = """# Test
 ## Key Learnings
@@ -188,24 +153,11 @@ class TestMarkRoutedKeywordDedup:
 - (2026-02-16) [pattern] Git merge strategies and rebase workflow
 - (2026-02-17) [tip] WSL2 idle timeout configuration
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ltm = self._make_ltm_file(tmpdir, "global-long-term-memory.md", content)
+        result = self._run_mark_routed(tmp_path, content)
+        lines = [ln for ln in result.splitlines() if ln.startswith("- (")]
+        assert len(lines) == 3
 
-            with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
-                 mock.patch("memory_utils.get_project_memory_dir", return_value=Path(tmpdir) / "project-memory"), \
-                 mock.patch("memory_utils.get_daily_dir", return_value=Path(tmpdir) / "daily"):
-                (Path(tmpdir) / "project-memory").mkdir()
-                (Path(tmpdir) / "daily").mkdir()
-
-                from devtools import cmd_mark_routed
-                args = argparse.Namespace(dry_run=False)
-                cmd_mark_routed(args)
-
-                result = ltm.read_text(encoding="utf-8")
-                lines = [ln for ln in result.splitlines() if ln.startswith("- (")]
-                assert len(lines) == 3
-
-    def test_dry_run_does_not_modify(self):
+    def test_dry_run_does_not_modify(self, tmp_path):
         """Dry run should not modify the file."""
         content = """# Test
 ## Key Learnings
@@ -213,21 +165,10 @@ class TestMarkRoutedKeywordDedup:
 - (2026-02-15) [gotcha] First entry about something
 - (2026-02-15) [gotcha] First entry about something
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ltm = self._make_ltm_file(tmpdir, "global-long-term-memory.md", content)
-            original = ltm.read_text(encoding="utf-8")
-
-            with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
-                 mock.patch("memory_utils.get_project_memory_dir", return_value=Path(tmpdir) / "project-memory"), \
-                 mock.patch("memory_utils.get_daily_dir", return_value=Path(tmpdir) / "daily"):
-                (Path(tmpdir) / "project-memory").mkdir()
-                (Path(tmpdir) / "daily").mkdir()
-
-                from devtools import cmd_mark_routed
-                args = argparse.Namespace(dry_run=True)
-                cmd_mark_routed(args)
-
-                assert ltm.read_text(encoding="utf-8") == original
+        ltm = tmp_path / "global-long-term-memory.md"
+        ltm.write_text(content, encoding="utf-8")
+        result = self._run_mark_routed(tmp_path, content, dry_run=True)
+        assert result == content
 
 
 # ── validate-ltm integration ──
@@ -236,7 +177,24 @@ class TestMarkRoutedKeywordDedup:
 class TestValidateLtm:
     """Test the validate-ltm command."""
 
-    def test_clean_file_no_issues(self):
+    def _validate(self, tmp_path, global_content, project_files=None):
+        """Set up LTM environment and run validate, return exit code."""
+        ltm = tmp_path / "global-long-term-memory.md"
+        ltm.write_text(global_content, encoding="utf-8")
+        project_dir = tmp_path / "project-memory"
+        project_dir.mkdir(exist_ok=True)
+        if project_files:
+            for name, file_content in project_files.items():
+                (project_dir / name).write_text(file_content, encoding="utf-8")
+        index_file = tmp_path / "projects-index.json"
+        index_file.write_text('{"projects": {}}', encoding="utf-8")
+        with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
+             mock.patch("memory_utils.get_project_memory_dir", return_value=project_dir), \
+             mock.patch("memory_utils.get_projects_index_file", return_value=index_file):
+            args = argparse.Namespace()
+            return cmd_validate_ltm(args)
+
+    def test_clean_file_no_issues(self, tmp_path):
         """A clean LTM file should report no issues."""
         content = """# Test
 ## Key Learnings
@@ -244,69 +202,28 @@ class TestValidateLtm:
 - (2026-02-15) [gotcha] MCP resource handlers block server initialization if slow
 - (2026-02-16) [pattern] Git merge strategies include squash rebase and merge commit
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ltm = Path(tmpdir) / "global-long-term-memory.md"
-            ltm.write_text(content, encoding="utf-8")
-            project_dir = Path(tmpdir) / "project-memory"
-            project_dir.mkdir()
-            index_file = Path(tmpdir) / "projects-index.json"
-            index_file.write_text('{"projects": {}}', encoding="utf-8")
+        assert self._validate(tmp_path, content) == 0
 
-            with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
-                 mock.patch("memory_utils.get_project_memory_dir", return_value=project_dir), \
-                 mock.patch("memory_utils.get_projects_index_file", return_value=index_file):
-                from devtools import cmd_validate_ltm
-                args = argparse.Namespace()
-                result = cmd_validate_ltm(args)
-                assert result == 0
-
-    def test_exact_duplicate_detected(self):
+    def test_exact_duplicate_detected(self, tmp_path):
         content = """# Test
 ## Key Learnings
 
 - (2026-02-15) [gotcha] Same entry here
 - (2026-02-15) [gotcha] Same entry here
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ltm = Path(tmpdir) / "global-long-term-memory.md"
-            ltm.write_text(content, encoding="utf-8")
-            project_dir = Path(tmpdir) / "project-memory"
-            project_dir.mkdir()
-            index_file = Path(tmpdir) / "projects-index.json"
-            index_file.write_text('{"projects": {}}', encoding="utf-8")
+        assert self._validate(tmp_path, content) == 1
 
-            with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
-                 mock.patch("memory_utils.get_project_memory_dir", return_value=project_dir), \
-                 mock.patch("memory_utils.get_projects_index_file", return_value=index_file):
-                from devtools import cmd_validate_ltm
-                args = argparse.Namespace()
-                result = cmd_validate_ltm(args)
-                assert result == 1  # Issues found
-
-    def test_unregistered_project_detected(self):
-        content = """# Test
+    def test_unregistered_project_detected(self, tmp_path):
+        project_content = """# Test
 ## Key Learnings
 
 - (2026-02-15) [gotcha] Some entry
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ltm = Path(tmpdir) / "global-long-term-memory.md"
-            ltm.write_text("# Empty\n", encoding="utf-8")
-            project_dir = Path(tmpdir) / "project-memory"
-            project_dir.mkdir()
-            # Create a project file that's NOT in the index
-            orphan = project_dir / "fake-project-long-term-memory.md"
-            orphan.write_text(content, encoding="utf-8")
-            index_file = Path(tmpdir) / "projects-index.json"
-            index_file.write_text('{"projects": {}}', encoding="utf-8")
-
-            with mock.patch("memory_utils.get_global_memory_file", return_value=ltm), \
-                 mock.patch("memory_utils.get_project_memory_dir", return_value=project_dir), \
-                 mock.patch("memory_utils.get_projects_index_file", return_value=index_file):
-                from devtools import cmd_validate_ltm
-                args = argparse.Namespace()
-                result = cmd_validate_ltm(args)
-                assert result == 1
+        assert self._validate(
+            tmp_path,
+            "# Empty\n",
+            project_files={"fake-project-long-term-memory.md": project_content},
+        ) == 1
 
 
 if __name__ == "__main__":

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -6,22 +6,14 @@ Run with: python -m pytest tests/test_indexing.py -v
 """
 
 import json
-import os
-import sys
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest import mock
 
 import pytest
-
-# Add scripts directory to path
-scripts_dir = Path(__file__).parent.parent / "scripts"
-sys.path.insert(0, str(scripts_dir))
-
+from helpers import make_jsonl_line, make_session_info  # noqa: I001
 from indexing import (
     MIN_SESSION_SIZE_BYTES,
-    SessionInfo,
     build_projects_index,
     get_session_date,
     has_assistant_message,
@@ -33,36 +25,6 @@ from transcript_ops import (
     parse_jsonl_file,
     should_skip_message,
 )
-
-# =============================================================================
-# Helper to create JSONL content
-# =============================================================================
-
-
-def make_jsonl_line(role: str, content: str) -> str:
-    return json.dumps({
-        "type": role,
-        "message": {"role": role, "content": content},
-    })
-
-
-def make_session_info(
-    session_id: str = "test-session",
-    transcript_path: Path = Path("/tmp/test.jsonl"),
-    file_size: int = 2000,
-    project_path: str | None = None,
-    created: datetime | None = None,
-) -> SessionInfo:
-    return SessionInfo(
-        session_id=session_id,
-        transcript_path=transcript_path,
-        project_hash="test-hash",
-        file_mtime=datetime.now(timezone.utc),
-        file_size=file_size,
-        project_path=project_path,
-        created=created,
-    )
-
 
 # =============================================================================
 # Content Extraction Tests
@@ -106,24 +68,22 @@ class TestExtractTextContent:
 # =============================================================================
 
 
-class TestShouldSkipMessage:
-    def test_skill_injection(self):
-        assert should_skip_message("Base directory for this skill: /home/user/.claude/skills/test")
+@pytest.mark.parametrize("content", [
+    "Base directory for this skill: /home/user/.claude/skills/test",
+    "<command-name>/synthesize</command-name> some content",
+    "Some text with <system-reminder> embedded",
+    "[Request interrupted by user]",
+])
+def test_should_skip(content):
+    assert should_skip_message(content)
 
-    def test_command_name_tag(self):
-        assert should_skip_message("<command-name>/synthesize</command-name> some content")
 
-    def test_system_reminder(self):
-        assert should_skip_message("Some text with <system-reminder> embedded")
-
-    def test_user_interruption(self):
-        assert should_skip_message("[Request interrupted by user]")
-
-    def test_normal_content(self):
-        assert not should_skip_message("I've analyzed the codebase and found the following patterns")
-
-    def test_empty_content(self):
-        assert not should_skip_message("")
+@pytest.mark.parametrize("content", [
+    "I've analyzed the codebase and found the following patterns",
+    "",
+])
+def test_should_not_skip(content):
+    assert not should_skip_message(content)
 
 
 # =============================================================================
@@ -132,67 +92,43 @@ class TestShouldSkipMessage:
 
 
 class TestHasAssistantMessage:
-    def test_with_assistant_message(self):
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False
-        ) as f:
-            f.write(make_jsonl_line("user", "hello") + "\n")
-            f.write(make_jsonl_line("assistant", "hi there") + "\n")
-            f.flush()
-            try:
-                assert has_assistant_message(Path(f.name)) is True
-            finally:
-                os.unlink(f.name)
+    def test_with_assistant_message(self, tmp_path):
+        f = tmp_path / "test.jsonl"
+        f.write_text(
+            make_jsonl_line("user", "hello") + "\n"
+            + make_jsonl_line("assistant", "hi there") + "\n"
+        )
+        assert has_assistant_message(f) is True
 
-    def test_without_assistant_message(self):
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False
-        ) as f:
-            f.write(make_jsonl_line("user", "hello") + "\n")
-            f.flush()
-            try:
-                assert has_assistant_message(Path(f.name)) is False
-            finally:
-                os.unlink(f.name)
+    def test_without_assistant_message(self, tmp_path):
+        f = tmp_path / "test.jsonl"
+        f.write_text(make_jsonl_line("user", "hello") + "\n")
+        assert has_assistant_message(f) is False
 
-    def test_empty_file(self):
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False
-        ) as f:
-            f.write("")
-            f.flush()
-            try:
-                assert has_assistant_message(Path(f.name)) is False
-            finally:
-                os.unlink(f.name)
+    def test_empty_file(self, tmp_path):
+        f = tmp_path / "test.jsonl"
+        f.write_text("")
+        assert has_assistant_message(f) is False
 
-    def test_metadata_only(self):
+    def test_metadata_only(self, tmp_path):
         """Sessions with only metadata (file-history-snapshot, progress) should return False."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False
-        ) as f:
-            f.write(json.dumps({"type": "progress", "data": {}}) + "\n")
-            f.write(json.dumps({"type": "file-history-snapshot", "files": []}) + "\n")
-            f.flush()
-            try:
-                assert has_assistant_message(Path(f.name)) is False
-            finally:
-                os.unlink(f.name)
+        f = tmp_path / "test.jsonl"
+        f.write_text(
+            json.dumps({"type": "progress", "data": {}}) + "\n"
+            + json.dumps({"type": "file-history-snapshot", "files": []}) + "\n"
+        )
+        assert has_assistant_message(f) is False
 
     def test_nonexistent_file(self):
         assert has_assistant_message(Path("/nonexistent/file.jsonl")) is False
 
-    def test_invalid_json_lines(self):
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False
-        ) as f:
-            f.write("not json\n")
-            f.write(make_jsonl_line("assistant", "valid") + "\n")
-            f.flush()
-            try:
-                assert has_assistant_message(Path(f.name)) is True
-            finally:
-                os.unlink(f.name)
+    def test_invalid_json_lines(self, tmp_path):
+        f = tmp_path / "test.jsonl"
+        f.write_text(
+            "not json\n"
+            + make_jsonl_line("assistant", "valid") + "\n"
+        )
+        assert has_assistant_message(f) is True
 
 
 # =============================================================================
@@ -201,58 +137,39 @@ class TestHasAssistantMessage:
 
 
 class TestParseJsonlFile:
-    def test_parses_assistant_messages(self):
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False
-        ) as f:
-            f.write(make_jsonl_line("assistant", "I found the bug") + "\n")
-            f.flush()
-            try:
-                messages = parse_jsonl_file(Path(f.name))
-                assert len(messages) == 1
-                assert messages[0]["role"] == "assistant"
-                assert "bug" in messages[0]["content"]
-            finally:
-                os.unlink(f.name)
+    def test_parses_assistant_messages(self, tmp_path):
+        f = tmp_path / "test.jsonl"
+        f.write_text(make_jsonl_line("assistant", "I found the bug") + "\n")
+        messages = parse_jsonl_file(f)
+        assert len(messages) == 1
+        assert messages[0]["role"] == "assistant"
+        assert "bug" in messages[0]["content"]
 
-    def test_skips_user_messages(self):
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False
-        ) as f:
-            f.write(make_jsonl_line("user", "Fix the bug") + "\n")
-            f.write(make_jsonl_line("assistant", "I found the issue") + "\n")
-            f.flush()
-            try:
-                messages = parse_jsonl_file(Path(f.name))
-                assert len(messages) == 1
-                assert messages[0]["role"] == "assistant"
-            finally:
-                os.unlink(f.name)
+    def test_skips_user_messages(self, tmp_path):
+        f = tmp_path / "test.jsonl"
+        f.write_text(
+            make_jsonl_line("user", "Fix the bug") + "\n"
+            + make_jsonl_line("assistant", "I found the issue") + "\n"
+        )
+        messages = parse_jsonl_file(f)
+        assert len(messages) == 1
+        assert messages[0]["role"] == "assistant"
 
-    def test_skips_system_reminders(self):
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False
-        ) as f:
-            f.write(make_jsonl_line("assistant", "Normal response") + "\n")
-            f.write(make_jsonl_line("assistant", "Response with <system-reminder> injected") + "\n")
-            f.flush()
-            try:
-                messages = parse_jsonl_file(Path(f.name))
-                assert len(messages) == 1
-                assert "Normal response" in messages[0]["content"]
-            finally:
-                os.unlink(f.name)
+    def test_skips_system_reminders(self, tmp_path):
+        f = tmp_path / "test.jsonl"
+        f.write_text(
+            make_jsonl_line("assistant", "Normal response") + "\n"
+            + make_jsonl_line("assistant", "Response with <system-reminder> injected") + "\n"
+        )
+        messages = parse_jsonl_file(f)
+        assert len(messages) == 1
+        assert "Normal response" in messages[0]["content"]
 
-    def test_empty_file(self):
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False
-        ) as f:
-            f.flush()
-            try:
-                messages = parse_jsonl_file(Path(f.name))
-                assert messages == []
-            finally:
-                os.unlink(f.name)
+    def test_empty_file(self, tmp_path):
+        f = tmp_path / "test.jsonl"
+        f.write_text("")
+        messages = parse_jsonl_file(f)
+        assert messages == []
 
     def test_nonexistent_file(self):
         messages = parse_jsonl_file(Path("/nonexistent/file.jsonl"))
@@ -265,7 +182,7 @@ class TestParseJsonlFile:
 
 
 class TestListPendingSessions:
-    def _make_sessions(self) -> list[SessionInfo]:
+    def _make_sessions(self):
         return [
             make_session_info("captured-1", file_size=2000),
             make_session_info("pending-1", file_size=2000),
@@ -411,6 +328,16 @@ def _make_session_entry(session_id, created, project_path=None):
 
 
 class TestBuildProjectsIndex:
+    @pytest.fixture()
+    def env(self, tmp_path):
+        projects_dir = tmp_path / "projects"
+        memory_dir = tmp_path / "memory"
+        index_file = memory_dir / "projects-index.json"
+        with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
+             mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
+             mock.patch("indexing.get_projects_index_file", return_value=index_file):
+            yield projects_dir, memory_dir, index_file
+
     def _setup_project(self, projects_dir, folder_name, original_path, entries):
         """Create a project folder with sessions-index.json."""
         folder = projects_dir / folder_name
@@ -420,262 +347,194 @@ class TestBuildProjectsIndex:
             json.dumps(index_data), encoding="utf-8"
         )
 
-    def test_basic_project_discovery(self):
+    def test_basic_project_discovery(self, env):
         """Smoke test: function runs and finds a project."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            self._setup_project(
-                projects_dir,
-                "-home-user-myproject",
-                "/home/user/myproject",
-                [_make_session_entry("s1", "2026-02-01T10:00:00Z")],
-            )
+        self._setup_project(
+            projects_dir,
+            "-home-user-myproject",
+            "/home/user/myproject",
+            [_make_session_entry("s1", "2026-02-01T10:00:00Z")],
+        )
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            projects = result["projects"]
-            assert len(projects) == 1
-            data = list(projects.values())[0]
-            assert data["name"] == "myproject"
-            assert "2026-02-01" in data["workDays"]
+        projects = result["projects"]
+        assert len(projects) == 1
+        data = list(projects.values())[0]
+        assert data["name"] == "myproject"
+        assert "2026-02-01" in data["workDays"]
 
-    def test_extracts_project_name_from_path(self):
+    def test_extracts_project_name_from_path(self, env):
         """Project name is the last component of originalPath."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            self._setup_project(
-                projects_dir,
-                "-home-user-swyfft-projects-tableau-agency-overview",
-                "/home/user/swyfft/projects/tableau/agency-overview",
-                [_make_session_entry("s1", "2026-02-06T10:00:00Z")],
-            )
+        self._setup_project(
+            projects_dir,
+            "-home-user-swyfft-projects-tableau-agency-overview",
+            "/home/user/swyfft/projects/tableau/agency-overview",
+            [_make_session_entry("s1", "2026-02-06T10:00:00Z")],
+        )
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            projects = result["projects"]
-            data = list(projects.values())[0]
-            assert data["name"] == "agency-overview"
+        projects = result["projects"]
+        data = list(projects.values())[0]
+        assert data["name"] == "agency-overview"
 
-    def test_multiple_work_days(self):
+    def test_multiple_work_days(self, env):
         """Sessions on different days produce multiple work days."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            self._setup_project(
-                projects_dir,
-                "-home-user-proj",
-                "/home/user/proj",
-                [
-                    _make_session_entry("s1", "2026-02-01T10:00:00Z"),
-                    _make_session_entry("s2", "2026-02-01T14:00:00Z"),
-                    _make_session_entry("s3", "2026-02-03T09:00:00Z"),
-                ],
-            )
+        self._setup_project(
+            projects_dir,
+            "-home-user-proj",
+            "/home/user/proj",
+            [
+                _make_session_entry("s1", "2026-02-01T10:00:00Z"),
+                _make_session_entry("s2", "2026-02-01T14:00:00Z"),
+                _make_session_entry("s3", "2026-02-03T09:00:00Z"),
+            ],
+        )
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            data = list(result["projects"].values())[0]
-            assert data["workDays"] == ["2026-02-01", "2026-02-03"]
+        data = list(result["projects"].values())[0]
+        assert data["workDays"] == ["2026-02-01", "2026-02-03"]
 
-    def test_multiple_projects(self):
+    def test_multiple_projects(self, env):
         """Discovers multiple projects from separate folders."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            self._setup_project(
-                projects_dir, "-proj-a", "/home/user/proj-a",
-                [_make_session_entry("s1", "2026-01-15T10:00:00Z")],
-            )
-            self._setup_project(
-                projects_dir, "-proj-b", "/home/user/proj-b",
-                [_make_session_entry("s2", "2026-01-20T10:00:00Z")],
-            )
+        self._setup_project(
+            projects_dir, "-proj-a", "/home/user/proj-a",
+            [_make_session_entry("s1", "2026-01-15T10:00:00Z")],
+        )
+        self._setup_project(
+            projects_dir, "-proj-b", "/home/user/proj-b",
+            [_make_session_entry("s2", "2026-01-20T10:00:00Z")],
+        )
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            assert len(result["projects"]) == 2
-            names = {d["name"] for d in result["projects"].values()}
-            assert names == {"proj-a", "proj-b"}
+        assert len(result["projects"]) == 2
+        names = {d["name"] for d in result["projects"].values()}
+        assert names == {"proj-a", "proj-b"}
 
-    def test_skips_folder_without_sessions_index(self):
+    def test_skips_folder_without_sessions_index(self, env):
         """Folders without sessions-index.json are ignored."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            # Folder with no sessions-index.json
-            (projects_dir / "empty-folder").mkdir(parents=True)
-            # Folder with sessions-index.json
-            self._setup_project(
-                projects_dir, "-real-proj", "/home/user/real-proj",
-                [_make_session_entry("s1", "2026-02-01T10:00:00Z")],
-            )
+        # Folder with no sessions-index.json
+        (projects_dir / "empty-folder").mkdir(parents=True)
+        # Folder with sessions-index.json
+        self._setup_project(
+            projects_dir, "-real-proj", "/home/user/real-proj",
+            [_make_session_entry("s1", "2026-02-01T10:00:00Z")],
+        )
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            assert len(result["projects"]) == 1
+        assert len(result["projects"]) == 1
 
-    def test_skips_entries_without_created(self):
+    def test_skips_entries_without_created(self, env):
         """Entries missing created timestamp are skipped."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            entry_no_created = {
-                "sessionId": "s1",
-                "fullPath": "/tmp/s1.jsonl",
-                "fileMtime": 1770000000000,
-            }
-            self._setup_project(
-                projects_dir, "-proj", "/home/user/proj",
-                [entry_no_created],
-            )
+        entry_no_created = {
+            "sessionId": "s1",
+            "fullPath": "/tmp/s1.jsonl",
+            "fileMtime": 1770000000000,
+        }
+        self._setup_project(
+            projects_dir, "-proj", "/home/user/proj",
+            [entry_no_created],
+        )
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            # No work days extracted -> project skipped
-            assert len(result["projects"]) == 0
+        # No work days extracted -> project skipped
+        assert len(result["projects"]) == 0
 
-    def test_empty_projects_dir(self):
+    def test_empty_projects_dir(self, env):
         """Empty projects directory returns no projects."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            projects_dir.mkdir()
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
+        projects_dir.mkdir()
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            assert len(result["projects"]) == 0
+        assert len(result["projects"]) == 0
 
-    def test_nonexistent_projects_dir(self):
+    def test_nonexistent_projects_dir(self, env):
         """Missing projects directory returns empty result."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "nonexistent"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        result = build_projects_index()
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        assert result == {"projects": {}}
 
-            assert result == {"projects": {}}
-
-    def test_case_insensitive_path_merging(self):
+    def test_case_insensitive_path_merging(self, env):
         """Same project path with different cases merges work days."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            self._setup_project(
-                projects_dir, "-folder-a", "/home/user/MyProject",
-                [_make_session_entry("s1", "2026-02-01T10:00:00Z")],
-            )
-            self._setup_project(
-                projects_dir, "-folder-b", "/home/user/myproject",
-                [_make_session_entry("s2", "2026-02-03T10:00:00Z")],
-            )
+        self._setup_project(
+            projects_dir, "-folder-a", "/home/user/MyProject",
+            [_make_session_entry("s1", "2026-02-01T10:00:00Z")],
+        )
+        self._setup_project(
+            projects_dir, "-folder-b", "/home/user/myproject",
+            [_make_session_entry("s2", "2026-02-03T10:00:00Z")],
+        )
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            assert len(result["projects"]) == 1
-            data = list(result["projects"].values())[0]
-            assert len(data["workDays"]) == 2
-            assert len(data["encodedPaths"]) == 2
+        assert len(result["projects"]) == 1
+        data = list(result["projects"].values())[0]
+        assert len(data["workDays"]) == 2
+        assert len(data["encodedPaths"]) == 2
 
-    def test_writes_index_file(self):
+    def test_writes_index_file(self, env):
         """Result is written to projects-index.json."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            self._setup_project(
-                projects_dir, "-proj", "/home/user/proj",
-                [_make_session_entry("s1", "2026-02-01T10:00:00Z")],
-            )
+        self._setup_project(
+            projects_dir, "-proj", "/home/user/proj",
+            [_make_session_entry("s1", "2026-02-01T10:00:00Z")],
+        )
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                build_projects_index()
+        build_projects_index()
 
-            assert index_file.exists()
-            saved = json.loads(index_file.read_text(encoding="utf-8"))
-            assert saved["version"] == 1
-            assert "lastUpdated" in saved
-            assert len(saved["projects"]) == 1
+        assert index_file.exists()
+        saved = json.loads(index_file.read_text(encoding="utf-8"))
+        assert saved["version"] == 1
+        assert "lastUpdated" in saved
+        assert len(saved["projects"]) == 1
 
-    def test_fallback_to_entry_project_path(self):
+    def test_fallback_to_entry_project_path(self, env):
         """Uses entries[0].projectPath when root originalPath is missing."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            folder = projects_dir / "-proj"
-            folder.mkdir(parents=True)
-            index_data = {
-                "version": 1,
-                "entries": [
-                    {
-                        "sessionId": "s1",
-                        "fullPath": "/tmp/s1.jsonl",
-                        "fileMtime": 1770000000000,
-                        "created": "2026-02-01T10:00:00Z",
-                        "projectPath": "/home/user/fallback-proj",
-                    }
-                ],
-            }
-            (folder / "sessions-index.json").write_text(
-                json.dumps(index_data), encoding="utf-8"
-            )
+        folder = projects_dir / "-proj"
+        folder.mkdir(parents=True)
+        index_data = {
+            "version": 1,
+            "entries": [
+                {
+                    "sessionId": "s1",
+                    "fullPath": "/tmp/s1.jsonl",
+                    "fileMtime": 1770000000000,
+                    "created": "2026-02-01T10:00:00Z",
+                    "projectPath": "/home/user/fallback-proj",
+                }
+            ],
+        }
+        (folder / "sessions-index.json").write_text(
+            json.dumps(index_data), encoding="utf-8"
+        )
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            data = list(result["projects"].values())[0]
-            assert data["name"] == "fallback-proj"
+        data = list(result["projects"].values())[0]
+        assert data["name"] == "fallback-proj"
 
     # --- JSONL fallback tests ---
 
@@ -692,145 +551,109 @@ class TestBuildProjectsIndex:
         jsonl_path.write_text(line + "\n", encoding="utf-8")
         return jsonl_path
 
-    def test_jsonl_fallback_discovers_project_without_sessions_index(self):
+    def test_jsonl_fallback_discovers_project_without_sessions_index(self, env):
         """Folders with JSONL files but no sessions-index.json are discovered."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            # Folder with JSONL but NO sessions-index.json
-            folder = projects_dir / "-home-user-swyfft-projects-tableau"
-            folder.mkdir(parents=True)
-            self._make_jsonl_file(
-                folder, "sess-1",
-                "/home/user/swyfft/projects/tableau",
-                "2026-02-12T10:00:00Z",
-            )
+        # Folder with JSONL but NO sessions-index.json
+        folder = projects_dir / "-home-user-swyfft-projects-tableau"
+        folder.mkdir(parents=True)
+        self._make_jsonl_file(
+            folder, "sess-1",
+            "/home/user/swyfft/projects/tableau",
+            "2026-02-12T10:00:00Z",
+        )
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            assert len(result["projects"]) == 1
-            data = list(result["projects"].values())[0]
-            assert data["name"] == "tableau"
-            assert data["originalPath"] == "/home/user/swyfft/projects/tableau"
-            assert "2026-02-12" in data["workDays"]
+        assert len(result["projects"]) == 1
+        data = list(result["projects"].values())[0]
+        assert data["name"] == "tableau"
+        assert data["originalPath"] == "/home/user/swyfft/projects/tableau"
+        assert "2026-02-12" in data["workDays"]
 
-    def test_jsonl_fallback_extracts_multiple_work_days(self):
+    def test_jsonl_fallback_extracts_multiple_work_days(self, env):
         """Multiple JSONL files produce multiple work days."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            folder = projects_dir / "-home-user-proj"
-            folder.mkdir(parents=True)
-            self._make_jsonl_file(folder, "s1", "/home/user/proj", "2026-02-10T10:00:00Z")
-            self._make_jsonl_file(folder, "s2", "/home/user/proj", "2026-02-11T14:00:00Z")
-            self._make_jsonl_file(folder, "s3", "/home/user/proj", "2026-02-12T09:00:00Z")
+        folder = projects_dir / "-home-user-proj"
+        folder.mkdir(parents=True)
+        self._make_jsonl_file(folder, "s1", "/home/user/proj", "2026-02-10T10:00:00Z")
+        self._make_jsonl_file(folder, "s2", "/home/user/proj", "2026-02-11T14:00:00Z")
+        self._make_jsonl_file(folder, "s3", "/home/user/proj", "2026-02-12T09:00:00Z")
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            data = list(result["projects"].values())[0]
-            assert data["workDays"] == ["2026-02-10", "2026-02-11", "2026-02-12"]
+        data = list(result["projects"].values())[0]
+        assert data["workDays"] == ["2026-02-10", "2026-02-11", "2026-02-12"]
 
-    def test_jsonl_supplements_sessions_index_work_days(self):
+    def test_jsonl_supplements_sessions_index_work_days(self, env):
         """JSONL files add work days that sessions-index.json missed."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            # Sessions-index with only one day
-            self._setup_project(
-                projects_dir,
-                "-home-user-proj",
-                "/home/user/proj",
-                [_make_session_entry("s1", "2026-02-01T10:00:00Z")],
-            )
+        # Sessions-index with only one day
+        self._setup_project(
+            projects_dir,
+            "-home-user-proj",
+            "/home/user/proj",
+            [_make_session_entry("s1", "2026-02-01T10:00:00Z")],
+        )
 
-            # Additional JSONL files for days not in the index
-            folder = projects_dir / "-home-user-proj"
-            self._make_jsonl_file(folder, "s2", "/home/user/proj", "2026-02-05T10:00:00Z")
-            self._make_jsonl_file(folder, "s3", "/home/user/proj", "2026-02-10T10:00:00Z")
+        # Additional JSONL files for days not in the index
+        folder = projects_dir / "-home-user-proj"
+        self._make_jsonl_file(folder, "s2", "/home/user/proj", "2026-02-05T10:00:00Z")
+        self._make_jsonl_file(folder, "s3", "/home/user/proj", "2026-02-10T10:00:00Z")
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            data = list(result["projects"].values())[0]
-            assert "2026-02-01" in data["workDays"]  # from sessions-index
-            assert "2026-02-05" in data["workDays"]  # from JSONL
-            assert "2026-02-10" in data["workDays"]  # from JSONL
+        data = list(result["projects"].values())[0]
+        assert "2026-02-01" in data["workDays"]  # from sessions-index
+        assert "2026-02-05" in data["workDays"]  # from JSONL
+        assert "2026-02-10" in data["workDays"]  # from JSONL
 
-    def test_jsonl_fallback_skips_empty_files(self):
+    def test_jsonl_fallback_skips_empty_files(self, env):
         """Empty or tiny JSONL files are skipped."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            folder = projects_dir / "-home-user-proj"
-            folder.mkdir(parents=True)
-            # Empty file
-            (folder / "empty.jsonl").write_text("", encoding="utf-8")
-            # Valid file
-            self._make_jsonl_file(folder, "valid", "/home/user/proj", "2026-02-12T10:00:00Z")
+        folder = projects_dir / "-home-user-proj"
+        folder.mkdir(parents=True)
+        # Empty file
+        (folder / "empty.jsonl").write_text("", encoding="utf-8")
+        # Valid file
+        self._make_jsonl_file(folder, "valid", "/home/user/proj", "2026-02-12T10:00:00Z")
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            assert len(result["projects"]) == 1
-            data = list(result["projects"].values())[0]
-            assert data["workDays"] == ["2026-02-12"]
+        assert len(result["projects"]) == 1
+        data = list(result["projects"].values())[0]
+        assert data["workDays"] == ["2026-02-12"]
 
-    def test_jsonl_fallback_handles_malformed_json(self):
+    def test_jsonl_fallback_handles_malformed_json(self, env):
         """Malformed JSONL lines are skipped gracefully."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            folder = projects_dir / "-home-user-proj"
-            folder.mkdir(parents=True)
-            (folder / "bad.jsonl").write_text("not valid json\n", encoding="utf-8")
-            self._make_jsonl_file(folder, "good", "/home/user/proj", "2026-02-12T10:00:00Z")
+        folder = projects_dir / "-home-user-proj"
+        folder.mkdir(parents=True)
+        (folder / "bad.jsonl").write_text("not valid json\n", encoding="utf-8")
+        self._make_jsonl_file(folder, "good", "/home/user/proj", "2026-02-12T10:00:00Z")
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            assert len(result["projects"]) == 1
+        assert len(result["projects"]) == 1
 
-    def test_jsonl_only_folder_no_cwd_is_skipped(self):
+    def test_jsonl_only_folder_no_cwd_is_skipped(self, env):
         """JSONL files without cwd field cannot determine project path."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            memory_dir = Path(tmpdir) / "memory"
-            index_file = memory_dir / "projects-index.json"
+        projects_dir, memory_dir, index_file = env
 
-            folder = projects_dir / "-home-user-proj"
-            folder.mkdir(parents=True)
-            # JSONL with no cwd
-            line = json.dumps({"type": "user", "timestamp": "2026-02-12T10:00:00Z"})
-            (folder / "no-cwd.jsonl").write_text(line + "\n", encoding="utf-8")
+        folder = projects_dir / "-home-user-proj"
+        folder.mkdir(parents=True)
+        # JSONL with no cwd
+        line = json.dumps({"type": "user", "timestamp": "2026-02-12T10:00:00Z"})
+        (folder / "no-cwd.jsonl").write_text(line + "\n", encoding="utf-8")
 
-            with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
-                 mock.patch("indexing.get_projects_index_file", return_value=index_file):
-                result = build_projects_index()
+        result = build_projects_index()
 
-            assert len(result["projects"]) == 0
+        assert len(result["projects"]) == 0
 
 
 if __name__ == "__main__":

--- a/tests/test_load_memory.py
+++ b/tests/test_load_memory.py
@@ -5,19 +5,13 @@ Unit tests for load_memory.py
 Run with: python -m pytest tests/test_load_memory.py -v
 """
 
-import sys
-import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
-# Add scripts directory to path
-scripts_dir = Path(__file__).parent.parent / "scripts"
-sys.path.insert(0, str(scripts_dir))
-
-from load_memory import (
+from load_memory import (  # noqa: I001
     _build_synthesis_prompt,
     load_daily_summaries,
     load_global_memory,
@@ -41,75 +35,70 @@ class TestShouldSynthesize:
             mock_f.return_value = Path("/nonexistent/.last-synthesis")
             assert should_synthesize(self._make_settings()) is True
 
-    def test_true_on_new_day(self):
+    def test_true_on_new_day(self, tmp_path):
         """Returns True when last synthesis was on a different UTC day."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ts_file = Path(tmpdir) / ".last-synthesis"
-            yesterday = datetime.now(timezone.utc) - timedelta(days=1)
-            ts_file.write_text(yesterday.isoformat())
+        ts_file = tmp_path / ".last-synthesis"
+        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+        ts_file.write_text(yesterday.isoformat())
 
-            with mock.patch("load_memory.get_last_synthesis_file") as mock_f:
-                mock_f.return_value = ts_file
-                assert should_synthesize(self._make_settings()) is True
+        with mock.patch("load_memory.get_last_synthesis_file") as mock_f:
+            mock_f.return_value = ts_file
+            assert should_synthesize(self._make_settings()) is True
 
-    def test_false_within_interval(self):
+    def test_false_within_interval(self, tmp_path):
         """Returns False when last synthesis is same day and within interval."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ts_file = Path(tmpdir) / ".last-synthesis"
-            fixed_now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
-            thirty_min_ago = fixed_now - timedelta(minutes=30)
-            ts_file.write_text(thirty_min_ago.isoformat())
+        ts_file = tmp_path / ".last-synthesis"
+        fixed_now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        thirty_min_ago = fixed_now - timedelta(minutes=30)
+        ts_file.write_text(thirty_min_ago.isoformat())
 
-            with mock.patch("load_memory.get_last_synthesis_file") as mock_f, \
-                 mock.patch("load_memory.datetime") as mock_dt:
-                mock_f.return_value = ts_file
-                mock_dt.now.return_value = fixed_now
-                mock_dt.fromisoformat = datetime.fromisoformat
-                mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
-                assert should_synthesize(self._make_settings()) is False
+        with mock.patch("load_memory.get_last_synthesis_file") as mock_f, \
+             mock.patch("load_memory.datetime") as mock_dt:
+            mock_f.return_value = ts_file
+            mock_dt.now.return_value = fixed_now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            assert should_synthesize(self._make_settings()) is False
 
-    def test_true_after_interval(self):
+    def test_true_after_interval(self, tmp_path):
         """Returns True when same day but past intervalHours."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ts_file = Path(tmpdir) / ".last-synthesis"
-            fixed_now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
-            three_hours_ago = fixed_now - timedelta(hours=3)
-            ts_file.write_text(three_hours_ago.isoformat())
+        ts_file = tmp_path / ".last-synthesis"
+        fixed_now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        three_hours_ago = fixed_now - timedelta(hours=3)
+        ts_file.write_text(three_hours_ago.isoformat())
 
-            with mock.patch("load_memory.get_last_synthesis_file") as mock_f, \
-                 mock.patch("load_memory.datetime") as mock_dt:
-                mock_f.return_value = ts_file
-                mock_dt.now.return_value = fixed_now
-                mock_dt.fromisoformat = datetime.fromisoformat
-                mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
-                assert should_synthesize(self._make_settings(interval_hours=2)) is True
+        with mock.patch("load_memory.get_last_synthesis_file") as mock_f, \
+             mock.patch("load_memory.datetime") as mock_dt:
+            mock_f.return_value = ts_file
+            mock_dt.now.return_value = fixed_now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            assert should_synthesize(self._make_settings(interval_hours=2)) is True
 
-    def test_true_on_invalid_file(self):
+    def test_true_on_invalid_file(self, tmp_path):
         """Returns True when file contains invalid content."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ts_file = Path(tmpdir) / ".last-synthesis"
-            ts_file.write_text("not a valid timestamp")
+        ts_file = tmp_path / ".last-synthesis"
+        ts_file.write_text("not a valid timestamp")
 
-            with mock.patch("load_memory.get_last_synthesis_file") as mock_f:
-                mock_f.return_value = ts_file
-                assert should_synthesize(self._make_settings()) is True
+        with mock.patch("load_memory.get_last_synthesis_file") as mock_f:
+            mock_f.return_value = ts_file
+            assert should_synthesize(self._make_settings()) is True
 
-    def test_respects_custom_interval(self):
+    def test_respects_custom_interval(self, tmp_path):
         """Uses intervalHours from settings, not hardcoded default."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ts_file = Path(tmpdir) / ".last-synthesis"
-            # Use fixed time to avoid UTC midnight edge case
-            fixed_now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
-            three_hours_ago = fixed_now - timedelta(hours=3)
-            ts_file.write_text(three_hours_ago.isoformat())
+        ts_file = tmp_path / ".last-synthesis"
+        # Use fixed time to avoid UTC midnight edge case
+        fixed_now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        three_hours_ago = fixed_now - timedelta(hours=3)
+        ts_file.write_text(three_hours_ago.isoformat())
 
-            with mock.patch("load_memory.get_last_synthesis_file") as mock_f, \
-                 mock.patch("load_memory.datetime") as mock_dt:
-                mock_f.return_value = ts_file
-                mock_dt.now.return_value = fixed_now
-                mock_dt.fromisoformat = datetime.fromisoformat
-                mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
-                assert should_synthesize(self._make_settings(interval_hours=4)) is False
+        with mock.patch("load_memory.get_last_synthesis_file") as mock_f, \
+             mock.patch("load_memory.datetime") as mock_dt:
+            mock_f.return_value = ts_file
+            mock_dt.now.return_value = fixed_now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            assert should_synthesize(self._make_settings(interval_hours=4)) is False
 
 
 # =============================================================================
@@ -118,16 +107,15 @@ class TestShouldSynthesize:
 
 
 class TestLoadGlobalMemory:
-    def test_returns_content_when_exists(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            mem_file = Path(tmpdir) / "global-long-term-memory.md"
-            mem_file.write_text("# Global Memory\nSome content here")
+    def test_returns_content_when_exists(self, tmp_path):
+        mem_file = tmp_path / "global-long-term-memory.md"
+        mem_file.write_text("# Global Memory\nSome content here")
 
-            with mock.patch("load_memory.get_global_memory_file") as mock_f:
-                mock_f.return_value = mem_file
-                content, size = load_global_memory()
-                assert "Global Memory" in content
-                assert size > 0
+        with mock.patch("load_memory.get_global_memory_file") as mock_f:
+            mock_f.return_value = mem_file
+            content, size = load_global_memory()
+            assert "Global Memory" in content
+            assert size > 0
 
     def test_returns_empty_when_no_file(self):
         with mock.patch("load_memory.get_global_memory_file") as mock_f:
@@ -136,21 +124,20 @@ class TestLoadGlobalMemory:
             assert content == ""
             assert size == 0
 
-    def test_returns_empty_on_io_error(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            mem_file = Path(tmpdir) / "memory.md"
-            mem_file.write_text("content")
-            # Make unreadable
-            mem_file.chmod(0o000)
+    def test_returns_empty_on_io_error(self, tmp_path):
+        mem_file = tmp_path / "memory.md"
+        mem_file.write_text("content")
+        # Make unreadable
+        mem_file.chmod(0o000)
 
-            with mock.patch("load_memory.get_global_memory_file") as mock_f:
-                mock_f.return_value = mem_file
-                content, size = load_global_memory()
-                assert content == ""
-                assert size == 0
+        with mock.patch("load_memory.get_global_memory_file") as mock_f:
+            mock_f.return_value = mem_file
+            content, size = load_global_memory()
+            assert content == ""
+            assert size == 0
 
-            # Restore permissions for cleanup
-            mem_file.chmod(0o644)
+        # Restore permissions for cleanup
+        mem_file.chmod(0o644)
 
 
 # =============================================================================
@@ -159,38 +146,33 @@ class TestLoadGlobalMemory:
 
 
 class TestLoadProjectMemory:
-    def test_returns_content(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            project_dir = Path(tmpdir)
-            mem_file = project_dir / "myproject-long-term-memory.md"
-            mem_file.write_text("# myproject\nProject learnings")
+    def test_returns_content(self, tmp_path):
+        mem_file = tmp_path / "myproject-long-term-memory.md"
+        mem_file.write_text("# myproject\nProject learnings")
 
-            with mock.patch("load_memory.get_project_memory_dir") as mock_d:
-                mock_d.return_value = project_dir
-                content, size = load_project_memory("myproject")
-                assert "Project learnings" in content
-                assert size > 0
+        with mock.patch("load_memory.get_project_memory_dir") as mock_d:
+            mock_d.return_value = tmp_path
+            content, size = load_project_memory("myproject")
+            assert "Project learnings" in content
+            assert size > 0
 
-    def test_returns_empty_when_missing(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch("load_memory.get_project_memory_dir") as mock_d:
-                mock_d.return_value = Path(tmpdir)
-                content, size = load_project_memory("nonexistent")
-                assert content == ""
-                assert size == 0
+    def test_returns_empty_when_missing(self, tmp_path):
+        with mock.patch("load_memory.get_project_memory_dir") as mock_d:
+            mock_d.return_value = tmp_path
+            content, size = load_project_memory("nonexistent")
+            assert content == ""
+            assert size == 0
 
-    def test_handles_special_chars_in_name(self):
+    def test_handles_special_chars_in_name(self, tmp_path):
         """Project names with special chars map to correct filenames."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            project_dir = Path(tmpdir)
-            # "My Project!" → "my-project-long-term-memory.md"
-            mem_file = project_dir / "my-project-long-term-memory.md"
-            mem_file.write_text("# My Project\nContent")
+        # "My Project!" -> "my-project-long-term-memory.md"
+        mem_file = tmp_path / "my-project-long-term-memory.md"
+        mem_file.write_text("# My Project\nContent")
 
-            with mock.patch("load_memory.get_project_memory_dir") as mock_d:
-                mock_d.return_value = project_dir
-                content, size = load_project_memory("My Project!")
-                assert "Content" in content
+        with mock.patch("load_memory.get_project_memory_dir") as mock_d:
+            mock_d.return_value = tmp_path
+            content, size = load_project_memory("My Project!")
+            assert "Content" in content
 
 
 # =============================================================================
@@ -218,64 +200,65 @@ SAMPLE_DAILY_PROJECT = """# 2026-02-04
 """
 
 
+def _setup_daily_dir(tmp_path, include_global_only_day=False):
+    daily_dir = tmp_path / "daily"
+    daily_dir.mkdir()
+    (daily_dir / "2026-02-05.md").write_text(SAMPLE_DAILY_GLOBAL)
+    (daily_dir / "2026-02-04.md").write_text(SAMPLE_DAILY_PROJECT)
+    if include_global_only_day:
+        (daily_dir / "2026-02-03.md").write_text(
+            "# 2026-02-03\n## Actions\n- [global/implement] Only global\n"
+        )
+    return daily_dir
+
+
 class TestLoadDailySummaries:
-    def _setup_daily_dir(self, tmpdir: str) -> Path:
-        daily_dir = Path(tmpdir) / "daily"
-        daily_dir.mkdir()
-        (daily_dir / "2026-02-05.md").write_text(SAMPLE_DAILY_GLOBAL)
-        (daily_dir / "2026-02-04.md").write_text(SAMPLE_DAILY_PROJECT)
-        return daily_dir
+    def test_global_scope_filtering(self, tmp_path):
+        daily_dir = _setup_daily_dir(tmp_path)
+        with mock.patch("load_memory.get_daily_dir") as mock_dd, \
+             mock.patch("load_memory.get_working_days") as mock_wd:
+            mock_dd.return_value = daily_dir
+            mock_wd.return_value = ["2026-02-05", "2026-02-04"]
 
-    def test_global_scope_filtering(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            daily_dir = self._setup_daily_dir(tmpdir)
-            with mock.patch("load_memory.get_daily_dir") as mock_dd, \
-                 mock.patch("load_memory.get_working_days") as mock_wd:
-                mock_dd.return_value = daily_dir
-                mock_wd.return_value = ["2026-02-05", "2026-02-04"]
+            summaries, total_bytes = load_daily_summaries(2, scope="global")
+            all_content = " ".join(content for _, content in summaries)
+            assert "[global/" in all_content
+            assert "[myproject/" not in all_content
 
-                summaries, total_bytes = load_daily_summaries(2, scope="global")
-                all_content = " ".join(content for _, content in summaries)
-                assert "[global/" in all_content
-                assert "[myproject/" not in all_content
+    def test_project_scope_filtering(self, tmp_path):
+        daily_dir = _setup_daily_dir(tmp_path)
+        with mock.patch("load_memory.get_daily_dir") as mock_dd, \
+             mock.patch("load_memory.get_working_days") as mock_wd:
+            mock_dd.return_value = daily_dir
+            mock_wd.return_value = ["2026-02-05", "2026-02-04"]
 
-    def test_project_scope_filtering(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            daily_dir = self._setup_daily_dir(tmpdir)
-            with mock.patch("load_memory.get_daily_dir") as mock_dd, \
-                 mock.patch("load_memory.get_working_days") as mock_wd:
-                mock_dd.return_value = daily_dir
-                mock_wd.return_value = ["2026-02-05", "2026-02-04"]
+            summaries, total_bytes = load_daily_summaries(2, scope="myproject")
+            all_content = " ".join(content for _, content in summaries)
+            assert "[myproject/" in all_content
+            assert "[global/" not in all_content
 
-                summaries, total_bytes = load_daily_summaries(2, scope="myproject")
-                all_content = " ".join(content for _, content in summaries)
-                assert "[myproject/" in all_content
-                assert "[global/" not in all_content
-
-    def test_respects_days_limit(self):
+    def test_respects_days_limit(self, tmp_path):
         """get_working_days already limits, so only those dates are loaded."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            daily_dir = self._setup_daily_dir(tmpdir)
-            with mock.patch("load_memory.get_daily_dir") as mock_dd, \
-                 mock.patch("load_memory.get_working_days") as mock_wd:
-                mock_dd.return_value = daily_dir
-                mock_wd.return_value = ["2026-02-05"]  # Only 1 day
+        daily_dir = _setup_daily_dir(tmp_path)
+        with mock.patch("load_memory.get_daily_dir") as mock_dd, \
+             mock.patch("load_memory.get_working_days") as mock_wd:
+            mock_dd.return_value = daily_dir
+            mock_wd.return_value = ["2026-02-05"]  # Only 1 day
 
-                summaries, _ = load_daily_summaries(1, scope="global")
-                dates = [d for d, _ in summaries]
-                assert "2026-02-04" not in dates
+            summaries, _ = load_daily_summaries(1, scope="global")
+            dates = [d for d, _ in summaries]
+            assert "2026-02-04" not in dates
 
-    def test_empty_when_no_matching_content(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            daily_dir = self._setup_daily_dir(tmpdir)
-            with mock.patch("load_memory.get_daily_dir") as mock_dd, \
-                 mock.patch("load_memory.get_working_days") as mock_wd:
-                mock_dd.return_value = daily_dir
-                mock_wd.return_value = ["2026-02-05"]
+    def test_empty_when_no_matching_content(self, tmp_path):
+        daily_dir = _setup_daily_dir(tmp_path)
+        with mock.patch("load_memory.get_daily_dir") as mock_dd, \
+             mock.patch("load_memory.get_working_days") as mock_wd:
+            mock_dd.return_value = daily_dir
+            mock_wd.return_value = ["2026-02-05"]
 
-                summaries, total_bytes = load_daily_summaries(1, scope="other-project")
-                assert summaries == []
-                assert total_bytes == 0
+            summaries, total_bytes = load_daily_summaries(1, scope="other-project")
+            assert summaries == []
+            assert total_bytes == 0
 
 
 # =============================================================================
@@ -284,50 +267,36 @@ class TestLoadDailySummaries:
 
 
 class TestLoadProjectHistory:
-    def _setup_daily_dir(self, tmpdir: str) -> Path:
-        daily_dir = Path(tmpdir) / "daily"
-        daily_dir.mkdir()
-        (daily_dir / "2026-02-05.md").write_text(SAMPLE_DAILY_GLOBAL)
-        (daily_dir / "2026-02-04.md").write_text(SAMPLE_DAILY_PROJECT)
-        # Day with no project content
-        (daily_dir / "2026-02-03.md").write_text(
-            "# 2026-02-03\n## Actions\n- [global/implement] Only global\n"
-        )
-        return daily_dir
+    def test_loads_project_entries(self, tmp_path):
+        daily_dir = _setup_daily_dir(tmp_path, include_global_only_day=True)
+        with mock.patch("load_memory.get_daily_dir") as mock_dd:
+            mock_dd.return_value = daily_dir
+            project = {"name": "myproject"}
+            summaries, total_bytes = load_project_history(project, days_limit=10)
 
-    def test_loads_project_entries(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            daily_dir = self._setup_daily_dir(tmpdir)
-            with mock.patch("load_memory.get_daily_dir") as mock_dd:
-                mock_dd.return_value = daily_dir
-                project = {"name": "myproject"}
-                summaries, total_bytes = load_project_history(project, days_limit=10)
+            assert len(summaries) == 2  # Feb 4 and Feb 5 have myproject entries
+            all_content = " ".join(content for _, content in summaries)
+            assert "[myproject/" in all_content
+            assert "[global/" not in all_content
+            assert total_bytes > 0
 
-                assert len(summaries) == 2  # Feb 4 and Feb 5 have myproject entries
-                all_content = " ".join(content for _, content in summaries)
-                assert "[myproject/" in all_content
-                assert "[global/" not in all_content
-                assert total_bytes > 0
-
-    def test_oldest_first_ordering(self):
+    def test_oldest_first_ordering(self, tmp_path):
         """Output should be chronological (oldest first)."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            daily_dir = self._setup_daily_dir(tmpdir)
-            with mock.patch("load_memory.get_daily_dir") as mock_dd:
-                mock_dd.return_value = daily_dir
-                project = {"name": "myproject"}
-                summaries, _ = load_project_history(project, days_limit=10)
-                dates = [d for d, _ in summaries]
-                assert dates == sorted(dates)
+        daily_dir = _setup_daily_dir(tmp_path, include_global_only_day=True)
+        with mock.patch("load_memory.get_daily_dir") as mock_dd:
+            mock_dd.return_value = daily_dir
+            project = {"name": "myproject"}
+            summaries, _ = load_project_history(project, days_limit=10)
+            dates = [d for d, _ in summaries]
+            assert dates == sorted(dates)
 
-    def test_respects_day_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            daily_dir = self._setup_daily_dir(tmpdir)
-            with mock.patch("load_memory.get_daily_dir") as mock_dd:
-                mock_dd.return_value = daily_dir
-                project = {"name": "myproject"}
-                summaries, _ = load_project_history(project, days_limit=1)
-                assert len(summaries) == 1
+    def test_respects_day_limit(self, tmp_path):
+        daily_dir = _setup_daily_dir(tmp_path, include_global_only_day=True)
+        with mock.patch("load_memory.get_daily_dir") as mock_dd:
+            mock_dd.return_value = daily_dir
+            project = {"name": "myproject"}
+            summaries, _ = load_project_history(project, days_limit=1)
+            assert len(summaries) == 1
 
     def test_empty_project_name(self):
         project = {"name": ""}
@@ -345,7 +314,7 @@ class TestSynthesisPromptRoutedMarker:
     """Verify [routed] marking is handled by post-synthesis mark-routed script, not subagent."""
 
     def test_prompt_does_not_contain_routed_instruction(self):
-        """Subagent should NOT be told to mark [routed] — devtools.py mark-routed handles it."""
+        """Subagent should NOT be told to mark [routed] -- devtools.py mark-routed handles it."""
         prompt = _build_synthesis_prompt("", ["2026-02-01"])
         assert "Dedup marking" not in prompt
 

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -1,23 +1,12 @@
 #!/usr/bin/env python3
-"""
-Unit tests for memory_utils.py
-
-Run with: python -m pytest tests/test_memory_utils.py -v
-"""
+"""Unit tests for memory_utils.py"""
 
 import json
 import os
-import sys
-import tempfile
 from pathlib import Path
 from unittest import mock
 
 import pytest
-
-# Add scripts directory to path
-scripts_dir = Path(__file__).parent.parent / "scripts"
-sys.path.insert(0, str(scripts_dir))
-
 from memory_utils import (
     DEFAULT_SETTINGS,
     SHORT_TERM_TOKENS_PER_DAY,
@@ -43,20 +32,14 @@ from memory_utils import (
 # =============================================================================
 
 
-class TestEstimateTokens:
-    def test_empty_string(self):
-        assert estimate_tokens("") == 0
-
-    def test_basic_text(self):
-        # 20 chars → 5 tokens
-        assert estimate_tokens("12345678901234567890") == 5
-
-    def test_short_text(self):
-        # 3 chars → 0 (integer division)
-        assert estimate_tokens("abc") == 0
-
-    def test_four_chars(self):
-        assert estimate_tokens("abcd") == 1
+@pytest.mark.parametrize("text,expected", [
+    ("", 0),
+    ("12345678901234567890", 5),
+    ("abc", 0),
+    ("abcd", 1),
+])
+def test_estimate_tokens(text, expected):
+    assert estimate_tokens(text) == expected
 
 
 # =============================================================================
@@ -65,62 +48,50 @@ class TestEstimateTokens:
 
 
 class TestLoadSettings:
-    def test_defaults_when_no_file(self):
+    @pytest.fixture
+    def no_settings_file(self):
         with mock.patch("memory_utils.get_settings_file") as mock_sf:
             mock_sf.return_value = Path("/nonexistent/settings.json")
+            yield
+
+    def test_defaults_when_no_file(self, no_settings_file):
+        settings = load_settings()
+        assert settings["globalShortTerm"]["workingDays"] == DEFAULT_SETTINGS["globalShortTerm"]["workingDays"]
+        assert settings["projectShortTerm"]["workingDays"] == DEFAULT_SETTINGS["projectShortTerm"]["workingDays"]
+        assert settings["globalLongTerm"]["tokenLimit"] == DEFAULT_SETTINGS["globalLongTerm"]["tokenLimit"]
+
+    def test_calculated_token_limits(self, no_settings_file):
+        settings = load_settings()
+        assert settings["globalShortTerm"]["tokenLimit"] == 2 * SHORT_TERM_TOKENS_PER_DAY
+        assert settings["projectShortTerm"]["tokenLimit"] == DEFAULT_SETTINGS["projectShortTerm"]["workingDays"] * SHORT_TERM_TOKENS_PER_DAY
+
+    def test_total_budget_calculation(self, no_settings_file):
+        settings = load_settings()
+        expected = (
+            DEFAULT_SETTINGS["globalLongTerm"]["tokenLimit"]
+            + DEFAULT_SETTINGS["globalShortTerm"]["workingDays"] * SHORT_TERM_TOKENS_PER_DAY
+            + DEFAULT_SETTINGS["projectLongTerm"]["tokenLimit"]
+            + DEFAULT_SETTINGS["projectShortTerm"]["workingDays"] * SHORT_TERM_TOKENS_PER_DAY
+        )
+        assert settings["totalTokenBudget"] == expected
+
+    def test_user_overrides_merge(self, tmp_path):
+        f = tmp_path / "settings.json"
+        f.write_text(json.dumps({"globalShortTerm": {"workingDays": 5}}))
+        with mock.patch("memory_utils.get_settings_file") as mock_sf:
+            mock_sf.return_value = f
+            settings = load_settings()
+            assert settings["globalShortTerm"]["workingDays"] == 5
+            # Other defaults preserved
+            assert settings["projectShortTerm"]["workingDays"] == DEFAULT_SETTINGS["projectShortTerm"]["workingDays"]
+
+    def test_invalid_json_returns_defaults(self, tmp_path):
+        f = tmp_path / "settings.json"
+        f.write_text("not valid json {{{")
+        with mock.patch("memory_utils.get_settings_file") as mock_sf:
+            mock_sf.return_value = f
             settings = load_settings()
             assert settings["globalShortTerm"]["workingDays"] == DEFAULT_SETTINGS["globalShortTerm"]["workingDays"]
-            assert settings["projectShortTerm"]["workingDays"] == DEFAULT_SETTINGS["projectShortTerm"]["workingDays"]
-            assert settings["globalLongTerm"]["tokenLimit"] == DEFAULT_SETTINGS["globalLongTerm"]["tokenLimit"]
-
-    def test_calculated_token_limits(self):
-        with mock.patch("memory_utils.get_settings_file") as mock_sf:
-            mock_sf.return_value = Path("/nonexistent/settings.json")
-            settings = load_settings()
-            assert settings["globalShortTerm"]["tokenLimit"] == 2 * SHORT_TERM_TOKENS_PER_DAY
-            assert settings["projectShortTerm"]["tokenLimit"] == DEFAULT_SETTINGS["projectShortTerm"]["workingDays"] * SHORT_TERM_TOKENS_PER_DAY
-
-    def test_total_budget_calculation(self):
-        with mock.patch("memory_utils.get_settings_file") as mock_sf:
-            mock_sf.return_value = Path("/nonexistent/settings.json")
-            settings = load_settings()
-            expected = (
-                DEFAULT_SETTINGS["globalLongTerm"]["tokenLimit"]
-                + DEFAULT_SETTINGS["globalShortTerm"]["workingDays"] * SHORT_TERM_TOKENS_PER_DAY
-                + DEFAULT_SETTINGS["projectLongTerm"]["tokenLimit"]
-                + DEFAULT_SETTINGS["projectShortTerm"]["workingDays"] * SHORT_TERM_TOKENS_PER_DAY
-            )
-            assert settings["totalTokenBudget"] == expected
-
-    def test_user_overrides_merge(self):
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as f:
-            json.dump({"globalShortTerm": {"workingDays": 5}}, f)
-            f.flush()
-            try:
-                with mock.patch("memory_utils.get_settings_file") as mock_sf:
-                    mock_sf.return_value = Path(f.name)
-                    settings = load_settings()
-                    assert settings["globalShortTerm"]["workingDays"] == 5
-                    # Other defaults preserved
-                    assert settings["projectShortTerm"]["workingDays"] == DEFAULT_SETTINGS["projectShortTerm"]["workingDays"]
-            finally:
-                os.unlink(f.name)
-
-    def test_invalid_json_returns_defaults(self):
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as f:
-            f.write("not valid json {{{")
-            f.flush()
-            try:
-                with mock.patch("memory_utils.get_settings_file") as mock_sf:
-                    mock_sf.return_value = Path(f.name)
-                    settings = load_settings()
-                    assert settings["globalShortTerm"]["workingDays"] == DEFAULT_SETTINGS["globalShortTerm"]["workingDays"]
-            finally:
-                os.unlink(f.name)
 
 
 class TestDeepMerge:
@@ -152,44 +123,30 @@ class TestJsonFileUtils:
         result = load_json_file(Path("/nonexistent/file.json"), {"default": True})
         assert result == {"default": True}
 
-    def test_load_valid_json(self):
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as f:
-            json.dump({"key": "value"}, f)
-            f.flush()
-            try:
-                result = load_json_file(Path(f.name))
-                assert result == {"key": "value"}
-            finally:
-                os.unlink(f.name)
+    def test_load_valid_json(self, tmp_path):
+        f = tmp_path / "data.json"
+        f.write_text(json.dumps({"key": "value"}))
+        result = load_json_file(f)
+        assert result == {"key": "value"}
 
-    def test_load_invalid_json_returns_default(self):
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as f:
-            f.write("broken")
-            f.flush()
-            try:
-                result = load_json_file(Path(f.name), [])
-                assert result == []
-            finally:
-                os.unlink(f.name)
+    def test_load_invalid_json_returns_default(self, tmp_path):
+        f = tmp_path / "broken.json"
+        f.write_text("broken")
+        result = load_json_file(f, [])
+        assert result == []
 
-    def test_save_creates_parent_dirs(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            filepath = Path(tmpdir) / "sub" / "dir" / "data.json"
-            assert save_json_file(filepath, {"saved": True})
-            assert filepath.exists()
-            assert json.loads(filepath.read_text()) == {"saved": True}
+    def test_save_creates_parent_dirs(self, tmp_path):
+        filepath = tmp_path / "sub" / "dir" / "data.json"
+        assert save_json_file(filepath, {"saved": True})
+        assert filepath.exists()
+        assert json.loads(filepath.read_text()) == {"saved": True}
 
-    def test_save_round_trip(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            filepath = Path(tmpdir) / "test.json"
-            data = {"nested": {"list": [1, 2, 3]}}
-            save_json_file(filepath, data)
-            loaded = load_json_file(filepath)
-            assert loaded == data
+    def test_save_round_trip(self, tmp_path):
+        filepath = tmp_path / "test.json"
+        data = {"nested": {"list": [1, 2, 3]}}
+        save_json_file(filepath, data)
+        loaded = load_json_file(filepath)
+        assert loaded == data
 
 
 # =============================================================================
@@ -197,21 +154,15 @@ class TestJsonFileUtils:
 # =============================================================================
 
 
-class TestProjectNameToFilename:
-    def test_simple_name(self):
-        assert project_name_to_filename("myproject") == "myproject-long-term-memory.md"
-
-    def test_spaces(self):
-        assert project_name_to_filename("My Project") == "my-project-long-term-memory.md"
-
-    def test_special_characters(self):
-        assert project_name_to_filename("My@Project!") == "myproject-long-term-memory.md"
-
-    def test_consecutive_hyphens(self):
-        assert project_name_to_filename("my--project") == "my-project-long-term-memory.md"
-
-    def test_leading_trailing_hyphens(self):
-        assert project_name_to_filename("-project-") == "project-long-term-memory.md"
+@pytest.mark.parametrize("name,expected", [
+    ("myproject", "myproject-long-term-memory.md"),
+    ("My Project", "my-project-long-term-memory.md"),
+    ("My@Project!", "myproject-long-term-memory.md"),
+    ("my--project", "my-project-long-term-memory.md"),
+    ("-project-", "project-long-term-memory.md"),
+])
+def test_project_name_to_filename(name, expected):
+    assert project_name_to_filename(name) == expected
 
 
 # =============================================================================
@@ -225,57 +176,47 @@ class TestCapturedSessions:
             mock_cf.return_value = Path("/nonexistent/.captured")
             assert get_captured_sessions() == set()
 
-    def test_read_captured(self):
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".captured", delete=False
-        ) as f:
-            f.write("session-1\nsession-2\n\nsession-3\n")
-            f.flush()
-            try:
-                with mock.patch("memory_utils.get_captured_file") as mock_cf:
-                    mock_cf.return_value = Path(f.name)
-                    result = get_captured_sessions()
-                    assert result == {"session-1", "session-2", "session-3"}
-            finally:
-                os.unlink(f.name)
+    def test_read_captured(self, tmp_path):
+        f = tmp_path / ".captured"
+        f.write_text("session-1\nsession-2\n\nsession-3\n")
+        with mock.patch("memory_utils.get_captured_file") as mock_cf:
+            mock_cf.return_value = f
+            result = get_captured_sessions()
+            assert result == {"session-1", "session-2", "session-3"}
 
-    def test_add_captured(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            captured_file = Path(tmpdir) / ".captured"
-            with mock.patch("memory_utils.get_captured_file") as mock_cf:
-                mock_cf.return_value = captured_file
-                add_captured_session("new-session")
-                assert "new-session" in captured_file.read_text()
+    def test_add_captured(self, tmp_path):
+        captured_file = tmp_path / ".captured"
+        with mock.patch("memory_utils.get_captured_file") as mock_cf:
+            mock_cf.return_value = captured_file
+            add_captured_session("new-session")
+            assert "new-session" in captured_file.read_text()
 
-    def test_add_duplicate_skipped(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            captured_file = Path(tmpdir) / ".captured"
-            captured_file.write_text("existing\n")
-            with mock.patch("memory_utils.get_captured_file") as mock_cf:
-                mock_cf.return_value = captured_file
-                add_captured_session("existing")
-                # Should not have duplicate
-                lines = [line for line in captured_file.read_text().splitlines() if line.strip()]
-                assert lines.count("existing") == 1
+    def test_add_duplicate_skipped(self, tmp_path):
+        captured_file = tmp_path / ".captured"
+        captured_file.write_text("existing\n")
+        with mock.patch("memory_utils.get_captured_file") as mock_cf:
+            mock_cf.return_value = captured_file
+            add_captured_session("existing")
+            # Should not have duplicate
+            lines = [line for line in captured_file.read_text().splitlines() if line.strip()]
+            assert lines.count("existing") == 1
 
-    def test_remove_captured(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            captured_file = Path(tmpdir) / ".captured"
-            captured_file.write_text("keep-me\nremove-me\nalso-keep\n")
-            with mock.patch("memory_utils.get_captured_file") as mock_cf:
-                mock_cf.return_value = captured_file
-                assert remove_captured_session("remove-me") is True
-                content = captured_file.read_text()
-                assert "remove-me" not in content
-                assert "keep-me" in content
+    def test_remove_captured(self, tmp_path):
+        captured_file = tmp_path / ".captured"
+        captured_file.write_text("keep-me\nremove-me\nalso-keep\n")
+        with mock.patch("memory_utils.get_captured_file") as mock_cf:
+            mock_cf.return_value = captured_file
+            assert remove_captured_session("remove-me") is True
+            content = captured_file.read_text()
+            assert "remove-me" not in content
+            assert "keep-me" in content
 
-    def test_remove_nonexistent(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            captured_file = Path(tmpdir) / ".captured"
-            captured_file.write_text("session-1\n")
-            with mock.patch("memory_utils.get_captured_file") as mock_cf:
-                mock_cf.return_value = captured_file
-                assert remove_captured_session("nonexistent") is False
+    def test_remove_nonexistent(self, tmp_path):
+        captured_file = tmp_path / ".captured"
+        captured_file.write_text("session-1\n")
+        with mock.patch("memory_utils.get_captured_file") as mock_cf:
+            mock_cf.return_value = captured_file
+            assert remove_captured_session("nonexistent") is False
 
 
 # =============================================================================
@@ -289,29 +230,27 @@ class TestGetWorkingDays:
             mock_dd.return_value = Path("/nonexistent/daily")
             assert get_working_days(7) == []
 
-    def test_returns_sorted_descending(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            daily_dir = Path(tmpdir)
-            (daily_dir / "2026-01-01.md").write_text("day 1")
-            (daily_dir / "2026-01-03.md").write_text("day 3")
-            (daily_dir / "2026-01-02.md").write_text("day 2")
+    def test_returns_sorted_descending(self, tmp_path):
+        daily_dir = tmp_path
+        (daily_dir / "2026-01-01.md").write_text("day 1")
+        (daily_dir / "2026-01-03.md").write_text("day 3")
+        (daily_dir / "2026-01-02.md").write_text("day 2")
 
-            with mock.patch("memory_utils.get_daily_dir") as mock_dd:
-                mock_dd.return_value = daily_dir
-                days = get_working_days(10)
-                assert days == ["2026-01-03", "2026-01-02", "2026-01-01"]
+        with mock.patch("memory_utils.get_daily_dir") as mock_dd:
+            mock_dd.return_value = daily_dir
+            days = get_working_days(10)
+            assert days == ["2026-01-03", "2026-01-02", "2026-01-01"]
 
-    def test_respects_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            daily_dir = Path(tmpdir)
-            for i in range(1, 6):
-                (daily_dir / f"2026-01-0{i}.md").write_text(f"day {i}")
+    def test_respects_limit(self, tmp_path):
+        daily_dir = tmp_path
+        for i in range(1, 6):
+            (daily_dir / f"2026-01-0{i}.md").write_text(f"day {i}")
 
-            with mock.patch("memory_utils.get_daily_dir") as mock_dd:
-                mock_dd.return_value = daily_dir
-                days = get_working_days(2)
-                assert len(days) == 2
-                assert days[0] == "2026-01-05"
+        with mock.patch("memory_utils.get_daily_dir") as mock_dd:
+            mock_dd.return_value = daily_dir
+            days = get_working_days(2)
+            assert len(days) == 2
+            assert days[0] == "2026-01-05"
 
 
 # =============================================================================
@@ -498,61 +437,55 @@ class TestFindCurrentProject:
 
 
 class TestFileLock:
-    def test_acquire_and_release(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            lock_path = Path(tmpdir) / "test.lock"
-            lock = FileLock(lock_path, timeout=2.0)
-            assert lock.acquire() is True
+    def test_acquire_and_release(self, tmp_path):
+        lock_path = tmp_path / "test.lock"
+        lock = FileLock(lock_path, timeout=2.0)
+        assert lock.acquire() is True
+        assert lock_path.exists()
+        lock.release()
+        assert not lock_path.exists()
+
+    def test_context_manager(self, tmp_path):
+        lock_path = tmp_path / "test.lock"
+        with FileLock(lock_path, timeout=2.0):
             assert lock_path.exists()
-            lock.release()
-            assert not lock_path.exists()
+        assert not lock_path.exists()
 
-    def test_context_manager(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            lock_path = Path(tmpdir) / "test.lock"
-            with FileLock(lock_path, timeout=2.0):
-                assert lock_path.exists()
-            assert not lock_path.exists()
+    def test_writes_pid(self, tmp_path):
+        lock_path = tmp_path / "test.lock"
+        with FileLock(lock_path, timeout=2.0):
+            pid_file = lock_path / "pid"
+            assert pid_file.exists()
+            assert int(pid_file.read_text().strip()) == os.getpid()
 
-    def test_writes_pid(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            lock_path = Path(tmpdir) / "test.lock"
-            with FileLock(lock_path, timeout=2.0):
-                pid_file = lock_path / "pid"
-                assert pid_file.exists()
-                assert int(pid_file.read_text().strip()) == os.getpid()
+    def test_stale_lock_removed_by_dead_pid(self, tmp_path):
+        lock_path = tmp_path / "test.lock"
+        # Create a stale lock with a dead PID
+        lock_path.mkdir()
+        (lock_path / "pid").write_text("999999999")  # Very unlikely to be a real PID
 
-    def test_stale_lock_removed_by_dead_pid(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            lock_path = Path(tmpdir) / "test.lock"
-            # Create a stale lock with a dead PID
-            lock_path.mkdir()
-            (lock_path / "pid").write_text("999999999")  # Very unlikely to be a real PID
+        lock = FileLock(lock_path, timeout=2.0)
+        assert lock.acquire() is True
+        lock.release()
 
-            lock = FileLock(lock_path, timeout=2.0)
-            assert lock.acquire() is True
-            lock.release()
+    def test_timeout_when_locked(self, tmp_path):
+        lock_path = tmp_path / "test.lock"
+        # Acquire lock
+        lock1 = FileLock(lock_path, timeout=2.0)
+        lock1.acquire()
 
-    def test_timeout_when_locked(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            lock_path = Path(tmpdir) / "test.lock"
-            # Acquire lock
-            lock1 = FileLock(lock_path, timeout=2.0)
-            lock1.acquire()
+        # Second lock should timeout (owner PID is alive — it's us)
+        lock2 = FileLock(lock_path, timeout=0.3, poll_interval=0.1)
+        assert lock2.acquire() is False
 
-            # Second lock should timeout (owner PID is alive — it's us)
-            lock2 = FileLock(lock_path, timeout=0.3, poll_interval=0.1)
-            assert lock2.acquire() is False
+        lock1.release()
 
-            lock1.release()
-
-    def test_double_release_is_safe(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            lock_path = Path(tmpdir) / "test.lock"
-            lock = FileLock(lock_path, timeout=2.0)
-            lock.acquire()
-            lock.release()
-            lock.release()  # Should not raise
+    def test_double_release_is_safe(self, tmp_path):
+        lock_path = tmp_path / "test.lock"
+        lock = FileLock(lock_path, timeout=2.0)
+        lock.acquire()
+        lock.release()
+        lock.release()  # Should not raise
 
 
 # =============================================================================

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -6,19 +6,12 @@ Run with: python -m pytest tests/test_project_manager.py -v
 """
 
 import json
-import os
-import sys
-import tempfile
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
-# Add scripts directory to path
-scripts_dir = Path(__file__).parent.parent / "scripts"
-sys.path.insert(0, str(scripts_dir))
-
-from project_manager import (
+from project_manager import (  # noqa: I001
     backup_files,
     decode_path_best_effort,
     encode_path,
@@ -41,27 +34,15 @@ from project_manager import (
 # =============================================================================
 
 
-class TestEncodePath:
-    """Tests for encode_path function."""
-
-    def test_simple_path(self):
-        assert encode_path("/home/user/project") == "-home-user-project"
-
-    def test_path_with_dots(self):
-        """Dots are also replaced with hyphens."""
-        assert encode_path("/home/user/.config") == "-home-user--config"
-
-    def test_path_with_existing_hyphens(self):
-        """Hyphens in the path are preserved (but this causes ambiguity)."""
-        # Note: This is a known limitation - we can't distinguish
-        # /home/user/my-project from /home/user/my/project after encoding
-        assert encode_path("/home/user/my-project") == "-home-user-my-project"
-
-    def test_empty_path(self):
-        assert encode_path("") == ""
-
-    def test_root_only(self):
-        assert encode_path("/") == "-"
+@pytest.mark.parametrize("path,expected", [
+    ("/home/user/project", "-home-user-project"),
+    ("/home/user/.config", "-home-user--config"),
+    ("/home/user/my-project", "-home-user-my-project"),
+    ("", ""),
+    ("/", "-"),
+])
+def test_encode_path(path, expected):
+    assert encode_path(path) == expected
 
 
 class TestDecodePathBestEffort:
@@ -92,41 +73,38 @@ class TestDecodePathBestEffort:
 class TestGetOriginalPathFromFolder:
     """Tests for get_original_path_from_folder function."""
 
-    def test_with_valid_sessions_index(self):
+    def test_with_valid_sessions_index(self, tmp_path):
         """Should extract originalPath from sessions-index.json."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            folder = Path(tmpdir) / "test-folder"
-            folder.mkdir()
+        folder = tmp_path / "test-folder"
+        folder.mkdir()
 
-            sessions_index = folder / "sessions-index.json"
-            sessions_index.write_text(json.dumps({
-                "originalPath": "/home/user/my-project",
-                "entries": []
-            }))
+        sessions_index = folder / "sessions-index.json"
+        sessions_index.write_text(json.dumps({
+            "originalPath": "/home/user/my-project",
+            "entries": []
+        }))
 
-            result = get_original_path_from_folder(folder)
-            assert result == "/home/user/my-project"
+        result = get_original_path_from_folder(folder)
+        assert result == "/home/user/my-project"
 
-    def test_without_sessions_index(self):
+    def test_without_sessions_index(self, tmp_path):
         """Should return None if no sessions-index.json."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            folder = Path(tmpdir) / "test-folder"
-            folder.mkdir()
+        folder = tmp_path / "test-folder"
+        folder.mkdir()
 
-            result = get_original_path_from_folder(folder)
-            assert result is None
+        result = get_original_path_from_folder(folder)
+        assert result is None
 
-    def test_with_invalid_json(self):
+    def test_with_invalid_json(self, tmp_path):
         """Should return None if sessions-index.json is invalid."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            folder = Path(tmpdir) / "test-folder"
-            folder.mkdir()
+        folder = tmp_path / "test-folder"
+        folder.mkdir()
 
-            sessions_index = folder / "sessions-index.json"
-            sessions_index.write_text("not valid json")
+        sessions_index = folder / "sessions-index.json"
+        sessions_index.write_text("not valid json")
 
-            result = get_original_path_from_folder(folder)
-            assert result is None
+        result = get_original_path_from_folder(folder)
+        assert result is None
 
 
 # =============================================================================
@@ -143,49 +121,44 @@ class TestValidateMove:
         assert not result.valid
         assert any("does not exist" in issue for issue in result.issues)
 
-    def test_source_not_directory(self):
+    def test_source_not_directory(self, tmp_path):
         """Should fail if source is a file, not directory."""
-        with tempfile.NamedTemporaryFile(delete=False) as f:
-            try:
-                result = validate_move(Path(f.name), Path("/tmp/dest"))
-                assert not result.valid
-                assert any("not a directory" in issue for issue in result.issues)
-            finally:
-                os.unlink(f.name)
+        f = tmp_path / "test.txt"
+        f.write_text("content")
+        result = validate_move(f, Path("/tmp/dest"))
+        assert not result.valid
+        assert any("not a directory" in issue for issue in result.issues)
 
-    def test_dest_parent_not_exists(self):
+    def test_dest_parent_not_exists(self, tmp_path):
         """Should fail if destination parent doesn't exist."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            source = Path(tmpdir) / "source"
-            source.mkdir()
+        source = tmp_path / "source"
+        source.mkdir()
 
-            result = validate_move(source, Path("/nonexistent/parent/dest"))
-            assert not result.valid
-            assert any("parent does not exist" in issue for issue in result.issues)
+        result = validate_move(source, Path("/nonexistent/parent/dest"))
+        assert not result.valid
+        assert any("parent does not exist" in issue for issue in result.issues)
 
-    def test_dest_exists_warning(self):
+    def test_dest_exists_warning(self, tmp_path):
         """Should warn (not fail) if destination exists."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            source = Path(tmpdir) / "source"
-            dest = Path(tmpdir) / "dest"
-            source.mkdir()
-            dest.mkdir()
+        source = tmp_path / "source"
+        dest = tmp_path / "dest"
+        source.mkdir()
+        dest.mkdir()
 
-            result = validate_move(source, dest)
-            assert result.valid  # Valid, just has warnings
-            assert any("exists" in w for w in result.warnings)
+        result = validate_move(source, dest)
+        assert result.valid  # Valid, just has warnings
+        assert any("exists" in w for w in result.warnings)
 
-    def test_valid_move(self):
+    def test_valid_move(self, tmp_path):
         """Should pass for valid move scenario."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            source = Path(tmpdir) / "source"
-            dest = Path(tmpdir) / "dest"
-            source.mkdir()
-            # dest doesn't exist, which is fine
+        source = tmp_path / "source"
+        dest = tmp_path / "dest"
+        source.mkdir()
+        # dest doesn't exist, which is fine
 
-            result = validate_move(source, dest)
-            assert result.valid
-            assert len(result.issues) == 0
+        result = validate_move(source, dest)
+        assert result.valid
+        assert len(result.issues) == 0
 
 
 class TestValidateMergeOrphan:
@@ -212,96 +185,68 @@ class TestValidateMergeOrphan:
 class TestPlanMergeOrphan:
     """Tests for plan_merge_orphan function."""
 
-    def test_same_encoded_path_skips_folder_operations(self):
-        """When orphan name equals target encoded path, no moves/merges/renames should be planned."""
-        with tempfile.TemporaryDirectory() as tmp:
-            projects_dir = Path(tmp) / "projects"
-            projects_dir.mkdir()
-            memory_dir = Path(tmp) / "memory"
-            memory_dir.mkdir()
-            claude_dir = Path(tmp) / "claude"
-            claude_dir.mkdir()
+    def _setup_and_plan(self, tmp_path, orphan_name, target_path, setup_fn=None):
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        claude_dir = tmp_path / "claude"
+        claude_dir.mkdir()
+        index_file = memory_dir / "projects-index.json"
+        index_file.write_text('{"projects":{}}')
+        if setup_fn:
+            setup_fn(projects_dir)
+        with mock.patch("project_manager.get_projects_dir", return_value=projects_dir), \
+             mock.patch("project_manager.get_projects_index_file", return_value=index_file), \
+             mock.patch("project_manager.get_claude_dir", return_value=claude_dir), \
+             mock.patch("project_manager.get_project_memory_dir", return_value=memory_dir / "project-memory"):
+            return plan_merge_orphan(orphan_name, target_path)
 
-            # Orphan folder whose name matches the target's encoded path
-            target_path = Path("/home/user/personal/investing")
-            orphan_name = encode_path(str(target_path))  # -home-user-personal-investing
+    def test_same_encoded_path_skips_folder_operations(self, tmp_path):
+        """When orphan name equals target encoded path, no moves/merges/renames should be planned."""
+        target_path = Path("/home/user/personal/investing")
+        orphan_name = encode_path(str(target_path))  # -home-user-personal-investing
+
+        def setup(projects_dir):
             orphan_folder = projects_dir / orphan_name
             orphan_folder.mkdir()
-
             # Create a session file so it's not empty
             (orphan_folder / "abc123.jsonl").write_text('{"type":"test"}\n')
 
-            # Create projects-index.json
-            index_file = memory_dir / "projects-index.json"
-            index_file.write_text('{"projects":{}}')
+        plan = self._setup_and_plan(tmp_path, orphan_name, target_path, setup_fn=setup)
 
-            with mock.patch("project_manager.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("project_manager.get_projects_index_file", return_value=index_file), \
-                 mock.patch("project_manager.get_claude_dir", return_value=claude_dir), \
-                 mock.patch("project_manager.get_project_memory_dir", return_value=memory_dir / "project-memory"):
-                plan = plan_merge_orphan(orphan_name, target_path)
+        assert plan.moves == [], f"Expected no moves, got {plan.moves}"
+        assert plan.merges == [], f"Expected no merges, got {plan.merges}"
+        assert plan.renames == [], f"Expected no renames, got {plan.renames}"
 
-            assert plan.moves == [], f"Expected no moves, got {plan.moves}"
-            assert plan.merges == [], f"Expected no merges, got {plan.merges}"
-            assert plan.renames == [], f"Expected no renames, got {plan.renames}"
-
-    def test_different_encoded_path_plans_move(self):
+    def test_different_encoded_path_plans_move(self, tmp_path):
         """When orphan name differs from target encoded path and target doesn't exist, should plan a move."""
-        with tempfile.TemporaryDirectory() as tmp:
-            projects_dir = Path(tmp) / "projects"
-            projects_dir.mkdir()
-            memory_dir = Path(tmp) / "memory"
-            memory_dir.mkdir()
-            claude_dir = Path(tmp) / "claude"
-            claude_dir.mkdir()
+        orphan_name = "-home-user-old-investing"
+        target_path = Path("/home/user/personal/investing")
 
-            # Orphan with old name, target has different encoded path
-            orphan_name = "-home-user-old-investing"
-            target_path = Path("/home/user/personal/investing")
-            orphan_folder = projects_dir / orphan_name
-            orphan_folder.mkdir()
+        def setup(projects_dir):
+            (projects_dir / orphan_name).mkdir()
 
-            index_file = memory_dir / "projects-index.json"
-            index_file.write_text('{"projects":{}}')
+        plan = self._setup_and_plan(tmp_path, orphan_name, target_path, setup_fn=setup)
 
-            with mock.patch("project_manager.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("project_manager.get_projects_index_file", return_value=index_file), \
-                 mock.patch("project_manager.get_claude_dir", return_value=claude_dir), \
-                 mock.patch("project_manager.get_project_memory_dir", return_value=memory_dir / "project-memory"):
-                plan = plan_merge_orphan(orphan_name, target_path)
+        assert len(plan.moves) == 1, f"Expected 1 move, got {plan.moves}"
+        assert len(plan.renames) == 1, f"Expected 1 rename, got {plan.renames}"
 
-            assert len(plan.moves) == 1, f"Expected 1 move, got {plan.moves}"
-            assert len(plan.renames) == 1, f"Expected 1 rename, got {plan.renames}"
-
-    def test_different_encoded_path_plans_merge_when_target_exists(self):
+    def test_different_encoded_path_plans_merge_when_target_exists(self, tmp_path):
         """When both orphan and target folders exist, should plan a merge + rename."""
-        with tempfile.TemporaryDirectory() as tmp:
-            projects_dir = Path(tmp) / "projects"
-            projects_dir.mkdir()
-            memory_dir = Path(tmp) / "memory"
-            memory_dir.mkdir()
-            claude_dir = Path(tmp) / "claude"
-            claude_dir.mkdir()
+        orphan_name = "-home-user-old-investing"
+        target_path = Path("/home/user/personal/investing")
+        target_encoded = encode_path(str(target_path))
 
-            orphan_name = "-home-user-old-investing"
-            target_path = Path("/home/user/personal/investing")
-            target_encoded = encode_path(str(target_path))
-
+        def setup(projects_dir):
             # Both folders exist
             (projects_dir / orphan_name).mkdir()
             (projects_dir / target_encoded).mkdir()
 
-            index_file = memory_dir / "projects-index.json"
-            index_file.write_text('{"projects":{}}')
+        plan = self._setup_and_plan(tmp_path, orphan_name, target_path, setup_fn=setup)
 
-            with mock.patch("project_manager.get_projects_dir", return_value=projects_dir), \
-                 mock.patch("project_manager.get_projects_index_file", return_value=index_file), \
-                 mock.patch("project_manager.get_claude_dir", return_value=claude_dir), \
-                 mock.patch("project_manager.get_project_memory_dir", return_value=memory_dir / "project-memory"):
-                plan = plan_merge_orphan(orphan_name, target_path)
-
-            assert len(plan.merges) == 1, f"Expected 1 merge, got {plan.merges}"
-            assert len(plan.renames) == 1, f"Expected 1 rename, got {plan.renames}"
+        assert len(plan.merges) == 1, f"Expected 1 merge, got {plan.merges}"
+        assert len(plan.renames) == 1, f"Expected 1 rename, got {plan.renames}"
 
 
 # =============================================================================
@@ -312,106 +257,102 @@ class TestPlanMergeOrphan:
 class TestMergeSessionsIndex:
     """Tests for merge_sessions_index function."""
 
-    def test_merge_disjoint_entries(self):
+    def test_merge_disjoint_entries(self, tmp_path):
         """Two files with different sessions should combine all."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            source = Path(tmpdir) / "source.json"
-            dest = Path(tmpdir) / "dest.json"
+        source = tmp_path / "source.json"
+        dest = tmp_path / "dest.json"
 
-            source.write_text(json.dumps({
-                "originalPath": "/old/path",
-                "entries": [
-                    {"id": "session-1", "created": "2026-01-01T10:00:00Z"},
-                    {"id": "session-2", "created": "2026-01-02T10:00:00Z"},
-                ]
-            }))
+        source.write_text(json.dumps({
+            "originalPath": "/old/path",
+            "entries": [
+                {"id": "session-1", "created": "2026-01-01T10:00:00Z"},
+                {"id": "session-2", "created": "2026-01-02T10:00:00Z"},
+            ]
+        }))
 
-            dest.write_text(json.dumps({
-                "originalPath": "/new/path",
-                "entries": [
-                    {"id": "session-3", "created": "2026-01-03T10:00:00Z"},
-                ]
-            }))
+        dest.write_text(json.dumps({
+            "originalPath": "/new/path",
+            "entries": [
+                {"id": "session-3", "created": "2026-01-03T10:00:00Z"},
+            ]
+        }))
 
-            merged_count = merge_sessions_index(source, dest)
-            assert merged_count == 2
+        merged_count = merge_sessions_index(source, dest)
+        assert merged_count == 2
 
-            result = json.loads(dest.read_text())
-            assert len(result["entries"]) == 3
+        result = json.loads(dest.read_text())
+        assert len(result["entries"]) == 3
 
-    def test_merge_duplicate_sessions_keeps_newer(self):
+    def test_merge_duplicate_sessions_keeps_newer(self, tmp_path):
         """Duplicate session IDs should keep the one with newer timestamp."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            source = Path(tmpdir) / "source.json"
-            dest = Path(tmpdir) / "dest.json"
+        source = tmp_path / "source.json"
+        dest = tmp_path / "dest.json"
 
-            source.write_text(json.dumps({
-                "originalPath": "/old/path",
-                "entries": [
-                    {"id": "session-1", "created": "2026-01-01T10:00:00Z",
-                     "lastActive": "2026-01-01T15:00:00Z"},  # Newer
-                ]
-            }))
+        source.write_text(json.dumps({
+            "originalPath": "/old/path",
+            "entries": [
+                {"id": "session-1", "created": "2026-01-01T10:00:00Z",
+                 "lastActive": "2026-01-01T15:00:00Z"},  # Newer
+            ]
+        }))
 
-            dest.write_text(json.dumps({
-                "originalPath": "/new/path",
-                "entries": [
-                    {"id": "session-1", "created": "2026-01-01T10:00:00Z",
-                     "lastActive": "2026-01-01T12:00:00Z"},  # Older
-                ]
-            }))
+        dest.write_text(json.dumps({
+            "originalPath": "/new/path",
+            "entries": [
+                {"id": "session-1", "created": "2026-01-01T10:00:00Z",
+                 "lastActive": "2026-01-01T12:00:00Z"},  # Older
+            ]
+        }))
 
-            merged_count = merge_sessions_index(source, dest)
-            assert merged_count == 1
+        merged_count = merge_sessions_index(source, dest)
+        assert merged_count == 1
 
-            result = json.loads(dest.read_text())
-            assert len(result["entries"]) == 1
-            assert result["entries"][0]["lastActive"] == "2026-01-01T15:00:00Z"
+        result = json.loads(dest.read_text())
+        assert len(result["entries"]) == 1
+        assert result["entries"][0]["lastActive"] == "2026-01-01T15:00:00Z"
 
-    def test_merge_into_empty(self):
+    def test_merge_into_empty(self, tmp_path):
         """Merging into file with no entries should work."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            source = Path(tmpdir) / "source.json"
-            dest = Path(tmpdir) / "dest.json"
+        source = tmp_path / "source.json"
+        dest = tmp_path / "dest.json"
 
-            source.write_text(json.dumps({
-                "originalPath": "/old/path",
-                "entries": [
-                    {"id": "session-1", "created": "2026-01-01T10:00:00Z"},
-                ]
-            }))
+        source.write_text(json.dumps({
+            "originalPath": "/old/path",
+            "entries": [
+                {"id": "session-1", "created": "2026-01-01T10:00:00Z"},
+            ]
+        }))
 
-            dest.write_text(json.dumps({
-                "originalPath": "/new/path",
-                "entries": []
-            }))
+        dest.write_text(json.dumps({
+            "originalPath": "/new/path",
+            "entries": []
+        }))
 
-            merged_count = merge_sessions_index(source, dest)
-            assert merged_count == 1
+        merged_count = merge_sessions_index(source, dest)
+        assert merged_count == 1
 
-            result = json.loads(dest.read_text())
-            assert len(result["entries"]) == 1
+        result = json.loads(dest.read_text())
+        assert len(result["entries"]) == 1
 
-    def test_merge_empty_source(self):
+    def test_merge_empty_source(self, tmp_path):
         """Merging from empty source should not change dest."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            source = Path(tmpdir) / "source.json"
-            dest = Path(tmpdir) / "dest.json"
+        source = tmp_path / "source.json"
+        dest = tmp_path / "dest.json"
 
-            source.write_text(json.dumps({
-                "originalPath": "/old/path",
-                "entries": []
-            }))
+        source.write_text(json.dumps({
+            "originalPath": "/old/path",
+            "entries": []
+        }))
 
-            dest.write_text(json.dumps({
-                "originalPath": "/new/path",
-                "entries": [
-                    {"id": "session-1", "created": "2026-01-01T10:00:00Z"},
-                ]
-            }))
+        dest.write_text(json.dumps({
+            "originalPath": "/new/path",
+            "entries": [
+                {"id": "session-1", "created": "2026-01-01T10:00:00Z"},
+            ]
+        }))
 
-            merged_count = merge_sessions_index(source, dest)
-            assert merged_count == 0
+        merged_count = merge_sessions_index(source, dest)
+        assert merged_count == 0
 
 
 # =============================================================================
@@ -422,45 +363,39 @@ class TestMergeSessionsIndex:
 class TestRewritePathsInFile:
     """Tests for rewrite_paths_in_file function."""
 
-    def test_simple_replacement(self):
+    def test_simple_replacement(self, tmp_path):
         """Should replace old path with new path."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-            f.write("/home/user/old-project\n")
-            f.write("some other text\n")
-            f.write("/home/user/old-project/subdir\n")
-            f.flush()
+        f = tmp_path / "test.txt"
+        f.write_text(
+            "/home/user/old-project\n"
+            "some other text\n"
+            "/home/user/old-project/subdir\n"
+        )
 
-            try:
-                count = rewrite_paths_in_file(
-                    Path(f.name),
-                    "/home/user/old-project",
-                    "/home/user/new-project"
-                )
+        count = rewrite_paths_in_file(
+            f,
+            "/home/user/old-project",
+            "/home/user/new-project"
+        )
 
-                assert count == 2
+        assert count == 2
 
-                content = Path(f.name).read_text()
-                assert "/home/user/new-project" in content
-                assert "/home/user/new-project/subdir" in content
-                assert "/home/user/old-project" not in content
-            finally:
-                os.unlink(f.name)
+        content = f.read_text()
+        assert "/home/user/new-project" in content
+        assert "/home/user/new-project/subdir" in content
+        assert "/home/user/old-project" not in content
 
-    def test_no_matches(self):
+    def test_no_matches(self, tmp_path):
         """Should return 0 if no matches found."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-            f.write("some text without the path\n")
-            f.flush()
+        f = tmp_path / "test.txt"
+        f.write_text("some text without the path\n")
 
-            try:
-                count = rewrite_paths_in_file(
-                    Path(f.name),
-                    "/nonexistent/path",
-                    "/new/path"
-                )
-                assert count == 0
-            finally:
-                os.unlink(f.name)
+        count = rewrite_paths_in_file(
+            f,
+            "/nonexistent/path",
+            "/new/path"
+        )
+        assert count == 0
 
     def test_nonexistent_file(self):
         """Should return 0 for nonexistent file."""
@@ -480,37 +415,35 @@ class TestRewritePathsInFile:
 class TestBackupFiles:
     """Tests for backup_files function."""
 
-    def test_creates_backup_directory(self):
+    def test_creates_backup_directory(self, tmp_path):
         """Should create timestamped backup directory."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create a test file
-            test_file = Path(tmpdir) / "test.json"
-            test_file.write_text('{"key": "value"}')
+        # Create a test file
+        test_file = tmp_path / "test.json"
+        test_file.write_text('{"key": "value"}')
 
-            # Mock the memory directory
-            with mock.patch("project_manager.get_memory_dir") as mock_mem:
-                mock_mem.return_value = Path(tmpdir) / "memory"
+        # Mock the memory directory
+        with mock.patch("project_manager.get_memory_dir") as mock_mem:
+            mock_mem.return_value = tmp_path / "memory"
 
-                backup_path = backup_files([test_file])
+            backup_path = backup_files([test_file])
 
-                assert backup_path.exists()
-                assert backup_path.is_dir()
-                assert (backup_path / "test.json").exists()
+            assert backup_path.exists()
+            assert backup_path.is_dir()
+            assert (backup_path / "test.json").exists()
 
-    def test_copies_file_contents(self):
+    def test_copies_file_contents(self, tmp_path):
         """Backup should preserve file contents."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            test_file = Path(tmpdir) / "test.json"
-            original_content = '{"important": "data"}'
-            test_file.write_text(original_content)
+        test_file = tmp_path / "test.json"
+        original_content = '{"important": "data"}'
+        test_file.write_text(original_content)
 
-            with mock.patch("project_manager.get_memory_dir") as mock_mem:
-                mock_mem.return_value = Path(tmpdir) / "memory"
+        with mock.patch("project_manager.get_memory_dir") as mock_mem:
+            mock_mem.return_value = tmp_path / "memory"
 
-                backup_path = backup_files([test_file])
-                backed_up = (backup_path / "test.json").read_text()
+            backup_path = backup_files([test_file])
+            backed_up = (backup_path / "test.json").read_text()
 
-                assert backed_up == original_content
+            assert backed_up == original_content
 
 
 class TestRestoreFromBackup:
@@ -522,26 +455,25 @@ class TestRestoreFromBackup:
         assert not result["success"]
         assert "not found" in result["message"]
 
-    def test_restore_projects_index(self):
+    def test_restore_projects_index(self, tmp_path):
         """Should restore projects-index.json to correct location."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create backup directory with a file
-            backup_dir = Path(tmpdir) / "backup"
-            backup_dir.mkdir()
-            (backup_dir / "projects-index.json").write_text('{"restored": true}')
+        # Create backup directory with a file
+        backup_dir = tmp_path / "backup"
+        backup_dir.mkdir()
+        (backup_dir / "projects-index.json").write_text('{"restored": true}')
 
-            # Mock the target location
-            memory_dir = Path(tmpdir) / "memory"
-            memory_dir.mkdir()
+        # Mock the target location
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
 
-            with mock.patch("project_manager.get_projects_index_file") as mock_idx:
-                mock_idx.return_value = memory_dir / "projects-index.json"
+        with mock.patch("project_manager.get_projects_index_file") as mock_idx:
+            mock_idx.return_value = memory_dir / "projects-index.json"
 
-                result = restore_from_backup(backup_dir)
+            result = restore_from_backup(backup_dir)
 
-                assert result["success"]
-                assert len(result["restored"]) == 1
-                assert (memory_dir / "projects-index.json").exists()
+            assert result["success"]
+            assert len(result["restored"]) == 1
+            assert (memory_dir / "projects-index.json").exists()
 
 
 # =============================================================================
@@ -552,54 +484,40 @@ class TestRestoreFromBackup:
 class TestPlanMove:
     """Tests for plan_move function."""
 
-    def test_plan_includes_backup_list(self):
+    def _plan_move(self, tmp_path, old_path, new_path):
+        with mock.patch("project_manager.get_projects_index_file") as mock_idx, \
+             mock.patch("project_manager.get_claude_dir") as mock_claude, \
+             mock.patch("project_manager.get_project_memory_dir") as mock_mem, \
+             mock.patch("project_manager.load_json_file") as mock_load:
+            mock_idx.return_value = tmp_path / "projects-index.json"
+            mock_claude.return_value = tmp_path
+            mock_mem.return_value = tmp_path / "project-memory"
+            mock_load.return_value = {"projects": {}}
+            (tmp_path / "projects-index.json").write_text("{}")
+            return plan_move(old_path, new_path)
+
+    def test_plan_includes_backup_list(self, tmp_path):
         """Plan should list files to backup."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            old_path = Path(tmpdir) / "old"
-            new_path = Path(tmpdir) / "new"
-            old_path.mkdir()
+        old_path = tmp_path / "old"
+        new_path = tmp_path / "new"
+        old_path.mkdir()
 
-            # Create mock index file
-            with mock.patch("project_manager.get_projects_index_file") as mock_idx, \
-                 mock.patch("project_manager.get_claude_dir") as mock_claude, \
-                 mock.patch("project_manager.get_project_memory_dir") as mock_mem, \
-                 mock.patch("project_manager.load_json_file") as mock_load:
+        plan = self._plan_move(tmp_path, old_path, new_path)
 
-                mock_idx.return_value = Path(tmpdir) / "projects-index.json"
-                mock_claude.return_value = Path(tmpdir)
-                mock_mem.return_value = Path(tmpdir) / "project-memory"
-                mock_load.return_value = {"projects": {}}
+        assert plan.operation == "move"
+        assert len(plan.backups) > 0
 
-                # Create the index file so it shows up in backups
-                (Path(tmpdir) / "projects-index.json").write_text("{}")
-
-                plan = plan_move(old_path, new_path)
-
-                assert plan.operation == "move"
-                assert len(plan.backups) > 0
-
-    def test_plan_summary_is_human_readable(self):
+    def test_plan_summary_is_human_readable(self, tmp_path):
         """Plan summary should describe the operation."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            old_path = Path(tmpdir) / "old"
-            new_path = Path(tmpdir) / "new"
-            old_path.mkdir()
+        old_path = tmp_path / "old"
+        new_path = tmp_path / "new"
+        old_path.mkdir()
 
-            with mock.patch("project_manager.get_projects_index_file") as mock_idx, \
-                 mock.patch("project_manager.get_claude_dir") as mock_claude, \
-                 mock.patch("project_manager.get_project_memory_dir") as mock_mem, \
-                 mock.patch("project_manager.load_json_file") as mock_load:
+        plan = self._plan_move(tmp_path, old_path, new_path)
 
-                mock_idx.return_value = Path(tmpdir) / "projects-index.json"
-                mock_claude.return_value = Path(tmpdir)
-                mock_mem.return_value = Path(tmpdir) / "project-memory"
-                mock_load.return_value = {"projects": {}}
-
-                plan = plan_move(old_path, new_path)
-
-                assert "Move project" in plan.summary
-                assert str(old_path) in plan.summary
-                assert str(new_path) in plan.summary
+        assert "Move project" in plan.summary
+        assert str(old_path) in plan.summary
+        assert str(new_path) in plan.summary
 
 
 class TestPlanCleanup:
@@ -660,36 +578,35 @@ class TestListProjects:
             projects = list_projects()
             assert projects == []
 
-    def test_with_valid_project(self):
+    def test_with_valid_project(self, tmp_path):
         """Should return project info for valid projects."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create a real directory
-            project_dir = Path(tmpdir) / "my-project"
-            project_dir.mkdir()
+        # Create a real directory
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
 
-            with mock.patch("project_manager.load_json_file") as mock_load, \
-                 mock.patch("project_manager.get_project_memory_dir") as mock_mem, \
-                 mock.patch("project_manager.get_projects_index_file") as mock_idx:
+        with mock.patch("project_manager.load_json_file") as mock_load, \
+             mock.patch("project_manager.get_project_memory_dir") as mock_mem, \
+             mock.patch("project_manager.get_projects_index_file") as mock_idx:
 
-                mock_load.return_value = {
-                    "projects": {
-                        str(project_dir).lower(): {
-                            "name": "my-project",
-                            "originalPath": str(project_dir),
-                            "workDays": ["2026-01-01"],
-                            "encodedPaths": ["-tmp-my-project"],
-                        }
+            mock_load.return_value = {
+                "projects": {
+                    str(project_dir).lower(): {
+                        "name": "my-project",
+                        "originalPath": str(project_dir),
+                        "workDays": ["2026-01-01"],
+                        "encodedPaths": ["-tmp-my-project"],
                     }
                 }
-                mock_mem.return_value = Path(tmpdir) / "project-memory"
-                mock_idx.return_value = Path(tmpdir) / "index.json"
+            }
+            mock_mem.return_value = tmp_path / "project-memory"
+            mock_idx.return_value = tmp_path / "index.json"
 
-                projects = list_projects()
+            projects = list_projects()
 
-                assert len(projects) == 1
-                assert projects[0].name == "my-project"
-                assert projects[0].exists is True
-                assert len(projects[0].issues) == 0
+            assert len(projects) == 1
+            assert projects[0].name == "my-project"
+            assert projects[0].exists is True
+            assert len(projects[0].issues) == 0
 
     def test_with_missing_path(self):
         """Should mark project with issue if path doesn't exist."""
@@ -726,84 +643,81 @@ class TestListProjects:
 class TestUpdateSessionIndexPaths:
     """Tests for update_session_index_paths function."""
 
-    def test_updates_matching_files(self):
+    def test_updates_matching_files(self, tmp_path):
         """Should update sessions-index.json files containing old path."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            projects_dir.mkdir()
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
 
-            # Create two project folders with sessions-index.json
-            folder1 = projects_dir / "-home-user-old-project"
-            folder1.mkdir()
-            (folder1 / "sessions-index.json").write_text(json.dumps({
-                "originalPath": "/home/user/old-project",
-                "entries": []
-            }))
+        # Create two project folders with sessions-index.json
+        folder1 = projects_dir / "-home-user-old-project"
+        folder1.mkdir()
+        (folder1 / "sessions-index.json").write_text(json.dumps({
+            "originalPath": "/home/user/old-project",
+            "entries": []
+        }))
 
-            folder2 = projects_dir / "-home-user-old-project-sub"
-            folder2.mkdir()
-            (folder2 / "sessions-index.json").write_text(json.dumps({
-                "originalPath": "/home/user/old-project/sub",
-                "entries": []
-            }))
+        folder2 = projects_dir / "-home-user-old-project-sub"
+        folder2.mkdir()
+        (folder2 / "sessions-index.json").write_text(json.dumps({
+            "originalPath": "/home/user/old-project/sub",
+            "entries": []
+        }))
 
-            with mock.patch("project_manager.get_projects_dir") as mock_dir:
-                mock_dir.return_value = projects_dir
+        with mock.patch("project_manager.get_projects_dir") as mock_dir:
+            mock_dir.return_value = projects_dir
 
-                count = update_session_index_paths(
-                    "/home/user/old-project", "/home/user/new-project"
-                )
+            count = update_session_index_paths(
+                "/home/user/old-project", "/home/user/new-project"
+            )
 
-            assert count == 2
+        assert count == 2
 
-            data1 = json.loads((folder1 / "sessions-index.json").read_text())
-            assert data1["originalPath"] == "/home/user/new-project"
+        data1 = json.loads((folder1 / "sessions-index.json").read_text())
+        assert data1["originalPath"] == "/home/user/new-project"
 
-            data2 = json.loads((folder2 / "sessions-index.json").read_text())
-            assert data2["originalPath"] == "/home/user/new-project/sub"
+        data2 = json.loads((folder2 / "sessions-index.json").read_text())
+        assert data2["originalPath"] == "/home/user/new-project/sub"
 
-    def test_skips_non_matching_files(self):
+    def test_skips_non_matching_files(self, tmp_path):
         """Should not modify files that don't contain old path."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            projects_dir.mkdir()
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
 
-            folder = projects_dir / "-home-user-other"
-            folder.mkdir()
-            original = json.dumps({
-                "originalPath": "/home/user/other",
-                "entries": []
-            })
-            (folder / "sessions-index.json").write_text(original)
+        folder = projects_dir / "-home-user-other"
+        folder.mkdir()
+        original = json.dumps({
+            "originalPath": "/home/user/other",
+            "entries": []
+        })
+        (folder / "sessions-index.json").write_text(original)
 
-            with mock.patch("project_manager.get_projects_dir") as mock_dir:
-                mock_dir.return_value = projects_dir
+        with mock.patch("project_manager.get_projects_dir") as mock_dir:
+            mock_dir.return_value = projects_dir
 
-                count = update_session_index_paths(
-                    "/home/user/old-project", "/home/user/new-project"
-                )
+            count = update_session_index_paths(
+                "/home/user/old-project", "/home/user/new-project"
+            )
 
-            assert count == 0
-            assert (folder / "sessions-index.json").read_text() == original
+        assert count == 0
+        assert (folder / "sessions-index.json").read_text() == original
 
-    def test_skips_folders_without_sessions_index(self):
+    def test_skips_folders_without_sessions_index(self, tmp_path):
         """Should skip folders that don't have sessions-index.json."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            projects_dir.mkdir()
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
 
-            folder = projects_dir / "-home-user-old-project"
-            folder.mkdir()
-            # No sessions-index.json created
+        folder = projects_dir / "-home-user-old-project"
+        folder.mkdir()
+        # No sessions-index.json created
 
-            with mock.patch("project_manager.get_projects_dir") as mock_dir:
-                mock_dir.return_value = projects_dir
+        with mock.patch("project_manager.get_projects_dir") as mock_dir:
+            mock_dir.return_value = projects_dir
 
-                count = update_session_index_paths(
-                    "/home/user/old-project", "/home/user/new-project"
-                )
+            count = update_session_index_paths(
+                "/home/user/old-project", "/home/user/new-project"
+            )
 
-            assert count == 0
+        assert count == 0
 
     def test_returns_zero_for_missing_projects_dir(self):
         """Should return 0 if projects directory doesn't exist."""
@@ -823,147 +737,111 @@ class TestUpdateSessionIndexPaths:
 class TestFindOrphanedFolders:
     """Tests for find_orphaned_folders function."""
 
-    def test_tracked_folder_not_orphan(self):
+    def _find_orphans(self, tmp_path, index):
+        projects_dir = tmp_path / "projects"
+        with mock.patch("project_manager.get_projects_dir", return_value=projects_dir), \
+             mock.patch("project_manager.get_projects_index_file", return_value=tmp_path / "index.json"), \
+             mock.patch("project_manager.load_json_file", return_value=index), \
+             mock.patch("project_manager.get_claude_dir", return_value=tmp_path):
+            return find_orphaned_folders()
+
+    def test_tracked_folder_not_orphan(self, tmp_path):
         """Folder in encodedPaths should not be flagged as orphan,
         even if sessions-index.json has stale originalPath."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            projects_dir.mkdir()
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
 
-            # Create a folder with stale originalPath
-            folder = projects_dir / "-home-user-new-project"
-            folder.mkdir()
-            (folder / "sessions-index.json").write_text(json.dumps({
-                "originalPath": "/home/user/old-project",  # Stale!
-                "entries": []
-            }))
+        # Create a folder with stale originalPath
+        folder = projects_dir / "-home-user-new-project"
+        folder.mkdir()
+        (folder / "sessions-index.json").write_text(json.dumps({
+            "originalPath": "/home/user/old-project",  # Stale!
+            "entries": []
+        }))
 
-            index = {
-                "projects": {
-                    "/home/user/new-project": {
-                        "name": "new-project",
-                        "originalPath": "/home/user/new-project",
-                        "encodedPaths": ["-home-user-new-project"],
-                        "workDays": [],
-                    }
+        index = {
+            "projects": {
+                "/home/user/new-project": {
+                    "name": "new-project",
+                    "originalPath": "/home/user/new-project",
+                    "encodedPaths": ["-home-user-new-project"],
+                    "workDays": [],
                 }
             }
+        }
 
-            with mock.patch("project_manager.get_projects_dir") as mock_dir, \
-                 mock.patch("project_manager.get_projects_index_file") as mock_idx, \
-                 mock.patch("project_manager.load_json_file") as mock_load, \
-                 mock.patch("project_manager.get_claude_dir") as mock_claude:
-                mock_dir.return_value = projects_dir
-                mock_idx.return_value = Path(tmpdir) / "index.json"
-                mock_load.return_value = index
-                mock_claude.return_value = Path(tmpdir)
+        orphans = self._find_orphans(tmp_path, index)
+        assert len(orphans) == 0
 
-                orphans = find_orphaned_folders()
-
-            assert len(orphans) == 0
-
-    def test_untracked_folder_with_stale_path_is_orphan(self):
+    def test_untracked_folder_with_stale_path_is_orphan(self, tmp_path):
         """Folder not in encodedPaths with stale originalPath should be orphan."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            projects_dir.mkdir()
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
 
-            folder = projects_dir / "-home-user-old-project"
-            folder.mkdir()
-            (folder / "sessions-index.json").write_text(json.dumps({
-                "originalPath": "/home/user/old-project",  # Path doesn't exist
-                "entries": []
-            }))
+        folder = projects_dir / "-home-user-old-project"
+        folder.mkdir()
+        (folder / "sessions-index.json").write_text(json.dumps({
+            "originalPath": "/home/user/old-project",  # Path doesn't exist
+            "entries": []
+        }))
 
-            index = {"projects": {}}  # Not tracked
+        index = {"projects": {}}  # Not tracked
 
-            with mock.patch("project_manager.get_projects_dir") as mock_dir, \
-                 mock.patch("project_manager.get_projects_index_file") as mock_idx, \
-                 mock.patch("project_manager.load_json_file") as mock_load, \
-                 mock.patch("project_manager.get_claude_dir") as mock_claude:
-                mock_dir.return_value = projects_dir
-                mock_idx.return_value = Path(tmpdir) / "index.json"
-                mock_load.return_value = index
-                mock_claude.return_value = Path(tmpdir)
+        orphans = self._find_orphans(tmp_path, index)
+        assert len(orphans) == 1
+        assert orphans[0].folder_name == "-home-user-old-project"
 
-                orphans = find_orphaned_folders()
-
-            assert len(orphans) == 1
-            assert orphans[0].folder_name == "-home-user-old-project"
-
-    def test_folder_with_valid_path_not_orphan(self):
+    def test_folder_with_valid_path_not_orphan(self, tmp_path):
         """Folder whose originalPath exists on disk should not be orphan."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            projects_dir.mkdir()
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
 
-            # Create the actual project directory so path exists
-            real_project = Path(tmpdir) / "my-project"
-            real_project.mkdir()
+        # Create the actual project directory so path exists
+        real_project = tmp_path / "my-project"
+        real_project.mkdir()
 
-            folder = projects_dir / "-tmp-my-project"
-            folder.mkdir()
-            (folder / "sessions-index.json").write_text(json.dumps({
-                "originalPath": str(real_project),
-                "entries": []
-            }))
+        folder = projects_dir / "-tmp-my-project"
+        folder.mkdir()
+        (folder / "sessions-index.json").write_text(json.dumps({
+            "originalPath": str(real_project),
+            "entries": []
+        }))
 
-            index = {"projects": {}}  # Not tracked, but path exists
+        index = {"projects": {}}  # Not tracked, but path exists
 
-            with mock.patch("project_manager.get_projects_dir") as mock_dir, \
-                 mock.patch("project_manager.get_projects_index_file") as mock_idx, \
-                 mock.patch("project_manager.load_json_file") as mock_load, \
-                 mock.patch("project_manager.get_claude_dir") as mock_claude:
-                mock_dir.return_value = projects_dir
-                mock_idx.return_value = Path(tmpdir) / "index.json"
-                mock_load.return_value = index
-                mock_claude.return_value = Path(tmpdir)
+        orphans = self._find_orphans(tmp_path, index)
+        assert len(orphans) == 0
 
-                orphans = find_orphaned_folders()
-
-            assert len(orphans) == 0
-
-    def test_old_encoded_path_also_tracked(self):
+    def test_old_encoded_path_also_tracked(self, tmp_path):
         """Old encoded path kept in encodedPaths should not be orphan."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            projects_dir = Path(tmpdir) / "projects"
-            projects_dir.mkdir()
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
 
-            # Simulate: folder was renamed from old to new,
-            # but old encoded name kept in encodedPaths for transcript discovery
-            folder = projects_dir / "-home-user-old-name"
-            folder.mkdir()
-            (folder / "sessions-index.json").write_text(json.dumps({
-                "originalPath": "/home/user/old-name",  # Stale
-                "entries": []
-            }))
+        # Simulate: folder was renamed from old to new,
+        # but old encoded name kept in encodedPaths for transcript discovery
+        folder = projects_dir / "-home-user-old-name"
+        folder.mkdir()
+        (folder / "sessions-index.json").write_text(json.dumps({
+            "originalPath": "/home/user/old-name",  # Stale
+            "entries": []
+        }))
 
-            index = {
-                "projects": {
-                    "/home/user/new-name": {
-                        "name": "new-name",
-                        "originalPath": "/home/user/new-name",
-                        "encodedPaths": [
-                            "-home-user-new-name",
-                            "-home-user-old-name",  # Old path kept
-                        ],
-                        "workDays": [],
-                    }
+        index = {
+            "projects": {
+                "/home/user/new-name": {
+                    "name": "new-name",
+                    "originalPath": "/home/user/new-name",
+                    "encodedPaths": [
+                        "-home-user-new-name",
+                        "-home-user-old-name",  # Old path kept
+                    ],
+                    "workDays": [],
                 }
             }
+        }
 
-            with mock.patch("project_manager.get_projects_dir") as mock_dir, \
-                 mock.patch("project_manager.get_projects_index_file") as mock_idx, \
-                 mock.patch("project_manager.load_json_file") as mock_load, \
-                 mock.patch("project_manager.get_claude_dir") as mock_claude:
-                mock_dir.return_value = projects_dir
-                mock_idx.return_value = Path(tmpdir) / "index.json"
-                mock_load.return_value = index
-                mock_claude.return_value = Path(tmpdir)
-
-                orphans = find_orphaned_folders()
-
-            assert len(orphans) == 0
+        orphans = self._find_orphans(tmp_path, index)
+        assert len(orphans) == 0
 
 
 if __name__ == "__main__":

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -1,22 +1,10 @@
 #!/usr/bin/env python3
-"""
-Unit tests for token_usage.py
+"""Unit tests for token_usage.py"""
 
-Run with: python -m pytest tests/test_token_usage.py -v
-"""
-
-import sys
-import tempfile
-from io import StringIO
 from pathlib import Path
 from unittest import mock
 
 import pytest
-
-# Add scripts directory to path
-scripts_dir = Path(__file__).parent.parent / "scripts"
-sys.path.insert(0, str(scripts_dir))
-
 from memory_utils import load_settings
 from token_usage import calculate_usage
 
@@ -41,57 +29,50 @@ EXPECTED_KEYS = [
 ]
 
 
-def _capture_usage(**overrides) -> dict[str, str]:
+def _capture_usage(tmp_path, capsys, **overrides) -> dict[str, str]:
     """Run calculate_usage() capturing stdout, return parsed key=value dict."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        daily_dir = Path(tmpdir) / "daily"
-        daily_dir.mkdir()
-        project_dir = Path(tmpdir) / "project-memory"
-        project_dir.mkdir()
-        global_file = Path(tmpdir) / "global-long-term-memory.md"
+    daily_dir = tmp_path / "daily"
+    daily_dir.mkdir()
+    project_dir = tmp_path / "project-memory"
+    project_dir.mkdir()
+    global_file = tmp_path / "global-long-term-memory.md"
 
-        # Write global memory if requested
-        global_content = overrides.get("global_content", "")
-        if global_content:
-            global_file.write_text(global_content)
+    # Write global memory if requested
+    global_content = overrides.get("global_content", "")
+    if global_content:
+        global_file.write_text(global_content)
 
-        # Write daily files if requested
-        for date, content in overrides.get("daily_files", {}).items():
-            (daily_dir / f"{date}.md").write_text(content)
+    # Write daily files if requested
+    for date, content in overrides.get("daily_files", {}).items():
+        (daily_dir / f"{date}.md").write_text(content)
 
-        # Write project memory if requested
-        project_name = overrides.get("project_name")
-        if project_name:
-            pfile = project_dir / f"{project_name}-long-term-memory.md"
-            pfile.write_text(overrides.get("project_content", "# Project"))
+    # Write project memory if requested
+    project_name = overrides.get("project_name")
+    if project_name:
+        pfile = project_dir / f"{project_name}-long-term-memory.md"
+        pfile.write_text(overrides.get("project_content", "# Project"))
 
-        # Build project index
-        project_index = {"projects": {}}
-        cwd = overrides.get("cwd", "/nonexistent/path")
-        if project_name:
-            project_index["projects"][cwd.lower()] = {
-                "name": project_name,
-                "originalPath": cwd,
-            }
+    # Build project index
+    project_index = {"projects": {}}
+    cwd = overrides.get("cwd", "/nonexistent/path")
+    if project_name:
+        project_index["projects"][cwd.lower()] = {
+            "name": project_name,
+            "originalPath": cwd,
+        }
 
-        with mock.patch("token_usage.get_daily_dir", return_value=daily_dir), \
-             mock.patch("token_usage.get_global_memory_file", return_value=global_file), \
-             mock.patch("token_usage.get_project_memory_dir", return_value=project_dir), \
-             mock.patch("token_usage.get_projects_index_file", return_value=Path(tmpdir) / "index.json"), \
-             mock.patch("token_usage.load_json_file", return_value=project_index), \
-             mock.patch("token_usage.load_settings", return_value=_default_settings()), \
-             mock.patch("os.getcwd", return_value=cwd):
+    with mock.patch("token_usage.get_daily_dir", return_value=daily_dir), \
+         mock.patch("token_usage.get_global_memory_file", return_value=global_file), \
+         mock.patch("token_usage.get_project_memory_dir", return_value=project_dir), \
+         mock.patch("token_usage.get_projects_index_file", return_value=tmp_path / "index.json"), \
+         mock.patch("token_usage.load_json_file", return_value=project_index), \
+         mock.patch("token_usage.load_settings", return_value=_default_settings()), \
+         mock.patch("os.getcwd", return_value=cwd):
 
-            captured = StringIO()
-            old_stdout = sys.stdout
-            sys.stdout = captured
-            try:
-                calculate_usage()
-            finally:
-                sys.stdout = old_stdout
+        calculate_usage()
 
-        output = captured.getvalue()
-        return dict(line.split("=", 1) for line in output.strip().split("\n") if "=" in line)
+    captured = capsys.readouterr()
+    return dict(line.split("=", 1) for line in captured.out.strip().split("\n") if "=" in line)
 
 
 def _default_settings() -> dict:
@@ -107,21 +88,21 @@ def _default_settings() -> dict:
 
 
 class TestCalculateUsage:
-    def test_output_format(self):
+    def test_output_format(self, tmp_path, capsys):
         """Output is key=value lines, one per metric."""
-        result = _capture_usage()
+        result = _capture_usage(tmp_path, capsys)
         # Every line should be key=value
         assert len(result) == len(EXPECTED_KEYS)
 
-    def test_all_metrics_present(self):
+    def test_all_metrics_present(self, tmp_path, capsys):
         """All expected metric keys are in the output."""
-        result = _capture_usage()
+        result = _capture_usage(tmp_path, capsys)
         for key in EXPECTED_KEYS:
             assert key in result, f"Missing key: {key}"
 
-    def test_handles_no_project(self):
+    def test_handles_no_project(self, tmp_path, capsys):
         """When CWD doesn't match any project, project_name=none."""
-        result = _capture_usage(cwd="/nonexistent/path")
+        result = _capture_usage(tmp_path, capsys, cwd="/nonexistent/path")
         assert result["project_name"] == "none"
         assert result["project_long_term_tokens"] == "0"
         assert result["project_short_term_tokens"] == "0"

--- a/tests/test_transcript_ops.py
+++ b/tests/test_transcript_ops.py
@@ -5,20 +5,11 @@ Unit tests for transcript_ops.py
 Run with: python -m pytest tests/test_transcript_ops.py -v
 """
 
-import json
-import sys
-import tempfile
 from datetime import datetime, timezone
-from pathlib import Path
 from unittest import mock
 
 import pytest
-
-# Add scripts directory to path
-scripts_dir = Path(__file__).parent.parent / "scripts"
-sys.path.insert(0, str(scripts_dir))
-
-from indexing import SessionInfo
+from helpers import make_jsonl_content, make_session_info  # noqa: I001
 from transcript_ops import (
     extract_transcripts,
     format_transcripts_for_output,
@@ -26,68 +17,32 @@ from transcript_ops import (
 )
 
 # =============================================================================
-# Helpers
-# =============================================================================
-
-
-def make_session_info(
-    session_id: str = "test-session",
-    transcript_path: Path = Path("/tmp/test.jsonl"),
-    file_size: int = 2000,
-    project_path: str | None = None,
-    created: datetime | None = None,
-    file_mtime: datetime | None = None,
-) -> SessionInfo:
-    return SessionInfo(
-        session_id=session_id,
-        transcript_path=transcript_path,
-        project_hash="test-hash",
-        file_mtime=file_mtime or datetime.now(timezone.utc),
-        file_size=file_size,
-        project_path=project_path,
-        created=created,
-    )
-
-
-def make_jsonl_content(messages: list[tuple[str, str]]) -> str:
-    """Create JSONL content from (role, text) pairs."""
-    lines = []
-    for role, text in messages:
-        lines.append(json.dumps({
-            "type": role,
-            "message": {"role": role, "content": text},
-        }))
-    return "\n".join(lines) + "\n"
-
-
-# =============================================================================
 # extract_transcripts Tests
 # =============================================================================
 
 
 class TestExtractTranscripts:
-    def test_extracts_specific_day(self):
+    def test_extracts_specific_day(self, tmp_path):
         """Filters to only the requested day."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create a transcript file with assistant content
-            transcript = Path(tmpdir) / "session.jsonl"
-            transcript.write_text(make_jsonl_content([
-                ("assistant", "I found the bug in the code"),
-            ]))
+        # Create a transcript file with assistant content
+        transcript = tmp_path / "session.jsonl"
+        transcript.write_text(make_jsonl_content([
+            ("assistant", "I found the bug in the code"),
+        ]))
 
-            session = make_session_info(
-                session_id="s1",
-                transcript_path=transcript,
-                created=datetime(2026, 2, 5, 12, 0, tzinfo=timezone.utc),
-            )
+        session = make_session_info(
+            session_id="s1",
+            transcript_path=transcript,
+            created=datetime(2026, 2, 5, 12, 0, tzinfo=timezone.utc),
+        )
 
-            with mock.patch("transcript_ops.get_captured_sessions", return_value=set()), \
-                 mock.patch("transcript_ops.list_pending_sessions", return_value=[session]), \
-                 mock.patch("transcript_ops.get_session_date", return_value="2026-02-05"):
-                result = extract_transcripts(specific_day="2026-02-05")
-                assert "2026-02-05" in result
-                assert len(result["2026-02-05"]) == 1
-                assert result["2026-02-05"][0]["session_id"] == "s1"
+        with mock.patch("transcript_ops.get_captured_sessions", return_value=set()), \
+             mock.patch("transcript_ops.list_pending_sessions", return_value=[session]), \
+             mock.patch("transcript_ops.get_session_date", return_value="2026-02-05"):
+            result = extract_transcripts(specific_day="2026-02-05")
+            assert "2026-02-05" in result
+            assert len(result["2026-02-05"]) == 1
+            assert result["2026-02-05"][0]["session_id"] == "s1"
 
     def test_excludes_non_matching_day(self):
         """Sessions from other days are excluded when specific_day is set."""
@@ -150,7 +105,7 @@ class TestGetPendingDays:
 
 
 class TestFormatWithLineBudget:
-    def _make_daily_data(self, num_messages: int, content_lines: int = 1) -> dict:
+    def _make_daily_data(self, num_messages, content_lines=1):
         """Create daily_data with one session containing N messages."""
         msg_content = "\n".join(f"Line {i}" for i in range(content_lines))
         messages = [


### PR DESCRIPTION
## Summary
- Add `conftest.py` + `helpers.py` to centralize path setup and shared test factories, eliminating duplicated boilerplate across 8 test files
- Replace all `tempfile.TemporaryDirectory`/`NamedTemporaryFile` with pytest `tmp_path`, manual stdout capture with `capsys`, and repeated mock setups with class helper methods
- Convert simple input/output test methods to `@pytest.mark.parametrize` and update CLAUDE.md test conventions

Net result: -517 lines, 263 tests pass (up from 255 due to parametrize expansion).

## Test plan
- [x] `python3 -m pytest tests/ -v` — 263 passed
- [x] No `tempfile`, `NamedTemporaryFile`, `os.unlink`, or `sys.path.insert` remaining in test files
- [x] No `from conftest import` (uses `from helpers import` instead)
- [x] Ruff lint clean on all files

Co-Authored-By: Claude <noreply@anthropic.com>