### PR TITLE
refactor: deduplicate sessions-index.json parsing (#7)

### DIFF
--- a/scripts/indexing.py
+++ b/scripts/indexing.py
@@ -52,6 +52,8 @@ from memory_utils import (
     get_memory_dir,
     get_projects_dir,
     get_projects_index_file,
+    get_sessions_original_path,
+    load_sessions_index,
     remove_captured_session,
     to_iso_z,
 )
@@ -118,36 +120,22 @@ def _load_sessions_index(project_folder: Path) -> dict:
 
     Returns dict mapping session_id to entry metadata, or empty dict if missing.
     """
-    index_file = project_folder / "sessions-index.json"
-    if not index_file.exists():
+    data = load_sessions_index(project_folder)
+    if not data:
         return {}
 
-    try:
-        with open(index_file, "r", encoding="utf-8") as f:
-            data = json.load(f)
+    original_path = get_sessions_original_path(data)
+    index = {}
+    for entry in data.get("entries", []):
+        session_id = entry.get("sessionId")
+        if session_id:
+            index[session_id] = {
+                "created": entry.get("created"),
+                "summary": entry.get("summary"),
+                "projectPath": original_path,
+            }
 
-        # Build lookup by sessionId
-        index = {}
-        entries = data.get("entries", [])
-
-        # Get original path (try root-level first, then entries[0].projectPath)
-        original_path = data.get("originalPath", "")
-        if not original_path and entries:
-            original_path = entries[0].get("projectPath", "")
-
-        for entry in entries:
-            session_id = entry.get("sessionId")
-            if session_id:
-                index[session_id] = {
-                    "created": entry.get("created"),
-                    "summary": entry.get("summary"),
-                    "projectPath": original_path,
-                }
-
-        return index
-
-    except (json.JSONDecodeError, IOError):
-        return {}
+    return index
 
 
 def list_all_sessions() -> list[SessionInfo]:
@@ -355,23 +343,12 @@ def build_projects_index() -> dict:
         original_path = ""
         work_days: set[str] = set()
 
-        sessions_file = project_folder / "sessions-index.json"
-        if sessions_file.exists():
-            try:
-                with open(sessions_file, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-            except (json.JSONDecodeError, IOError) as e:
-                print(f"Warning: Could not read {sessions_file}: {e}", file=sys.stderr)
-                data = {}
-
-            # Get original path: try root-level first, then entries[0].projectPath
-            original_path = data.get("originalPath", "")
-            entries = data.get("entries", [])
-            if not original_path and entries:
-                original_path = entries[0].get("projectPath", "")
+        data = load_sessions_index(project_folder)
+        if data:
+            original_path = get_sessions_original_path(data)
 
             # Extract work days from session entries
-            for entry in entries:
+            for entry in data.get("entries", []):
                 created = entry.get("created")
                 if created:
                     try:

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -44,6 +44,8 @@ LOCK_STALE_SECONDS = 300  # 5 minutes — locks older than this are considered s
 # Utilities:
 #   estimate_tokens(text) -> int          FileLock(path, timeout?, poll?)
 #   load_json_file(path, default?) -> Any  save_json_file(path, data) -> bool
+# Sessions index:
+#   load_sessions_index(folder) -> dict    get_sessions_original_path(data) -> str
 # =============================================================================
 
 
@@ -382,6 +384,32 @@ def save_json_file(filepath: Path, data: Any, indent: int = 2) -> bool:
     except IOError as e:
         print(f"Error: Could not save {filepath}: {e}", file=sys.stderr)
         return False
+
+
+def load_sessions_index(folder_path: Path) -> dict:
+    """
+    Load and parse sessions-index.json from a Claude Code project folder.
+
+    Returns the parsed JSON dict, or empty dict if missing/invalid.
+    """
+    return load_json_file(folder_path / "sessions-index.json", default={})
+
+
+def get_sessions_original_path(data: dict) -> str:
+    """
+    Extract the original project path from parsed sessions-index data.
+
+    Tries root-level 'originalPath' first (legacy/manual format),
+    falls back to entries[0].projectPath (Claude Code's actual format).
+
+    Returns empty string if not found.
+    """
+    original_path = data.get("originalPath", "")
+    if not original_path:
+        entries = data.get("entries", [])
+        if entries:
+            original_path = entries[0].get("projectPath", "")
+    return original_path
 
 
 def project_name_to_filename(project_name: str) -> str:

--- a/scripts/project_manager.py
+++ b/scripts/project_manager.py
@@ -36,7 +36,9 @@ from memory_utils import (
     get_project_memory_dir,
     get_projects_dir,
     get_projects_index_file,
+    get_sessions_original_path,
     load_json_file,
+    load_sessions_index,
     project_name_to_filename,
     save_json_file,
     to_iso_z,
@@ -161,20 +163,8 @@ def get_original_path_from_folder(folder_path: Path) -> Optional[str]:
 
     This is the only reliable way to get the original path since encoding is lossy.
     """
-    sessions_index = folder_path / "sessions-index.json"
-    if sessions_index.exists():
-        try:
-            data = json.loads(sessions_index.read_text(encoding="utf-8"))
-            # Try root-level originalPath first (legacy format)
-            if data.get("originalPath"):
-                return data.get("originalPath")
-            # Fall back to entries[0].projectPath (Claude Code format)
-            entries = data.get("entries", [])
-            if entries and entries[0].get("projectPath"):
-                return entries[0]["projectPath"]
-        except (json.JSONDecodeError, IOError):
-            pass
-    return None
+    data = load_sessions_index(folder_path)
+    return get_sessions_original_path(data) or None
 
 
 # =============================================================================

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -21,9 +21,11 @@ from memory_utils import (
     find_current_project,
     from_iso_z,
     get_captured_sessions,
+    get_sessions_original_path,
     get_working_days,
     is_routed_match,
     load_json_file,
+    load_sessions_index,
     load_settings,
     project_name_to_filename,
     remove_captured_session,
@@ -695,6 +697,87 @@ class TestCollectLtmFiles:
         assert "foo-long-term-memory.md" in filenames
         assert "bar-long-term-memory.md" in filenames
         assert "notes.md" not in filenames
+
+
+# =============================================================================
+# Sessions Index Tests
+# =============================================================================
+
+
+class TestLoadSessionsIndex:
+    """Tests for load_sessions_index function."""
+
+    def test_valid_file(self, tmp_path):
+        """Should return parsed dict from sessions-index.json."""
+        folder = tmp_path / "project"
+        folder.mkdir()
+        (folder / "sessions-index.json").write_text(json.dumps({
+            "originalPath": "/home/user/proj",
+            "entries": [{"sessionId": "abc"}],
+        }))
+        result = load_sessions_index(folder)
+        assert result["originalPath"] == "/home/user/proj"
+        assert len(result["entries"]) == 1
+
+    def test_missing_file(self, tmp_path):
+        """Should return empty dict when file doesn't exist."""
+        folder = tmp_path / "project"
+        folder.mkdir()
+        result = load_sessions_index(folder)
+        assert result == {}
+
+    def test_invalid_json(self, tmp_path):
+        """Should return empty dict on malformed JSON."""
+        folder = tmp_path / "project"
+        folder.mkdir()
+        (folder / "sessions-index.json").write_text("not json{{{")
+        result = load_sessions_index(folder)
+        assert result == {}
+
+    def test_empty_file(self, tmp_path):
+        """Should return empty dict on empty file."""
+        folder = tmp_path / "project"
+        folder.mkdir()
+        (folder / "sessions-index.json").write_text("")
+        result = load_sessions_index(folder)
+        assert result == {}
+
+
+class TestGetSessionsOriginalPath:
+    """Tests for get_sessions_original_path function."""
+
+    def test_root_level_original_path(self):
+        """Should prefer root-level originalPath."""
+        data = {
+            "originalPath": "/home/user/proj",
+            "entries": [{"projectPath": "/other/path"}],
+        }
+        assert get_sessions_original_path(data) == "/home/user/proj"
+
+    def test_fallback_to_entries(self):
+        """Should fall back to entries[0].projectPath."""
+        data = {
+            "entries": [{"projectPath": "/home/user/proj", "sessionId": "abc"}],
+        }
+        assert get_sessions_original_path(data) == "/home/user/proj"
+
+    def test_empty_original_path_falls_back(self):
+        """Should fall back when originalPath is empty string."""
+        data = {
+            "originalPath": "",
+            "entries": [{"projectPath": "/fallback"}],
+        }
+        assert get_sessions_original_path(data) == "/fallback"
+
+    def test_no_path_anywhere(self):
+        """Should return empty string when no path found."""
+        assert get_sessions_original_path({}) == ""
+        assert get_sessions_original_path({"entries": []}) == ""
+
+    def test_empty_entries(self):
+        """Should return empty string with no originalPath and empty entries."""
+        data = {"originalPath": "", "entries": []}
+        assert get_sessions_original_path(data) == ""
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Extract `load_sessions_index()` and `get_sessions_original_path()` into `memory_utils.py` as shared helpers
- Update 3 callers (`indexing.py:_load_sessions_index`, `indexing.py:build_projects_index`, `project_manager.py:get_original_path_from_folder`) to use shared helpers instead of inline parsing
- Add 9 unit tests for the new helpers; 325 tests pass

## Test plan
- [x] All 325 existing + new tests pass (`pytest tests/ -v`)
- [x] ruff checks pass on all modified files

Closes #7

Co-Authored-By: Claude <noreply@anthropic.com>