### PR TITLE
refactor: DRY consolidate project path resolution and markdown parsing (#32, #33)

### DIFF
--- a/scripts/decay.py
+++ b/scripts/decay.py
@@ -33,6 +33,7 @@ from memory_utils import (
     load_json_file,
     load_settings,
     local_today,
+    parse_markdown_sections,
     project_name_to_filename,
 )
 
@@ -87,25 +88,12 @@ def is_decay_eligible(section_name: str) -> bool:
 
 
 def parse_sections(content: str) -> list[tuple[str, str]]:
-    """Parse markdown into sections (header, content) tuples."""
-    sections = []
-    current_header = ""
-    current_content = []
+    """Parse markdown into sections (header, content) tuples.
 
-    for line in content.split("\n"):
-        if line.startswith("## "):
-            if current_header or current_content:
-                sections.append((current_header, "\n".join(current_content)))
-            current_header = line.strip()
-            current_content = []
-        else:
-            current_content.append(line)
-
-    # Don't forget the last section
-    if current_header or current_content:
-        sections.append((current_header, "\n".join(current_content)))
-
-    return sections
+    Wraps ``memory_utils.parse_markdown_sections()`` to join content lines
+    into a single string per section (decay.py's expected format).
+    """
+    return [(header, "\n".join(lines)) for header, lines in parse_markdown_sections(content)]
 
 
 def parse_learnings(section_content: str) -> list[tuple[str, date | None]]:

--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -41,6 +41,7 @@ from memory_utils import (
     load_settings,
     load_synthesis_state,
     project_name_to_filename,
+    resolve_project_path_to_name,
     resolve_worktree_to_main_repo,
 )
 from transcript_ops import (
@@ -454,28 +455,22 @@ def _build_synthesis_prompt(
 def _find_projects_in_extracts(daily_data: dict[str, list[dict]]) -> set[str]:
     """Find project names from extracted session data.
 
+    Delegates path-to-name resolution to
+    ``memory_utils.resolve_project_path_to_name()``.
+
     Args:
         daily_data: Dict mapping date -> list of session dicts
 
     Returns set of project names that had sessions extracted.
     """
-    projects_index = load_json_file(get_projects_index_file(), {})
-    projects = projects_index.get("projects", {})
-
-    # Collect unique project paths from sessions
-    project_paths: set[str] = set()
+    result: set[str] = set()
     for sessions in daily_data.values():
         for s in sessions:
             pp = s.get("project_path")
             if pp:
-                project_paths.add(pp)
-
-    # Map to project names
-    result: set[str] = set()
-    for path in project_paths:
-        data = projects.get(path)
-        if data and data.get("name"):
-            result.add(data["name"])
+                name = resolve_project_path_to_name(pp)
+                if name:
+                    result.add(name)
     return result
 
 

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -61,6 +61,10 @@ __all__ = [
     "save_synthesis_state",
     "update_synthesis_state",
     "prune_stale_state_entries",
+    # Project resolution
+    "resolve_project_path_to_name",
+    # Markdown parsing
+    "parse_markdown_sections",
     # Utilities
     "estimate_tokens",
     "project_name_to_filename",
@@ -821,6 +825,107 @@ def find_current_project(projects_index: dict, pwd: str, include_subdirs: bool) 
     else:
         # Exact match only
         return projects.get(pwd_lower)
+
+
+# Cache for resolve_project_path_to_name to avoid repeated file reads
+_projects_index_cache: dict | None = None
+
+
+def resolve_project_path_to_name(
+    project_path: str | None,
+    project_hash: str | None = None,
+) -> str | None:
+    """Resolve a project path or encoded hash to a project name.
+
+    Loads projects-index.json (cached) and resolves using three strategies:
+    1. Direct path lookup via project_path
+    2. Encoded folder name match via project_hash against encodedPaths
+    3. Worktree prefix match when hash contains ``--worktrees-``
+
+    Args:
+        project_path: Original filesystem path (e.g., "/home/user/myproject")
+        project_hash: Encoded folder name (e.g., "-home-user-myproject")
+
+    Returns:
+        Project name string, or None if not found.
+    """
+    global _projects_index_cache
+
+    if not project_path and not project_hash:
+        return None
+
+    try:
+        if _projects_index_cache is None:
+            _projects_index_cache = load_json_file(get_projects_index_file(), {})
+        projects = _projects_index_cache.get("projects", {})
+
+        # Primary: direct path lookup
+        if project_path:
+            data = projects.get(project_path)
+            if data and data.get("name"):
+                return data["name"]
+
+        # Fallback 1: match encoded folder name against encodedPaths
+        if project_hash:
+            for _path, data in projects.items():
+                if project_hash in data.get("encodedPaths", []):
+                    return data.get("name")
+
+            # Fallback 2: prefix match for unindexed worktrees
+            base = project_hash.rsplit("--worktrees-", 1)[0]
+            if base != project_hash:  # only if hash contains --worktrees-
+                for _path, data in projects.items():
+                    for ep in data.get("encodedPaths", []):
+                        ep_base = ep.rsplit("--worktrees-", 1)[0]
+                        if base == ep_base:
+                            return data.get("name")
+    except Exception:
+        pass
+    return None
+
+
+def _clear_projects_index_cache() -> None:
+    """Clear the projects index cache (for testing)."""
+    global _projects_index_cache
+    _projects_index_cache = None
+
+
+# =============================================================================
+# Markdown Parsing
+# =============================================================================
+
+
+def parse_markdown_sections(content: str) -> list[tuple[str, list[str]]]:
+    """Parse markdown content into sections split by ``## `` headers.
+
+    Returns a list of ``(header, content_lines)`` tuples. Content before
+    the first ``## `` header is returned with an empty-string header.
+
+    Args:
+        content: Raw markdown text.
+
+    Returns:
+        List of (header, content_lines) where header is the full ``## ...``
+        line (stripped) or ``""`` for the preamble, and content_lines is a
+        list of individual lines (without trailing newline).
+    """
+    sections: list[tuple[str, list[str]]] = []
+    current_header = ""
+    current_lines: list[str] = []
+
+    for line in content.split("\n"):
+        if line.startswith("## "):
+            if current_header or current_lines:
+                sections.append((current_header, current_lines))
+            current_header = line.strip()
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    if current_header or current_lines:
+        sections.append((current_header, current_lines))
+
+    return sections
 
 
 if __name__ == "__main__":

--- a/scripts/synthesis.py
+++ b/scripts/synthesis.py
@@ -35,6 +35,7 @@ from memory_utils import (  # noqa: E402
     get_project_memory_dir,
     get_projects_dir,
     is_routed_match,
+    parse_markdown_sections,
     prune_stale_state_entries,
     update_synthesis_state,
 )
@@ -244,6 +245,10 @@ SECTION_ORDER = ["Actions", "Decisions", "Learnings", "Lessons"]
 def parse_daily_sections(content: str) -> dict:
     """Parse a daily markdown file into structured sections.
 
+    Wraps ``memory_utils.parse_markdown_sections()`` with daily-file-specific
+    logic: extracts date from ``# YYYY-MM-DD`` header, filters to known
+    section names, skips HTML comments/blank lines, and collects entry lines.
+
     Returns dict with "date" (str) and section names mapping to entry lists.
     Skips HTML comments and blank lines. Preserves [routed] prefixes.
     """
@@ -254,38 +259,30 @@ def parse_daily_sections(content: str) -> dict:
     if not content.strip():
         return result
 
-    current_section = None
-    for line in content.split("\n"):
-        # Date header
-        if line.startswith("# ") and not line.startswith("## "):
-            date_match = re.match(r"^# (\d{4}-\d{2}-\d{2})", line)
-            if date_match:
-                result["date"] = date_match.group(1)
+    for header, lines in parse_markdown_sections(content):
+        if not header:
+            # Preamble — look for date header in the lines
+            for line in lines:
+                if line.startswith("# ") and not line.startswith("## "):
+                    date_match = re.match(r"^# (\d{4}-\d{2}-\d{2})", line)
+                    if date_match:
+                        result["date"] = date_match.group(1)
             continue
 
-        # Section header
-        if line.startswith("## "):
-            section_name = line[3:].strip()
-            if section_name in SECTION_ORDER:
-                current_section = section_name
-            else:
-                current_section = None
+        section_name = header[3:].strip()  # strip "## " prefix
+        if section_name not in SECTION_ORDER:
             continue
 
-        if current_section is None:
-            continue
-
-        # Skip HTML comments
-        if re.match(r"^\s*<!--.*-->\s*$", line):
-            continue
-
-        # Skip blank lines
-        if not line.strip():
-            continue
-
-        # Entry line (starts with -)
-        if line.strip().startswith("-"):
-            result[current_section].append(line)
+        for line in lines:
+            # Skip HTML comments
+            if re.match(r"^\s*<!--.*-->\s*$", line):
+                continue
+            # Skip blank lines
+            if not line.strip():
+                continue
+            # Entry line (starts with -)
+            if line.strip().startswith("-"):
+                result[section_name].append(line)
 
     return result
 

--- a/scripts/transcript_ops.py
+++ b/scripts/transcript_ops.py
@@ -24,6 +24,7 @@ if str(script_dir) not in sys.path:
     sys.path.insert(0, str(script_dir))
 
 from indexing import get_session_date, list_recent_sessions
+from memory_utils import resolve_project_path_to_name
 
 
 def _resolve_project_name(
@@ -32,43 +33,11 @@ def _resolve_project_name(
 ) -> str | None:
     """Resolve a session's project_path to a project name via projects-index.
 
-    Falls back to matching project_hash against encodedPaths when
-    project_path is unavailable (sessions-index.json missing).
-
-    If exact match fails and the hash contains ``--worktrees-``, a prefix
-    fallback extracts the base repo path (before ``--worktrees-``) and
-    compares it to the base of each known encodedPath. This resolves
-    unindexed worktrees to their parent project.
+    Delegates to ``memory_utils.resolve_project_path_to_name()`` which
+    handles direct path lookup, encodedPaths fallback, and worktree
+    prefix matching.
     """
-    if not project_path and not project_hash:
-        return None
-    try:
-        from memory_utils import get_projects_index_file, load_json_file
-        index = load_json_file(get_projects_index_file(), {})
-        projects = index.get("projects", {})
-        # Primary: direct path lookup
-        if project_path:
-            data = projects.get(project_path)
-            if data and data.get("name"):
-                return data["name"]
-        # Fallback 1: match encoded folder name against encodedPaths
-        if project_hash:
-            for _path, data in projects.items():
-                if project_hash in data.get("encodedPaths", []):
-                    return data.get("name")
-            # Fallback 2: prefix match for unindexed worktrees
-            # e.g., -home-user-project--worktrees-new-branch matches
-            #        -home-user-project or -home-user-project--worktrees-old-branch
-            base = project_hash.rsplit("--worktrees-", 1)[0]
-            if base != project_hash:  # only if hash contains --worktrees-
-                for _path, data in projects.items():
-                    for ep in data.get("encodedPaths", []):
-                        ep_base = ep.rsplit("--worktrees-", 1)[0]
-                        if base == ep_base:
-                            return data.get("name")
-    except Exception:
-        pass
-    return None
+    return resolve_project_path_to_name(project_path, project_hash=project_hash)
 
 __all__ = [
     # Parsing

--- a/tests/test_load_memory.py
+++ b/tests/test_load_memory.py
@@ -837,11 +837,16 @@ class TestBuildEmbeddedFiles:
 class TestFindProjectsInExtracts:
     """Tests for _find_projects_in_extracts helper."""
 
+    def setup_method(self):
+        """Clear the projects index cache before each test."""
+        from memory_utils import _clear_projects_index_cache
+        _clear_projects_index_cache()
+
     def test_maps_project_path_to_name(self, tmp_path):
         index = {"projects": {
             "/home/user/myproject": {"name": "myproject", "encodedPaths": ["-home-user-myproject"]}
         }}
-        with mock.patch("load_memory.get_projects_index_file") as mock_idx:
+        with mock.patch("memory_utils.get_projects_index_file") as mock_idx:
             mock_idx.return_value = tmp_path / "index.json"
             (tmp_path / "index.json").write_text(json.dumps(index))
             result = _find_projects_in_extracts({
@@ -854,7 +859,7 @@ class TestFindProjectsInExtracts:
             "/proj/a": {"name": "alpha", "encodedPaths": []},
             "/proj/b": {"name": "beta", "encodedPaths": []},
         }}
-        with mock.patch("load_memory.get_projects_index_file") as mock_idx:
+        with mock.patch("memory_utils.get_projects_index_file") as mock_idx:
             mock_idx.return_value = tmp_path / "index.json"
             (tmp_path / "index.json").write_text(json.dumps(index))
             result = _find_projects_in_extracts({
@@ -866,14 +871,16 @@ class TestFindProjectsInExtracts:
         assert result == {"alpha", "beta"}
 
     def test_empty_data_returns_empty(self):
-        with mock.patch("load_memory.get_projects_index_file") as mock_idx:
+        from memory_utils import _clear_projects_index_cache
+        _clear_projects_index_cache()
+        with mock.patch("memory_utils.get_projects_index_file") as mock_idx:
             mock_idx.return_value = Path("/nonexistent/index.json")
             result = _find_projects_in_extracts({})
         assert result == set()
 
     def test_unknown_project_skipped(self, tmp_path):
         index = {"projects": {}}
-        with mock.patch("load_memory.get_projects_index_file") as mock_idx:
+        with mock.patch("memory_utils.get_projects_index_file") as mock_idx:
             mock_idx.return_value = tmp_path / "index.json"
             (tmp_path / "index.json").write_text(json.dumps(index))
             result = _find_projects_in_extracts({

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -15,6 +15,7 @@ from memory_utils import (
     SHORT_TERM_TOKENS_PER_DAY,
     FileLock,
     _calculate_token_limits,
+    _clear_projects_index_cache,
     _deep_merge,
     estimate_tokens,
     extract_entry_keywords,
@@ -30,8 +31,10 @@ from memory_utils import (
     load_settings,
     load_synthesis_state,
     local_today,
+    parse_markdown_sections,
     project_name_to_filename,
     prune_stale_state_entries,
+    resolve_project_path_to_name,
     resolve_worktree_to_main_repo,
     save_json_file,
     save_synthesis_state,
@@ -1097,6 +1100,145 @@ class TestExtractEntryKeywordsMultiScope:
         assert "tailscale" in keywords
         assert "2026" not in keywords
         assert "global" not in keywords
+
+
+# =============================================================================
+# resolve_project_path_to_name Tests
+# =============================================================================
+
+
+class TestResolveProjectPathToName:
+    """Tests for the shared project path-to-name resolution utility."""
+
+    def setup_method(self):
+        _clear_projects_index_cache()
+
+    def test_direct_path_lookup(self, tmp_path):
+        index = {"projects": {
+            "/home/user/myproject": {"name": "myproject", "encodedPaths": ["-home-user-myproject"]}
+        }}
+        with mock.patch("memory_utils.load_json_file", return_value=index), \
+             mock.patch("memory_utils.get_projects_index_file", return_value=tmp_path / "idx.json"):
+            assert resolve_project_path_to_name("/home/user/myproject") == "myproject"
+
+    def test_encoded_path_fallback(self, tmp_path):
+        index = {"projects": {
+            "/home/user/myproject": {"name": "myproject", "encodedPaths": ["-home-user-myproject"]}
+        }}
+        with mock.patch("memory_utils.load_json_file", return_value=index), \
+             mock.patch("memory_utils.get_projects_index_file", return_value=tmp_path / "idx.json"):
+            assert resolve_project_path_to_name(None, project_hash="-home-user-myproject") == "myproject"
+
+    def test_worktree_prefix_fallback(self, tmp_path):
+        index = {"projects": {
+            "/home/user/repo": {
+                "name": "repo",
+                "encodedPaths": ["-home-user-repo", "-home-user-repo--worktrees-branch-a"],
+            }
+        }}
+        with mock.patch("memory_utils.load_json_file", return_value=index), \
+             mock.patch("memory_utils.get_projects_index_file", return_value=tmp_path / "idx.json"):
+            result = resolve_project_path_to_name(None, project_hash="-home-user-repo--worktrees-branch-b")
+        assert result == "repo"
+
+    def test_none_when_both_args_none(self):
+        assert resolve_project_path_to_name(None) is None
+
+    def test_none_when_not_found(self, tmp_path):
+        index = {"projects": {}}
+        with mock.patch("memory_utils.load_json_file", return_value=index), \
+             mock.patch("memory_utils.get_projects_index_file", return_value=tmp_path / "idx.json"):
+            assert resolve_project_path_to_name("/unknown/path") is None
+
+    def test_path_takes_precedence_over_hash(self, tmp_path):
+        index = {"projects": {
+            "/alpha": {"name": "alpha", "encodedPaths": ["-alpha"]},
+            "/beta": {"name": "beta", "encodedPaths": ["-beta"]},
+        }}
+        with mock.patch("memory_utils.load_json_file", return_value=index), \
+             mock.patch("memory_utils.get_projects_index_file", return_value=tmp_path / "idx.json"):
+            assert resolve_project_path_to_name("/alpha", project_hash="-beta") == "alpha"
+
+    def test_caching_avoids_repeated_reads(self, tmp_path):
+        index = {"projects": {
+            "/proj": {"name": "proj", "encodedPaths": []}
+        }}
+        with mock.patch("memory_utils.load_json_file", return_value=index) as mock_load, \
+             mock.patch("memory_utils.get_projects_index_file", return_value=tmp_path / "idx.json"):
+            resolve_project_path_to_name("/proj")
+            resolve_project_path_to_name("/proj")
+            # Should only load once thanks to caching
+            mock_load.assert_called_once()
+
+    def test_non_worktree_hash_no_prefix_fallback(self, tmp_path):
+        """Hash without --worktrees- does not trigger prefix matching."""
+        index = {"projects": {
+            "/home/user/myproject": {"name": "myproject", "encodedPaths": ["-home-user-myproject"]}
+        }}
+        with mock.patch("memory_utils.load_json_file", return_value=index), \
+             mock.patch("memory_utils.get_projects_index_file", return_value=tmp_path / "idx.json"):
+            result = resolve_project_path_to_name(None, project_hash="-home-user-myproject-subfolder")
+        assert result is None
+
+
+# =============================================================================
+# parse_markdown_sections Tests
+# =============================================================================
+
+
+class TestParseMarkdownSections:
+    """Tests for the shared markdown section parser."""
+
+    def test_basic_sections(self):
+        content = "## Section 1\nContent 1\n## Section 2\nContent 2"
+        sections = parse_markdown_sections(content)
+        assert len(sections) == 2
+        assert sections[0][0] == "## Section 1"
+        assert sections[0][1] == ["Content 1"]
+        assert sections[1][0] == "## Section 2"
+        assert sections[1][1] == ["Content 2"]
+
+    def test_preamble_before_sections(self):
+        content = "# Title\nPreamble\n## Section 1\nContent"
+        sections = parse_markdown_sections(content)
+        assert len(sections) == 2
+        assert sections[0][0] == ""
+        assert "# Title" in sections[0][1]
+        assert "Preamble" in sections[0][1]
+        assert sections[1][0] == "## Section 1"
+
+    def test_empty_content(self):
+        sections = parse_markdown_sections("")
+        assert len(sections) == 1
+        assert sections[0][0] == ""
+        assert sections[0][1] == [""]
+
+    def test_multiline_section(self):
+        content = "## Section\nLine 1\nLine 2\nLine 3"
+        sections = parse_markdown_sections(content)
+        assert len(sections) == 1
+        assert sections[0][1] == ["Line 1", "Line 2", "Line 3"]
+
+    def test_returns_lines_not_joined_string(self):
+        """Verify output is list of lines, not joined string."""
+        content = "## Sec\nA\nB"
+        sections = parse_markdown_sections(content)
+        assert isinstance(sections[0][1], list)
+
+    def test_decay_compat_join(self):
+        """Verify that joining lines matches decay.py's original output."""
+        content = "## Section 1\nContent 1\n## Section 2\nContent 2"
+        sections = parse_markdown_sections(content)
+        joined = [(h, "\n".join(lines)) for h, lines in sections]
+        assert joined[0] == ("## Section 1", "Content 1")
+        assert joined[1] == ("## Section 2", "Content 2")
+
+    def test_no_sections_only_content(self):
+        content = "Just plain text\nwith no headers"
+        sections = parse_markdown_sections(content)
+        assert len(sections) == 1
+        assert sections[0][0] == ""
+        assert sections[0][1] == ["Just plain text", "with no headers"]
 
 
 if __name__ == "__main__":

--- a/tests/test_transcript_ops.py
+++ b/tests/test_transcript_ops.py
@@ -605,18 +605,13 @@ class TestFormatTranscriptsIncrementalProjectHeader:
 class TestResolveProjectName:
     """Test _resolve_project_name with project_hash fallback."""
 
+    def setup_method(self):
+        """Clear the projects index cache before each test."""
+        from memory_utils import _clear_projects_index_cache
+        _clear_projects_index_cache()
+
     def _make_index(self, projects):
         return {"projects": projects, "version": 1}
-
-    def _patch_index(self, index, tmp_path):
-        """Return context manager that patches the projects-index lookup."""
-        return mock.patch.dict(
-            "memory_utils.__dict__",
-        ), mock.patch(
-            "memory_utils.load_json_file", return_value=index,
-        ), mock.patch(
-            "memory_utils.get_projects_index_file", return_value=tmp_path / "idx.json",
-        )
 
     def test_resolves_via_project_path(self, tmp_path):
         """Direct project_path lookup (existing behavior)."""
@@ -715,6 +710,11 @@ class TestResolveProjectName:
 
 class TestResolveProjectNameWorktreePrefix:
     """Test that unindexed worktrees resolve via prefix match."""
+
+    def setup_method(self):
+        """Clear the projects index cache before each test."""
+        from memory_utils import _clear_projects_index_cache
+        _clear_projects_index_cache()
 
     def test_new_worktree_resolves_to_parent(self, tmp_path):
         """ts-phase-4 should resolve to 'investing' when ts-phase-1..3 are indexed."""


### PR DESCRIPTION
Add resolve_project_path_to_name() and parse_markdown_sections() to
memory_utils.py as shared utilities, eliminating duplicated logic across
transcript_ops.py, load_memory.py, decay.py, and synthesis.py.

- resolve_project_path_to_name: 3-level fallback (direct path, encodedPaths,
  worktree prefix) with index caching; replaces independent implementations
  in transcript_ops._resolve_project_name and load_memory._find_projects_in_extracts
- parse_markdown_sections: splits markdown by ## headers into (header, lines)
  tuples; decay.py wraps with join, synthesis.py wraps with daily-specific filtering

https://claude.ai/code/session_01ATzYfPpG5uVLCpjXrfx9FW