### PR TITLE
fix: prevent duplicate synthesis when multiple sessions start simultaneously

### DIFF
--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -531,6 +531,12 @@ def main() -> None:
     # Exclude current session — it's still active and shouldn't be synthesized
     pending_dates = get_pending_days(exclude_session_id=current_session_id)
     if pending_dates and should_synthesize(settings):
+        # Write timestamp eagerly to prevent duplicate synthesis when multiple
+        # sessions start simultaneously (all would see stale timestamp otherwise)
+        get_last_synthesis_file().write_text(
+            datetime.now(timezone.utc).isoformat(), encoding="utf-8"
+        )
+
         synthesis_model = settings.get("synthesis", {}).get("model", "sonnet")
         synthesis_background = settings.get("synthesis", {}).get("background", True)
 

--- a/tests/test_load_memory.py
+++ b/tests/test_load_memory.py
@@ -104,6 +104,27 @@ class TestShouldSynthesize:
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
             assert should_synthesize(self._make_settings(interval_hours=4)) is False
 
+    def test_eager_timestamp_prevents_concurrent_synthesis(self, tmp_path):
+        """Second caller sees eager timestamp and skips synthesis (race condition fix)."""
+        ts_file = tmp_path / ".last-synthesis"
+        fixed_now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        with mock.patch("load_memory.get_last_synthesis_file") as mock_f, \
+             mock.patch("load_memory.datetime") as mock_dt:
+            mock_f.return_value = ts_file
+            mock_dt.now.return_value = fixed_now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+
+            # First caller: no file exists, should synthesize
+            assert should_synthesize(self._make_settings()) is True
+
+            # Simulate eager write (what main() now does after should_synthesize returns True)
+            ts_file.write_text(fixed_now.isoformat())
+
+            # Second caller moments later: sees fresh timestamp, should NOT synthesize
+            assert should_synthesize(self._make_settings()) is False
+
 
 # =============================================================================
 # load_global_memory Tests


### PR DESCRIPTION
## Summary
- Write `.last-synthesis` timestamp eagerly at decision time (before launching subagent), not at the end of the subagent run
- Prevents race condition where multiple concurrent sessions all see a stale timestamp and each launch their own synthesis agent
- Added test validating that a second caller sees the fresh timestamp and skips synthesis

## Test plan
- [x] All 346 tests pass
- [x] New test `test_eager_timestamp_prevents_concurrent_synthesis` validates the fix
- [x] Subagent still writes timestamp at end of run (harmless refresh)

Co-Authored-By: Claude <noreply@anthropic.com>