### PR TITLE
feat(synthesis): default to deferred synthesis via systemd timer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ Use `/settings` skill to view/modify. Key settings in `~/.claude/memory/settings
 | `synthesis.intervalHours` | 2 | Hours between auto-synthesis |
 | `synthesis.model` | sonnet | Model for synthesis subagent |
 | `synthesis.background` | true | Run auto-synthesis in background |
-| `synthesis.deferred` | false | Enable deferred synthesis (systemd timer instead of in-session) |
+| `synthesis.deferred` | true | Enable deferred synthesis (systemd timer instead of in-session) |
 | `synthesis.minSessionMessages` | 10 | Skip sessions with fewer messages during synthesis |
 | `decay.ageDays` | 30 | Global LTM: archive after N calendar days |
 | `decay.projectWorkingDays` | 20 | Project LTM: archive after N project work days |

--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -695,7 +695,7 @@ def main() -> None:
     # Check for pending transcripts (only if synthesis scheduling allows)
     # Exclude current session — it's still active and shouldn't be synthesized
     pending_dates = get_recent_days(exclude_session_id=current_session_id)
-    synthesis_deferred = settings.get("synthesis", {}).get("deferred", False)
+    synthesis_deferred = settings.get("synthesis", {}).get("deferred", True)
     if pending_dates and should_synthesize(settings) and not synthesis_deferred:
         # Write timestamp eagerly to prevent duplicate synthesis when multiple
         # sessions start simultaneously (all would see stale timestamp otherwise)

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -221,7 +221,7 @@ DEFAULT_SETTINGS = {
         "intervalHours": 2,
         "model": "sonnet",
         "background": True,
-        "deferred": False,
+        "deferred": True,
         "minSessionMessages": 10,
     },
     "decay": {

--- a/scripts/synthesis_cron.py
+++ b/scripts/synthesis_cron.py
@@ -38,7 +38,7 @@ def should_run_deferred_synthesis() -> bool:
     Returns True if deferred mode is enabled and synthesis is due.
     """
     settings = load_settings()
-    if not settings.get("synthesis", {}).get("deferred", False):
+    if not settings.get("synthesis", {}).get("deferred", True):
         return False
     return should_synthesize(settings)
 

--- a/tests/test_load_memory.py
+++ b/tests/test_load_memory.py
@@ -1354,14 +1354,14 @@ class TestSkipMemory:
 
 
 class TestSynthesisDeferredSetting:
-    def test_default_deferred_is_false(self, tmp_path):
-        """synthesis.deferred defaults to False."""
-        from memory_utils import load_settings
+    def test_default_deferred_matches_default_settings(self, tmp_path):
+        """synthesis.deferred defaults to DEFAULT_SETTINGS value."""
+        from memory_utils import DEFAULT_SETTINGS, load_settings
 
         settings_file = tmp_path / "settings.json"
         with mock.patch("memory_utils.get_settings_file", return_value=settings_file):
             settings = load_settings()
-        assert settings["synthesis"]["deferred"] is False
+        assert settings["synthesis"]["deferred"] is DEFAULT_SETTINGS["synthesis"]["deferred"]
 
     def _make_settings(self, deferred=False):
         """Build a settings dict with synthesis.deferred set."""

--- a/tests/test_synthesis_cron.py
+++ b/tests/test_synthesis_cron.py
@@ -48,17 +48,24 @@ class TestShouldRunDeferredSynthesis:
         }), patch("load_memory.get_last_synthesis_file", return_value=last_synth):
             assert should_run_deferred_synthesis() is True
 
-    def test_returns_false_when_deferred_missing_defaults_false(self):
-        """If synthesis.deferred key is missing, defaults to False."""
+    def test_returns_true_when_deferred_missing_defaults_to_setting(self):
+        """If synthesis.deferred key is missing, defaults to DEFAULT_SETTINGS value."""
+        from memory_utils import DEFAULT_SETTINGS
+
+        expected = DEFAULT_SETTINGS["synthesis"]["deferred"]
         with patch("synthesis_cron.load_settings", return_value={
             "synthesis": {"intervalHours": 2}
-        }):
-            assert should_run_deferred_synthesis() is False
+        }), patch("synthesis_cron.should_synthesize", return_value=True):
+            assert should_run_deferred_synthesis() is expected
 
-    def test_returns_false_when_synthesis_section_missing(self):
-        """If synthesis section is missing entirely, defaults to False."""
-        with patch("synthesis_cron.load_settings", return_value={}):
-            assert should_run_deferred_synthesis() is False
+    def test_returns_true_when_synthesis_section_missing(self):
+        """If synthesis section is missing entirely, defaults to DEFAULT_SETTINGS deferred."""
+        from memory_utils import DEFAULT_SETTINGS
+
+        expected = DEFAULT_SETTINGS["synthesis"]["deferred"]
+        with patch("synthesis_cron.load_settings", return_value={}), \
+             patch("synthesis_cron.should_synthesize", return_value=True):
+            assert should_run_deferred_synthesis() is expected
 
 
 class TestBuildClaudeCommand:


### PR DESCRIPTION
## Summary
- Change `synthesis.deferred` default from `false` to `true` — synthesis now runs out-of-session via systemd timer by default, eliminating in-session subagent token overhead on SessionStart
- Update all inline `.get("deferred", ...)` fallbacks in `load_memory.py` and `synthesis_cron.py` to match
- Fix tests to import `DEFAULT_SETTINGS` instead of hardcoding expected values

## Test plan
- [x] Full suite: 568 passed
- [x] `TestSynthesisDeferredSetting` validates default matches `DEFAULT_SETTINGS`
- [x] `TestShouldRunDeferredSynthesis` missing-key tests derive from `DEFAULT_SETTINGS`

Co-Authored-By: Claude <noreply@anthropic.com>