### PR TITLE
fix: compute synthesis offsets at apply time (#24)

### DIFF
--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -394,10 +394,6 @@ Output ONLY entries from new/continued sessions — do not re-state anything bel
     # (using $$ would expand in Bash but stay literal in Write, causing a mismatch)
     output_filename = f"/tmp/synthesis-output-{os.getpid()}.txt"
 
-    # Build --offsets-json arg for incremental synthesis state update
-    offsets_path = embedded_files.get("offsets_path", "")
-    offsets_arg = f" --offsets-json {offsets_path}" if offsets_path else ""
-
     first_date = sorted(pending_dates)[0]
 
     return f'''You are a structured data extractor. Your job is to read session transcripts and produce ONLY delimited structured output — no prose, no commentary, no summary.
@@ -434,7 +430,7 @@ Every output starts with ===DAILY:YYYY-MM-DD=== and ends with ===END===. Nothing
 Only use the Write and Bash tools — no other tools.
 
 1. Write(`{output_filename}`, <your structured output>)
-2. Bash: `python3 $HOME/.claude/scripts/synthesis.py apply {output_filename} --extracts {extracts_arg}{offsets_arg}`
+2. Bash: `python3 $HOME/.claude/scripts/synthesis.py apply {output_filename} --extracts {extracts_arg}`
 
 ## Synthesis Instructions
 
@@ -645,11 +641,6 @@ def write_synthesis_prompt(exclude_session_id: str | None = None) -> None:
         extracted_files, include_dailies=include_dailies, daily_data=daily_data
     )
 
-    if session_offsets:
-        offsets_path = f"/tmp/synthesis-offsets-{os.getpid()}.json"
-        Path(offsets_path).write_text(json.dumps(session_offsets), encoding="utf-8")
-        embedded["offsets_path"] = offsets_path
-
     prompt = _build_synthesis_prompt(list(extracted_files.keys()), extracted_files, embedded)
 
     # Write prompt to temp file instead of stdout (avoids 30K Bash truncation)
@@ -723,12 +714,6 @@ def main() -> None:
             embedded = _build_embedded_files(
                 extracted_files, include_dailies=include_dailies, daily_data=daily_data
             )
-
-            # Write session offsets to temp file for synthesis.py state update
-            if session_offsets:
-                offsets_path = f"/tmp/synthesis-offsets-{os.getpid()}.json"
-                Path(offsets_path).write_text(json.dumps(session_offsets), encoding="utf-8")
-                embedded["offsets_path"] = offsets_path
 
             synth_prompt = _build_synthesis_prompt(
                 list(extracted_files.keys()), extracted_files, embedded

--- a/scripts/synthesis.py
+++ b/scripts/synthesis.py
@@ -33,6 +33,7 @@ from memory_utils import (  # noqa: E402
     get_global_memory_file,
     get_memory_dir,
     get_project_memory_dir,
+    get_projects_dir,
     is_routed_match,
     prune_stale_state_entries,
     update_synthesis_state,
@@ -53,6 +54,7 @@ __all__ = [
     "write_daily_files",
     "append_to_ltm",
     "apply_results",
+    "compute_offsets_from_extracts",
     "run_mark_routed",
     "run_validate_ltm",
     "run_decay",
@@ -663,6 +665,67 @@ def run_post_processing(
     ts_file.write_text(datetime.now(timezone.utc).isoformat(), encoding="utf-8")
 
 
+_SESSION_HEADER_RE = re.compile(r"^Session:\s+(\S+)")
+
+
+def _count_nonblank_lines(filepath: Path) -> int:
+    """Count non-blank lines in a file."""
+    count = 0
+    with open(filepath, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                count += 1
+    return count
+
+
+def compute_offsets_from_extracts(extract_paths: list[str]) -> dict[str, dict]:
+    """Compute session offsets from extract files and JSONL sources on disk.
+
+    Parses session IDs from extract file headers, locates the corresponding
+    JSONL transcript files in ~/.claude/projects/, and computes current file
+    size and line count.
+
+    This eliminates the dependency on --offsets-json being passed via CLI,
+    which required the LLM to faithfully reproduce the argument.
+
+    Returns:
+        Dict mapping session_id -> {"offset": file_size, "lines": line_count}
+    """
+    # Parse session IDs from extract files
+    session_ids: set[str] = set()
+    for path in extract_paths:
+        try:
+            for line in Path(path).open(encoding="utf-8"):
+                match = _SESSION_HEADER_RE.match(line)
+                if match:
+                    session_ids.add(match.group(1))
+        except IOError:
+            continue
+
+    if not session_ids:
+        return {}
+
+    # Find JSONL files and compute offsets
+    projects_dir = get_projects_dir()
+    if not projects_dir.exists():
+        return {}
+
+    offsets: dict[str, dict] = {}
+    for sid in session_ids:
+        for proj_dir in projects_dir.iterdir():
+            if not proj_dir.is_dir():
+                continue
+            session_file = proj_dir / f"{sid}.jsonl"
+            if session_file.exists():
+                offsets[sid] = {
+                    "offset": session_file.stat().st_size,
+                    "lines": _count_nonblank_lines(session_file),
+                }
+                break
+
+    return offsets
+
+
 def apply_results(
     output_file: str,
     extract_paths: list[str],
@@ -700,11 +763,17 @@ def apply_results(
 
     # Update synthesis state with new high water marks
     if offsets_json:
+        # Legacy path: offsets passed via --offsets-json CLI arg
         try:
             offsets = json.loads(Path(offsets_json).read_text(encoding="utf-8"))
             update_synthesis_state(offsets)
         except (IOError, json.JSONDecodeError) as e:
             print(f"Warning: Could not update synthesis state: {e}", file=sys.stderr)
+    else:
+        # Primary path: compute offsets directly from extract files and JSONL sources
+        offsets = compute_offsets_from_extracts(extract_paths)
+        if offsets:
+            update_synthesis_state(offsets)
 
     # Post-processing
     run_post_processing(extract_paths, offsets_json=offsets_json)

--- a/tests/test_load_memory.py
+++ b/tests/test_load_memory.py
@@ -1105,21 +1105,8 @@ class TestPromptMergeContext:
 class TestIncrementalWiring:
     """Verify incremental extraction is wired into the prompt."""
 
-    def test_offsets_arg_in_prompt_when_offsets_present(self):
-        """When offsets_path is in embedded_files, apply command includes --offsets-json."""
-        prompt = _build_preextracted_prompt(
-            pending_dates=["2026-02-22"],
-            extracted_files={"2026-02-22": "/tmp/dummy.txt"},
-            synthesis_instructions="INSTRUCTIONS",
-            embedded_files={
-                "transcripts": {"2026-02-22": "data"},
-                "offsets_path": "/tmp/synthesis-offsets-123.json",
-            },
-        )
-        assert "--offsets-json /tmp/synthesis-offsets-123.json" in prompt
-
-    def test_no_offsets_arg_when_no_offsets(self):
-        """Without offsets_path, apply command has no --offsets-json."""
+    def test_no_offsets_arg_in_prompt(self):
+        """Prompt command never includes --offsets-json (offsets computed at apply time)."""
         prompt = _build_preextracted_prompt(
             pending_dates=["2026-02-22"],
             extracted_files={"2026-02-22": "/tmp/dummy.txt"},
@@ -1129,6 +1116,7 @@ class TestIncrementalWiring:
             },
         )
         assert "--offsets-json" not in prompt
+        assert "synthesis.py apply" in prompt
 
 
 # =============================================================================
@@ -1206,8 +1194,8 @@ class TestSynthesisPromptFileOutput:
 
         assert "No pending transcripts with content." in captured.getvalue()
 
-    def test_offsets_file_written_when_session_offsets(self, tmp_path, monkeypatch):
-        """Session offsets are written to a temp JSON file and embedded in the prompt args."""
+    def test_no_offsets_file_written(self, tmp_path, monkeypatch):
+        """Offsets are no longer written to temp files (computed at apply time instead)."""
         monkeypatch.setattr("load_memory.get_recent_days", lambda **kw: ["2026-02-23"])
         monkeypatch.setattr(
             "load_memory.pre_extract_transcripts_incremental",
@@ -1217,15 +1205,13 @@ class TestSynthesisPromptFileOutput:
                 {"2026-02-23": [{"session_id": "sid1", "project_path": "/test", "messages": ["hi"]}]},
             ),
         )
-        # Capture what's passed to _build_embedded_files
+        # Capture what's passed to _build_synthesis_prompt
         captured_embedded = {}
 
         def mock_build_embedded(*a, **kw):
-            result = {"transcripts": {"2026-02-23": "test"}, "global_ltm": "", "project_ltms": {}}
-            return result
+            return {"transcripts": {"2026-02-23": "test"}, "global_ltm": "", "project_ltms": {}}
 
         def mock_build_prompt(*a, **kw):
-            # Capture the embedded arg passed to _build_synthesis_prompt
             if len(a) >= 3:
                 captured_embedded.update(a[2] or {})
             elif "embedded_files" in kw:
@@ -1243,12 +1229,8 @@ class TestSynthesisPromptFileOutput:
 
         write_synthesis_prompt(exclude_session_id=None)
 
-        # Verify offsets_path was added to embedded files
-        assert "offsets_path" in captured_embedded
-        offsets_file = Path(captured_embedded["offsets_path"])
-        assert offsets_file.exists()
-        offsets_data = json.loads(offsets_file.read_text())
-        assert offsets_data["sid1"]["offset"] == 200
+        # offsets_path should NOT be in embedded files (computed at apply time now)
+        assert "offsets_path" not in captured_embedded
 
 
 # =============================================================================

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -877,7 +877,211 @@ class TestApplyResults:
 
 
 # =============================================================================
-# apply_results --offsets-json Tests
+# compute_offsets_from_extracts Tests
+# =============================================================================
+
+
+class TestComputeOffsetsFromExtracts:
+    """Test computing session offsets directly from extract files and JSONL sources."""
+
+    def test_finds_sessions_and_computes_offsets(self, tmp_path):
+        """Parses session IDs from extract headers, finds JSONL files, returns offsets."""
+        from synthesis import compute_offsets_from_extracts
+
+        # Create a fake extract file with session headers
+        extract = tmp_path / "extract-2026-02-22.txt"
+        extract.write_text(
+            "======\n"
+            "DAY: 2026-02-22\n"
+            "======\n"
+            "──────\n"
+            "Session: abc-123 [project: myproject]\n"
+            "──────\n"
+            "[CLAUDE]\nDid some work\n"
+        )
+
+        # Create a fake JSONL file for that session
+        projects_dir = tmp_path / "projects"
+        proj_dir = projects_dir / "encoded-path"
+        proj_dir.mkdir(parents=True)
+        jsonl = proj_dir / "abc-123.jsonl"
+        jsonl.write_text('{"type":"user","message":{"role":"user","content":"hi"}}\n'
+                         '{"type":"assistant","message":{"role":"assistant","content":"hello"}}\n'
+                         '\n'  # blank line (should not count)
+                         '{"type":"assistant","message":{"role":"assistant","content":"done"}}\n')
+
+        with patch("synthesis.get_projects_dir", return_value=projects_dir):
+            offsets = compute_offsets_from_extracts([str(extract)])
+
+        assert "abc-123" in offsets
+        assert offsets["abc-123"]["offset"] == jsonl.stat().st_size
+        assert offsets["abc-123"]["lines"] == 3  # 3 non-blank lines
+
+    def test_multiple_sessions_across_extracts(self, tmp_path):
+        """Handles multiple sessions across multiple extract files."""
+        from synthesis import compute_offsets_from_extracts
+
+        extract1 = tmp_path / "e1.txt"
+        extract1.write_text("Session: sess-1 [project: p1]\n[CLAUDE]\nstuff\n")
+
+        extract2 = tmp_path / "e2.txt"
+        extract2.write_text("Session: sess-2 [project: p2]\n[CLAUDE]\nmore\n")
+
+        projects_dir = tmp_path / "projects"
+        p1 = projects_dir / "p1"
+        p1.mkdir(parents=True)
+        p1_jsonl = p1 / "sess-1.jsonl"
+        p1_jsonl.write_text('{"type":"user"}\n{"type":"assistant"}\n')
+
+        p2 = projects_dir / "p2"
+        p2.mkdir(parents=True)
+        p2_jsonl = p2 / "sess-2.jsonl"
+        p2_jsonl.write_text('{"type":"user"}\n')
+
+        with patch("synthesis.get_projects_dir", return_value=projects_dir):
+            offsets = compute_offsets_from_extracts([str(extract1), str(extract2)])
+
+        assert len(offsets) == 2
+        assert offsets["sess-1"]["lines"] == 2
+        assert offsets["sess-2"]["lines"] == 1
+
+    def test_empty_extracts_returns_empty(self, tmp_path):
+        """No extract paths returns empty dict."""
+        from synthesis import compute_offsets_from_extracts
+
+        with patch("synthesis.get_projects_dir", return_value=tmp_path):
+            assert compute_offsets_from_extracts([]) == {}
+
+    def test_session_not_found_on_disk_skipped(self, tmp_path):
+        """Session ID in extract but no matching JSONL returns empty for that session."""
+        from synthesis import compute_offsets_from_extracts
+
+        extract = tmp_path / "extract.txt"
+        extract.write_text("Session: ghost-session [project: x]\n[CLAUDE]\ntext\n")
+
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
+        (projects_dir / "somedir").mkdir()  # No JSONL inside
+
+        with patch("synthesis.get_projects_dir", return_value=projects_dir):
+            offsets = compute_offsets_from_extracts([str(extract)])
+
+        assert offsets == {}
+
+    def test_missing_extract_file_skipped(self, tmp_path):
+        """Missing extract file path is silently skipped."""
+        from synthesis import compute_offsets_from_extracts
+
+        with patch("synthesis.get_projects_dir", return_value=tmp_path):
+            offsets = compute_offsets_from_extracts(["/nonexistent/file.txt"])
+
+        assert offsets == {}
+
+
+# =============================================================================
+# apply_results offset computation Tests
+# =============================================================================
+
+
+class TestApplyResultsComputesOffsets:
+    """Test that apply_results computes offsets from extracts when --offsets-json not passed."""
+
+    def test_computes_offsets_when_no_offsets_json(self, tmp_path):
+        """apply_results calls compute_offsets_from_extracts and updates state."""
+        daily_dir = tmp_path / "daily"
+        daily_dir.mkdir()
+
+        output_text = """===DAILY:2026-02-22===
+# 2026-02-22
+## Learnings
+- [global/pattern] Something
+
+===END==="""
+
+        output_file = tmp_path / "output.txt"
+        output_file.write_text(output_text)
+
+        computed = {"s1": {"offset": 5000, "lines": 50}}
+
+        with patch("synthesis.get_daily_dir", return_value=daily_dir), \
+             patch("synthesis.get_global_memory_file", return_value=tmp_path / "g.md"), \
+             patch("synthesis.get_project_memory_dir", return_value=tmp_path / "pm"), \
+             patch("synthesis.get_memory_dir", return_value=tmp_path), \
+             patch("synthesis.run_post_processing"), \
+             patch("synthesis.compute_offsets_from_extracts", return_value=computed) as mock_compute, \
+             patch("synthesis.update_synthesis_state") as mock_update:
+            apply_results(
+                output_file=str(output_file),
+                extract_paths=["/tmp/e1.txt"],
+            )
+
+        mock_compute.assert_called_once_with(["/tmp/e1.txt"])
+        mock_update.assert_called_once_with(computed)
+
+    def test_skips_state_update_when_no_offsets_computed(self, tmp_path):
+        """No offsets computed (empty extracts) means no state update."""
+        daily_dir = tmp_path / "daily"
+        daily_dir.mkdir()
+
+        output_text = """===DAILY:2026-02-22===
+# 2026-02-22
+## Actions
+- [global/implement] Something
+
+===END==="""
+
+        output_file = tmp_path / "output.txt"
+        output_file.write_text(output_text)
+
+        with patch("synthesis.get_daily_dir", return_value=daily_dir), \
+             patch("synthesis.get_global_memory_file", return_value=tmp_path / "g.md"), \
+             patch("synthesis.get_project_memory_dir", return_value=tmp_path / "pm"), \
+             patch("synthesis.get_memory_dir", return_value=tmp_path), \
+             patch("synthesis.run_post_processing"), \
+             patch("synthesis.compute_offsets_from_extracts", return_value={}), \
+             patch("synthesis.update_synthesis_state") as mock_update:
+            apply_results(output_file=str(output_file), extract_paths=[])
+
+        mock_update.assert_not_called()
+
+    def test_offsets_json_overrides_computed(self, tmp_path):
+        """Explicit --offsets-json takes precedence over computed offsets."""
+        daily_dir = tmp_path / "daily"
+        daily_dir.mkdir()
+
+        output_text = """===DAILY:2026-02-22===
+# 2026-02-22
+## Actions
+- [global/implement] Something
+
+===END==="""
+
+        output_file = tmp_path / "output.txt"
+        output_file.write_text(output_text)
+
+        cli_offsets = tmp_path / "offsets.json"
+        cli_offsets.write_text('{"s1": {"offset": 9999, "lines": 99}}')
+
+        with patch("synthesis.get_daily_dir", return_value=daily_dir), \
+             patch("synthesis.get_global_memory_file", return_value=tmp_path / "g.md"), \
+             patch("synthesis.get_project_memory_dir", return_value=tmp_path / "pm"), \
+             patch("synthesis.get_memory_dir", return_value=tmp_path), \
+             patch("synthesis.run_post_processing"), \
+             patch("synthesis.compute_offsets_from_extracts") as mock_compute, \
+             patch("synthesis.update_synthesis_state") as mock_update:
+            apply_results(
+                output_file=str(output_file),
+                extract_paths=[],
+                offsets_json=str(cli_offsets),
+            )
+
+        # Should not compute if CLI offsets provided
+        mock_compute.assert_not_called()
+        mock_update.assert_called_once_with({"s1": {"offset": 9999, "lines": 99}})
+
+
+# =============================================================================
+# apply_results --offsets-json Tests (legacy)
 # =============================================================================
 
 


### PR DESCRIPTION
## Summary
- Synthesis state offsets (`byte_offset`, `line_count`) were never persisted because the pipeline relied on the LLM subagent faithfully reproducing `--offsets-json` in its Bash command
- Added `compute_offsets_from_extracts()` to `synthesis.py` — parses session IDs from extract file headers, finds JSONL files on disk, computes file size + line count at apply time
- Removed offsets temp file creation and `--offsets-json` from the LLM prompt command (kept CLI arg for backward compat)

## Test plan
- [x] 5 unit tests for `compute_offsets_from_extracts()` (happy path, multi-session, empty, missing JSONL, missing extract)
- [x] 3 integration tests for `apply_results` offset computation (auto-compute, skip when empty, CLI override)
- [x] Updated 2 existing tests to reflect removed offsets-in-prompt behavior
- [x] Full suite: 555 passed

Closes #24

Co-Authored-By: Claude <noreply@anthropic.com>