### PR TITLE
fix(synthesis): fall back to project_hash when sessions-index missing

### DIFF
--- a/scripts/transcript_ops.py
+++ b/scripts/transcript_ops.py
@@ -26,17 +26,31 @@ if str(script_dir) not in sys.path:
 from indexing import get_session_date, list_recent_sessions
 
 
-def _resolve_project_name(project_path: str | None) -> str | None:
-    """Resolve a session's project_path to a project name via projects-index."""
-    if not project_path:
+def _resolve_project_name(
+    project_path: str | None,
+    project_hash: str | None = None,
+) -> str | None:
+    """Resolve a session's project_path to a project name via projects-index.
+
+    Falls back to matching project_hash against encodedPaths when
+    project_path is unavailable (sessions-index.json missing).
+    """
+    if not project_path and not project_hash:
         return None
     try:
         from memory_utils import get_projects_index_file, load_json_file
         index = load_json_file(get_projects_index_file(), {})
         projects = index.get("projects", {})
-        data = projects.get(project_path)
-        if data and data.get("name"):
-            return data["name"]
+        # Primary: direct path lookup
+        if project_path:
+            data = projects.get(project_path)
+            if data and data.get("name"):
+                return data["name"]
+        # Fallback: match encoded folder name against encodedPaths
+        if project_hash:
+            for _path, data in projects.items():
+                if project_hash in data.get("encodedPaths", []):
+                    return data.get("name")
     except Exception:
         pass
     return None
@@ -245,7 +259,9 @@ def extract_transcripts_incremental(
                 "session_id": sid,
                 "filepath": str(session.transcript_path),
                 "project_path": session.project_path,
-                "project_name": _resolve_project_name(session.project_path),
+                "project_name": _resolve_project_name(
+                    session.project_path, project_hash=session.project_hash,
+                ),
                 "message_count": len(messages),
                 "messages": messages,
                 "mode": mode,

--- a/tests/test_transcript_ops.py
+++ b/tests/test_transcript_ops.py
@@ -473,5 +473,116 @@ class TestFormatTranscriptsIncrementalProjectHeader:
         assert "[project: global]" in result
 
 
+# =============================================================================
+# _resolve_project_name Fallback Tests
+# =============================================================================
+
+
+class TestResolveProjectName:
+    """Test _resolve_project_name with project_hash fallback."""
+
+    def _make_index(self, projects):
+        return {"projects": projects, "version": 1}
+
+    def _patch_index(self, index, tmp_path):
+        """Return context manager that patches the projects-index lookup."""
+        return mock.patch.dict(
+            "memory_utils.__dict__",
+        ), mock.patch(
+            "memory_utils.load_json_file", return_value=index,
+        ), mock.patch(
+            "memory_utils.get_projects_index_file", return_value=tmp_path / "idx.json",
+        )
+
+    def test_resolves_via_project_path(self, tmp_path):
+        """Direct project_path lookup (existing behavior)."""
+        from transcript_ops import _resolve_project_name
+
+        index = self._make_index({
+            "/home/user/myproject": {
+                "name": "myproject",
+                "encodedPaths": ["-home-user-myproject"],
+            }
+        })
+        with mock.patch("memory_utils.load_json_file", return_value=index), \
+             mock.patch("memory_utils.get_projects_index_file", return_value=tmp_path / "idx.json"):
+            result = _resolve_project_name("/home/user/myproject")
+        assert result == "myproject"
+
+    def test_falls_back_to_project_hash(self, tmp_path):
+        """When project_path is None, resolve via project_hash in encodedPaths."""
+        from transcript_ops import _resolve_project_name
+
+        index = self._make_index({
+            "/home/user/myproject": {
+                "name": "myproject",
+                "encodedPaths": ["-home-user-myproject"],
+            }
+        })
+        with mock.patch("memory_utils.load_json_file", return_value=index), \
+             mock.patch("memory_utils.get_projects_index_file", return_value=tmp_path / "idx.json"):
+            result = _resolve_project_name(None, project_hash="-home-user-myproject")
+        assert result == "myproject"
+
+    def test_hash_fallback_matches_worktree_encoded_path(self, tmp_path):
+        """Worktree encoded paths are in the same project's encodedPaths list."""
+        from transcript_ops import _resolve_project_name
+
+        index = self._make_index({
+            "/home/user/myproject": {
+                "name": "myproject",
+                "encodedPaths": [
+                    "-home-user-myproject",
+                    "-home-user-myproject--worktrees-feature-x",
+                ],
+            }
+        })
+        with mock.patch("memory_utils.load_json_file", return_value=index), \
+             mock.patch("memory_utils.get_projects_index_file", return_value=tmp_path / "idx.json"):
+            result = _resolve_project_name(None, project_hash="-home-user-myproject--worktrees-feature-x")
+        assert result == "myproject"
+
+    def test_returns_none_when_no_path_and_no_hash(self, tmp_path):
+        """Both None returns None."""
+        from transcript_ops import _resolve_project_name
+
+        result = _resolve_project_name(None, project_hash=None)
+        assert result is None
+
+    def test_returns_none_when_hash_not_in_index(self, tmp_path):
+        """Unknown project_hash returns None."""
+        from transcript_ops import _resolve_project_name
+
+        index = self._make_index({
+            "/home/user/myproject": {
+                "name": "myproject",
+                "encodedPaths": ["-home-user-myproject"],
+            }
+        })
+        with mock.patch("memory_utils.load_json_file", return_value=index), \
+             mock.patch("memory_utils.get_projects_index_file", return_value=tmp_path / "idx.json"):
+            result = _resolve_project_name(None, project_hash="-home-user-unknown")
+        assert result is None
+
+    def test_project_path_takes_precedence_over_hash(self, tmp_path):
+        """When both are available, project_path wins."""
+        from transcript_ops import _resolve_project_name
+
+        index = self._make_index({
+            "/home/user/alpha": {
+                "name": "alpha",
+                "encodedPaths": ["-home-user-alpha"],
+            },
+            "/home/user/beta": {
+                "name": "beta",
+                "encodedPaths": ["-home-user-beta"],
+            },
+        })
+        with mock.patch("memory_utils.load_json_file", return_value=index), \
+             mock.patch("memory_utils.get_projects_index_file", return_value=tmp_path / "idx.json"):
+            result = _resolve_project_name("/home/user/alpha", project_hash="-home-user-beta")
+        assert result == "alpha"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- `_resolve_project_name` relied on `projectPath` from `.sessions-index.json`, which is missing ~26% of the time — causing all affected sessions to resolve as `global` scope
- Added `project_hash` fallback: when `project_path` is `None`, matches the encoded folder name against each project's `encodedPaths` list in `projects-index.json`
- The `project_hash` was already available on `SessionInfo` but never used for name resolution

## Test plan
- [x] 6 new tests: direct path lookup, hash fallback, worktree hash, both None, unknown hash, precedence
- [x] Verified with real session data: `-home-nsitaram-personal-investing` → `investing`, `-home-nsitaram-claude-memory-system` → `claude-memory-system`
- [x] Full suite: 563 passed

Co-Authored-By: Claude <noreply@anthropic.com>