### PR TITLE
fix(synthesize): pass prompt file path to subagent instead of contents

### DIFF
--- a/skills/synthesize/SKILL.md
+++ b/skills/synthesize/SKILL.md
@@ -18,14 +18,14 @@ Launch a subagent to process memory transcripts into daily summaries and selecti
    ```
    - If output says "No pending transcripts", inform the user and stop.
    - First line: `model=<model>`. Second line: `prompt_file=<path>`.
-   - Read the prompt file to get the subagent prompt.
 
-2. Launch a synthesis subagent (**foreground** — manual `/synthesize` always blocks so user sees results):
+2. Launch a synthesis subagent (**foreground** — manual `/synthesize` always blocks so user sees results).
+   **IMPORTANT:** Do NOT read the prompt file. Pass the file path to the subagent and let it read the file itself. This avoids the main agent regenerating ~50K tokens of prompt content.
    ```
    Task(
      subagent_type: "general-purpose",
      model: <model from first line>,
-     prompt: <contents of prompt_file>
+     prompt: "Read <prompt_file path> and follow the instructions in it exactly. Use only Write and Bash tools."
    )
    ```
 


### PR DESCRIPTION
## Summary
- The synthesis skill previously instructed the main agent to read the ~1,567-line prompt file and copy its contents into the Task tool call parameter
- This caused a 6+ minute stall as the main agent regenerated ~50K tokens of prompt content verbatim
- Now the subagent reads the prompt file itself, reducing main agent output to ~50 tokens

## Test plan
- [x] 451 unit tests pass
- [ ] Manual test: run `/synthesize` and verify subagent reads prompt file and produces output

Co-Authored-By: Claude <noreply@anthropic.com>