### PR TITLE
fix(synthesis): reject LLM-leaked {name} placeholders in scope injection

### DIFF
--- a/scripts/synthesis.py
+++ b/scripts/synthesis.py
@@ -297,7 +297,8 @@ _UNSCOPED_ENTRY = re.compile(
 )
 _GLOBAL_MARKER = re.compile(r"^\s*-\s*\[GLOBAL\]")
 # Pattern to detect already-scoped entries: - [scope/type] or - [scope|scope/type]
-_SCOPED_ENTRY = re.compile(r"^\s*-\s*(?:\[routed\])?\s*\[[^\]]+/[^\]]+\]")
+# Scope names must be lowercase alphanumeric + hyphens (rejects placeholders like {name})
+_SCOPED_ENTRY = re.compile(r"^\s*-\s*(?:\[routed\])?\s*\[[a-z0-9-]+(?:\|[a-z0-9-]+)*/[^\]]+\]")
 
 
 def inject_scopes(
@@ -326,6 +327,13 @@ def inject_scopes(
             if not line.strip().startswith("-"):
                 new_lines.append(line)
                 continue
+
+            # Strip LLM-leaked placeholder scopes like [{name}/type] -> [type]
+            line = re.sub(
+                r"(\s*-\s*(?:\[GLOBAL\])?)\[\{[^}]*\}/([a-z]+)\]",
+                r"\1[\2]",
+                line,
+            )
 
             # Already scoped — pass through
             if _SCOPED_ENTRY.match(line):

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -1491,6 +1491,27 @@ class TestInjectScopes:
         result = inject_scopes([daily], session_projects)
         assert "- [cartwheel/implement] Built OAuth" in result[0].content
 
+    def test_placeholder_name_gets_rescoped(self):
+        """LLM-leaked {name} placeholder is treated as unscoped and gets project injection."""
+        daily = DailyFile(
+            date="2026-02-23",
+            content="# 2026-02-23\n## Actions\n- [{name}/implement] Built OAuth\n"
+        )
+        session_projects = {"2026-02-23": "cartwheel"}
+        result = inject_scopes([daily], session_projects)
+        assert "- [cartwheel/implement] Built OAuth" in result[0].content
+        assert "{name}" not in result[0].content
+
+    def test_placeholder_name_no_project_gets_global(self):
+        """LLM-leaked {name} placeholder defaults to global when no project."""
+        daily = DailyFile(
+            date="2026-02-23",
+            content="# 2026-02-23\n## Learnings\n- [{name}/gotcha] Bad thing\n"
+        )
+        session_projects = {"2026-02-23": None}
+        result = inject_scopes([daily], session_projects)
+        assert "- [global/gotcha] Bad thing" in result[0].content
+
     def test_multiple_sessions_different_projects(self):
         """Different dates can have different projects."""
         dailies = [


### PR DESCRIPTION
## Summary
- `_SCOPED_ENTRY` regex was too permissive — `[{name}/type]` matched as already-scoped, bypassing `inject_scopes()` entirely
- Tightened regex to only accept `[a-z0-9-]` scope names (rejects braces, placeholders)
- Added placeholder stripping step that converts `[{name}/type]` back to `[type]` before scope injection runs
- 2 new tests covering placeholder-to-project and placeholder-to-global paths

## Test plan
- [x] `test_placeholder_name_gets_rescoped` — `[{name}/implement]` becomes `[cartwheel/implement]` when session has project
- [x] `test_placeholder_name_no_project_gets_global` — `[{name}/gotcha]` becomes `[global/gotcha]` when no project
- [x] Full suite: 557 tests pass

Co-Authored-By: Claude <noreply@anthropic.com>