### PR TITLE
refactor: split _build_synthesis_prompt into smaller functions (#9)

### DIFF
--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -207,36 +207,20 @@ def load_project_history(
     return summaries, total_bytes
 
 
-def _build_synthesis_prompt(
-    exclude_flag: str,
-    pending_dates: list[str],
-    extracted_files: dict[str, str] | None = None,
-) -> str:
-    """
-    Build the embedded synthesis prompt for the subagent.
-
-    Two modes:
-    - Pre-extracted (manual /synthesize): files already on disk, skip extraction
-    - Dates-only (auto-synthesis): subagent extracts each date
-
-    Args:
-        exclude_flag: The --exclude-session flag string (or empty)
-        pending_dates: List of pending date strings (YYYY-MM-DD)
-        extracted_files: Optional dict mapping date -> file path (pre-extracted)
-    """
-    dates_str = ", ".join(pending_dates)
-
-    # Load valid project names from index for scope tagging
+def _get_project_names_str() -> str:
+    """Load registered project names from index, formatted for prompt insertion."""
     projects_index = load_json_file(get_projects_index_file(), {})
     project_names = sorted({
         data.get("name", "")
         for data in projects_index.get("projects", {}).values()
         if data.get("name")
     })
-    project_names_str = ", ".join(f"`{n}`" for n in project_names) if project_names else "(none registered)"
+    return ", ".join(f"`{n}`" for n in project_names) if project_names else "(none registered)"
 
-    # Common synthesis instructions (shared by both paths)
-    synthesis_instructions = '''**Daily summary** — Write to `~/.claude/memory/daily/YYYY-MM-DD.md`:
+
+def _build_synthesis_instructions(project_names_str: str) -> str:
+    """Build the shared synthesis instructions block (tagging, routing, dedup, batching)."""
+    return '''**Daily summary** — Write to `~/.claude/memory/daily/YYYY-MM-DD.md`:
 
 ALWAYS use a single **Write** call per daily file — even if the file already exists.
 If an earlier version exists (from Step 1 Read), merge its content into your output, then Write the complete file.
@@ -292,34 +276,41 @@ Create missing project files from template at `~/.claude/memory/templates/projec
 Do NOT make separate Edit calls per learning — batch them into a single Edit per file.
 Example: old_string ends with section header + comment, new_string = same header + comment + all new entries appended.'''
 
-    if extracted_files:
-        # Pre-extracted path: files already on disk
-        # Count lines per file for Read limit hints
-        file_metadata: list[tuple[str, str, int]] = []
-        for date, path in sorted(extracted_files.items()):
-            try:
-                line_count = Path(path).read_text(encoding="utf-8").count("\n") + 1
-            except IOError:
-                line_count = 2000
-            file_metadata.append((date, path, line_count))
 
-        file_list = "\n".join(
-            f"- **{date}**: `{path}` ({lines} lines)"
-            for date, path, lines in file_metadata
-        )
-        read_transcript_lines = "\n".join(
-            f"- Read(`{path}`, limit={lines + 100}) — transcript for {date}"
-            for date, path, lines in file_metadata
-        )
-        read_daily_lines = "\n".join(
-            f"- Read(`~/.claude/memory/daily/{d}.md`) — may not exist, Read error is expected"
-            for d in pending_dates
-        )
-        mark_captured_lines = "\n".join(
-            f'python3 $HOME/.claude/scripts/indexing.py mark-captured --sidecar {path.rsplit(".", 1)[0]}.sessions && rm {path} {path.rsplit(".", 1)[0]}.sessions &&'
-            for date, path in sorted(extracted_files.items())
-        )
-        return f'''Process pre-extracted memory transcripts into daily summaries and route key learnings to long-term memory.
+def _build_preextracted_prompt(
+    pending_dates: list[str],
+    extracted_files: dict[str, str],
+    synthesis_instructions: str,
+) -> str:
+    """Build synthesis prompt for pre-extracted mode (manual /synthesize)."""
+    dates_str = ", ".join(pending_dates)
+
+    # Count lines per file for Read limit hints
+    file_metadata: list[tuple[str, str, int]] = []
+    for date, path in sorted(extracted_files.items()):
+        try:
+            line_count = Path(path).read_text(encoding="utf-8").count("\n") + 1
+        except IOError:
+            line_count = 2000
+        file_metadata.append((date, path, line_count))
+
+    file_list = "\n".join(
+        f"- **{date}**: `{path}` ({lines} lines)"
+        for date, path, lines in file_metadata
+    )
+    read_transcript_lines = "\n".join(
+        f"- Read(`{path}`, limit={lines + 100}) — transcript for {date}"
+        for date, path, lines in file_metadata
+    )
+    read_daily_lines = "\n".join(
+        f"- Read(`~/.claude/memory/daily/{d}.md`) — may not exist, Read error is expected"
+        for d in pending_dates
+    )
+    mark_captured_lines = "\n".join(
+        f'python3 $HOME/.claude/scripts/indexing.py mark-captured --sidecar {path.rsplit(".", 1)[0]}.sessions && rm {path} {path.rsplit(".", 1)[0]}.sessions &&'
+        for date, path in sorted(extracted_files.items())
+    )
+    return f'''Process pre-extracted memory transcripts into daily summaries and route key learnings to long-term memory.
 
 **CRITICAL: Process all dates in a single pass. If a tool call fails, handle the error and continue. Do NOT restart the synthesis process from the beginning.**
 
@@ -370,9 +361,17 @@ python3 $HOME/.claude/scripts/devtools.py mark-routed && python3 $HOME/.claude/s
 ```
 
 Return a summary: "Processed N days. Created/updated daily summaries for [dates]. Routed X items to long-term memory (list them). Archived Y old items."'''
-    else:
-        # Dates-only path: subagent must extract
-        return f'''Process pending memory transcripts into daily summaries and route key learnings to long-term memory.
+
+
+def _build_autoextract_prompt(
+    exclude_flag: str,
+    pending_dates: list[str],
+    synthesis_instructions: str,
+) -> str:
+    """Build synthesis prompt for auto-extract mode (auto-synthesis)."""
+    dates_str = ", ".join(pending_dates)
+
+    return f'''Process pending memory transcripts into daily summaries and route key learnings to long-term memory.
 
 **CRITICAL: Process all dates in a single pass. If a tool call fails, handle the error and continue. Do NOT restart the synthesis process from the beginning.**
 
@@ -422,6 +421,32 @@ python3 $HOME/.claude/scripts/indexing.py mark-captured --sidecar /tmp/memory-ex
 ```
 
 Return a summary: "Processed N days. Created/updated daily summaries for [dates]. Routed X items to long-term memory (list them). Archived Y old items."'''
+
+
+def _build_synthesis_prompt(
+    exclude_flag: str,
+    pending_dates: list[str],
+    extracted_files: dict[str, str] | None = None,
+) -> str:
+    """
+    Build the embedded synthesis prompt for the subagent.
+
+    Two modes:
+    - Pre-extracted (manual /synthesize): files already on disk, skip extraction
+    - Dates-only (auto-synthesis): subagent extracts each date
+
+    Args:
+        exclude_flag: The --exclude-session flag string (or empty)
+        pending_dates: List of pending date strings (YYYY-MM-DD)
+        extracted_files: Optional dict mapping date -> file path (pre-extracted)
+    """
+    project_names_str = _get_project_names_str()
+    synthesis_instructions = _build_synthesis_instructions(project_names_str)
+
+    if extracted_files:
+        return _build_preextracted_prompt(pending_dates, extracted_files, synthesis_instructions)
+    else:
+        return _build_autoextract_prompt(exclude_flag, pending_dates, synthesis_instructions)
 
 
 def pre_extract_transcripts(

--- a/tests/test_load_memory.py
+++ b/tests/test_load_memory.py
@@ -10,9 +10,12 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
-from load_memory import (  # noqa: I001
+from load_memory import (
+    _build_autoextract_prompt,
+    _build_preextracted_prompt,
+    _build_synthesis_instructions,
     _build_synthesis_prompt,
+    _get_project_names_str,
     load_daily_summaries,
     load_global_memory,
     load_project_history,
@@ -405,6 +408,202 @@ class TestSynthesisPromptRoutedMarker:
         """Step 3 bash command should run mark-routed after synthesis."""
         prompt = _build_synthesis_prompt("", ["2026-02-01"])
         assert "devtools.py mark-routed" in prompt
+
+
+# =============================================================================
+# _get_project_names_str Tests
+# =============================================================================
+
+
+class TestGetProjectNamesStr:
+    def test_returns_formatted_names(self):
+        index = {"projects": {
+            "/path/a": {"name": "alpha"},
+            "/path/b": {"name": "beta"},
+        }}
+        with mock.patch("load_memory.load_json_file", return_value=index):
+            result = _get_project_names_str()
+        assert "`alpha`" in result
+        assert "`beta`" in result
+        # Sorted order
+        assert result.index("`alpha`") < result.index("`beta`")
+
+    def test_returns_none_registered_when_empty(self):
+        with mock.patch("load_memory.load_json_file", return_value={}):
+            result = _get_project_names_str()
+        assert result == "(none registered)"
+
+    def test_deduplicates_names(self):
+        index = {"projects": {
+            "/path/a": {"name": "same"},
+            "/path/b": {"name": "same"},
+        }}
+        with mock.patch("load_memory.load_json_file", return_value=index):
+            result = _get_project_names_str()
+        assert result.count("`same`") == 1
+
+    def test_skips_entries_without_name(self):
+        index = {"projects": {
+            "/path/a": {"name": "valid"},
+            "/path/b": {},
+            "/path/c": {"name": ""},
+        }}
+        with mock.patch("load_memory.load_json_file", return_value=index):
+            result = _get_project_names_str()
+        assert "`valid`" in result
+        assert result.count("`") == 2  # only `valid`
+
+
+# =============================================================================
+# _build_synthesis_instructions Tests
+# =============================================================================
+
+
+class TestBuildSynthesisInstructions:
+    def test_contains_tag_format(self):
+        instructions = _build_synthesis_instructions("`alpha`, `beta`")
+        assert "[scope/type]" in instructions
+        assert "`alpha`, `beta`" in instructions
+
+    def test_contains_routing_rules(self):
+        instructions = _build_synthesis_instructions("(none registered)")
+        assert "Long-term routing" in instructions
+        assert "DEDUP REQUIREMENT" in instructions
+        assert "GRANULARITY CAP" in instructions
+
+    def test_contains_batching_requirement(self):
+        instructions = _build_synthesis_instructions("`proj`")
+        assert "CRITICAL batching requirement" in instructions
+
+    def test_contains_daily_summary_template(self):
+        instructions = _build_synthesis_instructions("`proj`")
+        assert "## Actions" in instructions
+        assert "## Decisions" in instructions
+        assert "## Learnings" in instructions
+        assert "## Lessons" in instructions
+
+
+# =============================================================================
+# _build_preextracted_prompt Tests
+# =============================================================================
+
+
+class TestBuildPreextractedPrompt:
+    def test_contains_file_references(self, tmp_path):
+        transcript = tmp_path / "extract-2026-02-01.txt"
+        transcript.write_text("line1\nline2\nline3\n")
+
+        prompt = _build_preextracted_prompt(
+            ["2026-02-01"],
+            {"2026-02-01": str(transcript)},
+            "SYNTHESIS_INSTRUCTIONS_PLACEHOLDER",
+        )
+        assert str(transcript) in prompt
+        assert "4 lines" in prompt  # 3 newlines + 1
+
+    def test_contains_synthesis_instructions(self, tmp_path):
+        transcript = tmp_path / "extract.txt"
+        transcript.write_text("content\n")
+
+        prompt = _build_preextracted_prompt(
+            ["2026-02-01"],
+            {"2026-02-01": str(transcript)},
+            "MY_CUSTOM_INSTRUCTIONS",
+        )
+        assert "MY_CUSTOM_INSTRUCTIONS" in prompt
+
+    def test_contains_mark_captured_commands(self, tmp_path):
+        transcript = tmp_path / "extract-2026-02-01.txt"
+        transcript.write_text("content\n")
+
+        prompt = _build_preextracted_prompt(
+            ["2026-02-01"],
+            {"2026-02-01": str(transcript)},
+            "instructions",
+        )
+        assert "mark-captured --sidecar" in prompt
+
+    def test_contains_read_instructions_for_all_dates(self, tmp_path):
+        f1 = tmp_path / "extract-01.txt"
+        f2 = tmp_path / "extract-02.txt"
+        f1.write_text("a\n")
+        f2.write_text("b\n")
+
+        prompt = _build_preextracted_prompt(
+            ["2026-02-01", "2026-02-02"],
+            {"2026-02-01": str(f1), "2026-02-02": str(f2)},
+            "instructions",
+        )
+        assert "2026-02-01" in prompt
+        assert "2026-02-02" in prompt
+        assert "Read(`~/.claude/memory/daily/2026-02-01.md`)" in prompt
+        assert "Read(`~/.claude/memory/daily/2026-02-02.md`)" in prompt
+
+    def test_handles_unreadable_file(self, tmp_path):
+        """Falls back to 2000 line count when file is unreadable."""
+        prompt = _build_preextracted_prompt(
+            ["2026-02-01"],
+            {"2026-02-01": "/nonexistent/file.txt"},
+            "instructions",
+        )
+        assert "2000 lines" in prompt
+
+
+# =============================================================================
+# _build_autoextract_prompt Tests
+# =============================================================================
+
+
+class TestBuildAutoextractPrompt:
+    def test_contains_extract_command(self):
+        prompt = _build_autoextract_prompt(" --exclude-session abc", ["2026-02-01"], "instructions")
+        assert "indexing.py extract" in prompt
+        assert "--exclude-session abc" in prompt
+
+    def test_contains_synthesis_instructions(self):
+        prompt = _build_autoextract_prompt("", ["2026-02-01"], "MY_INSTRUCTIONS")
+        assert "MY_INSTRUCTIONS" in prompt
+
+    def test_contains_all_dates(self):
+        prompt = _build_autoextract_prompt("", ["2026-02-01", "2026-02-02"], "instructions")
+        assert "2026-02-01, 2026-02-02" in prompt
+
+    def test_contains_mark_captured_and_cleanup(self):
+        prompt = _build_autoextract_prompt("", ["2026-02-01"], "instructions")
+        assert "mark-captured --sidecar" in prompt
+        assert "devtools.py mark-routed" in prompt
+        assert "decay.py" in prompt
+
+
+# =============================================================================
+# _build_synthesis_prompt integration Tests
+# =============================================================================
+
+
+class TestBuildSynthesisPromptIntegration:
+    """Test the orchestrator dispatches correctly to sub-functions."""
+
+    def test_autoextract_path(self):
+        """Without extracted_files, returns autoextract prompt."""
+        prompt = _build_synthesis_prompt("", ["2026-02-01"])
+        assert "indexing.py extract" in prompt
+        assert "Pre-extracted transcript files" not in prompt
+
+    def test_preextracted_path(self, tmp_path):
+        """With extracted_files, returns preextracted prompt."""
+        transcript = tmp_path / "extract.txt"
+        transcript.write_text("content\n")
+
+        prompt = _build_synthesis_prompt(
+            "", ["2026-02-01"],
+            extracted_files={"2026-02-01": str(transcript)},
+        )
+        assert "Pre-extracted transcript files" in prompt
+        assert "indexing.py extract YYYY-MM-DD" not in prompt
+
+    def test_exclude_flag_passed_to_autoextract(self):
+        prompt = _build_synthesis_prompt(" --exclude-session xyz", ["2026-02-01"])
+        assert "--exclude-session xyz" in prompt
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Extract 215-line `_build_synthesis_prompt` into 5 focused functions: `_get_project_names_str`, `_build_synthesis_instructions`, `_build_preextracted_prompt`, `_build_autoextract_prompt`, and a 4-line orchestrator
- Add 20 new tests for the extracted functions (28 → 48 in test_load_memory.py)
- No behavioral changes — pure refactor for maintainability

Closes #9

## Test plan
- [x] All 345 existing tests pass
- [x] 20 new tests cover each extracted function (project names, instructions, both prompt modes, orchestrator dispatch)
- [x] Ruff lint clean

Co-Authored-By: Claude <noreply@anthropic.com>