### PR TITLE
fix(dates): use local timezone for daily file date boundaries

### DIFF
--- a/scripts/decay.py
+++ b/scripts/decay.py
@@ -16,7 +16,7 @@ Requirements: Python 3.9+
 import argparse
 import re
 import sys
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 # Add scripts directory to path for local imports
@@ -32,6 +32,7 @@ from memory_utils import (
     get_projects_index_file,
     load_json_file,
     load_settings,
+    local_today,
     project_name_to_filename,
 )
 
@@ -184,7 +185,7 @@ def decay_file(
 
     content = filepath.read_text(encoding="utf-8")
     sections = parse_sections(content)
-    today = datetime.now(timezone.utc).date()
+    today = local_today()
 
     archived_learnings = []
     modified_sections = []
@@ -250,7 +251,7 @@ def append_to_archive(learnings: list[str], dry_run: bool = False) -> None:
         return
 
     archive_file = get_memory_dir() / ".decay-archive.md"
-    today_header = f"## Archived {datetime.now(timezone.utc).date().isoformat()}"
+    today_header = f"## Archived {local_today().isoformat()}"
 
     if dry_run:
         return
@@ -298,7 +299,7 @@ def purge_old_archives(retention_days: int, dry_run: bool = False) -> int:
         return 0
 
     content = archive_file.read_text(encoding="utf-8")
-    today = datetime.now(timezone.utc).date()
+    today = local_today()
     cutoff_date = today - timedelta(days=retention_days)
 
     # Parse archive sections

--- a/scripts/devtools.py
+++ b/scripts/devtools.py
@@ -17,7 +17,7 @@ import filecmp
 import re
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 REPO_DIR = Path(__file__).parent.parent.resolve()
@@ -172,7 +172,7 @@ def cmd_memory_status(args: argparse.Namespace) -> int:
 def cmd_extract_debug(args: argparse.Namespace) -> int:
     """Debug transcript extraction for a specific day."""
     do_all = args.mode == "all"
-    day = args.day or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    day = args.day or datetime.now().strftime("%Y-%m-%d")
 
     sys.path.insert(0, str(REPO_DIR / "scripts"))
     from indexing import get_session_date, list_all_sessions

--- a/scripts/indexing.py
+++ b/scripts/indexing.py
@@ -42,6 +42,7 @@ from memory_utils import (
     load_sessions_index,
     resolve_worktree_to_main_repo,
     to_iso_z,
+    utc_to_local_datestr,
 )
 
 # Sessions smaller than this are likely empty/metadata-only (2-3 messages ~ 1000 bytes)
@@ -268,8 +269,8 @@ def get_session_date(session: SessionInfo) -> str:
     Prefers index.created if available, falls back to file_mtime.
     """
     if session.created:
-        return session.created.strftime("%Y-%m-%d")
-    return session.file_mtime.strftime("%Y-%m-%d")
+        return utc_to_local_datestr(session.created)
+    return utc_to_local_datestr(session.file_mtime)
 
 
 # =============================================================================
@@ -305,7 +306,7 @@ def _extract_from_jsonl(folder: Path) -> tuple[str, set[str]]:
                 timestamp = data.get("timestamp", "")
                 if timestamp:
                     dt = from_iso_z(timestamp)
-                    work_days.add(dt.strftime("%Y-%m-%d"))
+                    work_days.add(utc_to_local_datestr(dt))
         except (json.JSONDecodeError, IOError, ValueError):
             continue
 
@@ -362,7 +363,7 @@ def build_projects_index() -> dict:
                 if created:
                     try:
                         dt = from_iso_z(created)
-                        work_days.add(dt.strftime("%Y-%m-%d"))
+                        work_days.add(utc_to_local_datestr(dt))
                     except ValueError:
                         continue
 

--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -107,8 +107,8 @@ def should_synthesize(settings: dict) -> bool:
         now = datetime.now(timezone.utc)
         hours_since = (now - last_time).total_seconds() / 3600
 
-        # First session of day (UTC) OR >interval since last
-        return last_time.date() < now.date() or hours_since > interval_hours
+        # First session of day (local time) OR >interval since last
+        return last_time.astimezone().date() < datetime.now().date() or hours_since > interval_hours
 
     except (ValueError, OSError, IOError):
         return True  # Fallback: always synthesize if file missing/invalid

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -14,7 +14,7 @@ import re
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +27,8 @@ __all__ = [
     # Version check
     "check_python_version",
     # Datetime
+    "local_today",
+    "utc_to_local_datestr",
     "to_iso_z",
     "from_iso_z",
     # Path helpers
@@ -97,6 +99,16 @@ LOCK_STALE_SECONDS = 300  # 5 minutes — locks older than this are considered s
 # Sessions index:
 #   load_sessions_index(folder) -> dict    get_sessions_original_path(data) -> str
 # =============================================================================
+
+
+def local_today() -> date:
+    """Get today's date in local timezone."""
+    return datetime.now().date()
+
+
+def utc_to_local_datestr(dt: datetime) -> str:
+    """Convert a UTC-aware datetime to a local-timezone date string (YYYY-MM-DD)."""
+    return dt.astimezone().strftime("%Y-%m-%d")
 
 
 def to_iso_z(dt: datetime) -> str:

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -250,8 +250,8 @@ class TestGetSessionDate:
 
     def test_falls_back_to_mtime(self):
         session = make_session_info(created=None)
-        # mtime is set to now in the helper
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        # mtime is set to now in the helper; get_session_date converts to local tz
+        today = datetime.now().strftime("%Y-%m-%d")
         assert get_session_date(session) == today
 
 

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -29,6 +29,7 @@ from memory_utils import (
     load_sessions_index,
     load_settings,
     load_synthesis_state,
+    local_today,
     project_name_to_filename,
     prune_stale_state_entries,
     resolve_worktree_to_main_repo,
@@ -36,6 +37,7 @@ from memory_utils import (
     save_synthesis_state,
     to_iso_z,
     update_synthesis_state,
+    utc_to_local_datestr,
 )
 
 # =============================================================================
@@ -643,6 +645,42 @@ class TestRoutedMatching:
 # =============================================================================
 # ISO Datetime Helper Tests
 # =============================================================================
+
+
+class TestLocalTimezoneHelpers:
+    def test_local_today_returns_date(self):
+        from datetime import date
+        result = local_today()
+        assert isinstance(result, date)
+        # Should match datetime.now().date()
+        assert result == datetime.now().date()
+
+    def test_utc_to_local_datestr_format(self):
+        dt = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        result = utc_to_local_datestr(dt)
+        # Should be YYYY-MM-DD format
+        assert len(result) == 10
+        assert result[4] == "-"
+        assert result[7] == "-"
+
+    def test_utc_to_local_datestr_late_night_utc(self):
+        """A late-night UTC time should map to local date, not UTC date."""
+        # 11:30 PM UTC on Feb 24 = 5:30 PM CT on Feb 24 (CT = UTC-6)
+        # But 5:00 AM UTC on Feb 24 = 11:00 PM CT on Feb 23
+        dt = datetime(2026, 2, 24, 5, 0, 0, tzinfo=timezone.utc)
+        result = utc_to_local_datestr(dt)
+        # Result depends on system timezone, but should be a valid date
+        assert len(result) == 10
+        # The key invariant: result should match what astimezone() gives
+        expected = dt.astimezone().strftime("%Y-%m-%d")
+        assert result == expected
+
+    def test_utc_to_local_datestr_noon_utc(self):
+        """Midday UTC should produce a valid local date string."""
+        dt = datetime(2026, 7, 4, 12, 0, 0, tzinfo=timezone.utc)
+        result = utc_to_local_datestr(dt)
+        expected = dt.astimezone().strftime("%Y-%m-%d")
+        assert result == expected
 
 
 class TestIsoDatetimeHelpers:


### PR DESCRIPTION
## Summary
- Adds `local_today()` and `utc_to_local_datestr()` helpers to `memory_utils.py`
- Switches all date-boundary logic (session dates, work days, decay, synthesis scheduling, devtools) from UTC to local timezone
- UTC stays for storage/serialization (ISO Z strings, `.last-synthesis` timestamps, interval deltas)

## Test plan
- [x] All 500 tests pass (`python3 -m pytest tests/ -q`)
- [x] Verified with `TZ=America/Chicago` that UTC 5AM Feb 24 maps to local Feb 23 (CT = UTC-6)
- [x] Updated `TestGetSessionDate.test_falls_back_to_mtime` to compare local date
- [x] Added `TestLocalTimezoneHelpers` with 4 tests for new helpers

Co-Authored-By: Claude <noreply@anthropic.com>