### PR TITLE
chore: remove dead code and fix stale settings docs

### DIFF
--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -179,10 +179,6 @@ def get_settings_file() -> Path:
     return get_memory_dir() / "settings.json"
 
 
-def get_claude_settings_file() -> Path:
-    """Get Claude Code's settings file path."""
-    return get_claude_dir() / "settings.json"
-
 
 def get_projects_index_file() -> Path:
     """Get the projects index file path."""

--- a/scripts/synthesis.py
+++ b/scripts/synthesis.py
@@ -560,16 +560,6 @@ def _extract_session_projects(extract_paths: list[str]) -> dict[str, str | None]
     return result
 
 
-def _inject_route_scopes(
-    routes: list[RouteEntry],
-    session_projects: dict[str, str | None],
-) -> list[RouteEntry]:
-    """Pass-through for now -- route scopes come from daily entry tags.
-
-    Legacy: intended for the ===DAILY:date=== format path. Currently unused.
-    """
-    return routes
-
 
 def mark_routed_entries(
     dailies: list[DailyFile],

--- a/skills/settings/SKILL.md
+++ b/skills/settings/SKILL.md
@@ -54,9 +54,12 @@ Reset to defaults from `_defaults` section of settings.json. Omit path to reset 
 | `projectShortTerm.workingDays` | int | 1-30 | 5 | Also updates tokenLimit |
 | `projectSettings.includeSubdirectories` | bool | — | false | Match subdirs to parent project |
 | `synthesis.intervalHours` | int | 1-24 | 2 | Hours between auto-synthesis |
-| `synthesis.model` | string | haiku/sonnet/opus | haiku | Model for synthesis subagent |
+| `synthesis.model` | string | haiku/sonnet/opus | sonnet | Model for synthesis subagent |
 | `synthesis.background` | bool | — | true | Run auto-synthesis in background |
+| `synthesis.deferred` | bool | — | true | Use systemd timer instead of in-session synthesis |
+| `synthesis.minSessionMessages` | int | 0-100 | 10 | Skip sessions with fewer messages during synthesis |
 | `decay.ageDays` | int | 7-365 | 30 | Archive learnings older than this |
+| `decay.projectWorkingDays` | int | 5-100 | 20 | Archive project entries after N project work days |
 | `decay.archiveRetentionDays` | int | 30-730 | 365 | Purge archived items older than this |
 
 ## Token Budget

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -25,8 +25,9 @@
     "intervalHours": 2,
     "model": "sonnet",
     "background": true,
-    "deferred": false,
-    "_comment": "Minimum hours between auto-synthesis prompts (always runs on first session of day). Model: sonnet (default)|haiku|opus. Background: true runs synthesis without blocking user. Deferred: true moves synthesis to systemd timer instead of in-session."
+    "deferred": true,
+    "minSessionMessages": 10,
+    "_comment": "Minimum hours between auto-synthesis prompts (always runs on first session of day). Model: sonnet (default)|haiku|opus. Background: true runs synthesis without blocking user. Deferred: true moves synthesis to systemd timer instead of in-session. minSessionMessages: skip sessions with fewer messages during synthesis."
   },
   "decay": {
     "ageDays": 30,
@@ -56,6 +57,8 @@
     "synthesis.intervalHours": 2,
     "synthesis.model": "sonnet",
     "synthesis.background": true,
+    "synthesis.deferred": true,
+    "synthesis.minSessionMessages": 10,
     "decay.ageDays": 30,
     "decay.projectWorkingDays": 20,
     "decay.archiveRetentionDays": 365


### PR DESCRIPTION
## Summary
- Remove 2 dead functions: `_inject_route_scopes()` (synthesis.py) and `get_claude_settings_file()` (memory_utils.py)
- Fix `templates/settings.json`: `deferred` default `false`→`true`, add missing `minSessionMessages: 10`
- Fix `skills/settings/SKILL.md`: correct `synthesis.model` default `haiku`→`sonnet`, add 3 missing settings rows (`deferred`, `minSessionMessages`, `projectWorkingDays`)

## Test plan
- [x] 630 tests pass
- [x] Lint passes on all modified files
- [x] Verified both functions are unused via grep across entire codebase
- [x] Settings template and SKILL.md now match `DEFAULT_SETTINGS` in `memory_utils.py`

Co-Authored-By: Claude <noreply@anthropic.com>