### PR TITLE
docs: audit and reorganize README.md and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,6 @@
 # Claude Code Memory System - Development Guide
 
-## Project Purpose
-
-Markdown-based memory persistence for Claude Code. Installs hooks, scripts, and skills that enable context across sessions.
+Markdown-based memory persistence for Claude Code. See README.md for user-facing documentation.
 
 ## Repo Structure
 
@@ -26,55 +24,9 @@ claude-memory-system/
 ```
 
 **Installs to:**
-- `scripts/*.py` → `~/.claude/scripts/`
-- `skills/*/` → `~/.claude/skills/`
-- `templates/` → `~/.claude/memory/templates/` (always) + `~/.claude/memory/` (if not exists)
-
-## Two-Tier Memory Architecture
-
-**Long-term memory** (curated, persistent):
-| Tier | File | Loaded | Content |
-|------|------|--------|---------|
-| Global | `~/.claude/memory/global-long-term-memory.md` | Every session | User profile, global patterns |
-| Project | `~/.claude/memory/project-memory/{project}-long-term-memory.md` | When `$PWD` matches | Project-specific learnings |
-
-**Short-term memory** (recent daily summaries, filtered by scope tags):
-| Tier | Source | Days | Filter |
-|------|--------|------|--------|
-| Global | `~/.claude/memory/daily/*.md` | 2 | `[global/*]` tagged entries only |
-| Project | `~/.claude/memory/daily/*.md` | 7 | `[project-name/*]` tagged entries only |
-
-**Learning flow:**
-```
-Session transcript → /synthesize Phase 1 → Daily summary (Actions, Decisions, Learnings)
-                  → /synthesize Phase 2 → Route to long-term memory
-```
-
-**Daily file format:**
-- `## Actions` - What was done, tagged `[scope/action]`
-- `## Decisions` - Choices with rationale, tagged `[scope/decision]`
-- `## Learnings` - Patterns/gotchas, format: `- [scope/type] Description`
-- `## Lessons` - Actionable takeaways, format: `- [scope/type] Takeaway`
-
-**Long-term file format (decay-eligible sections):**
-- `## Key Actions` - Significant actions (from daily Actions)
-- `## Key Decisions` - Important choices (from daily Decisions)
-- `## Key Learnings` - Patterns/insights (from daily Learnings)
-- `## Key Lessons` - Actionable takeaways (from daily Lessons)
-
-**Long-term entry format:** `- (YYYY-MM-DD) [type] Description` (date first, then subtype)
-
-**Action types:** `implement`, `improve`, `document`, `analyze`
-**Decision types:** `design`, `tradeoff`, `scope`
-**Learning types:** `gotcha`, `pitfall`, `pattern`
-**Lesson types:** `insight`, `tip`, `workaround`
-
-**Routed entries:** Entries that exist in both daily files and LTM are prefixed with `[routed]` (e.g., `- [routed][scope/type] Description`) and skipped at load time. Marking is applied by `synthesis.py` at write time and reinforced by `devtools.py mark-routed` post-processing.
-
-**Filtering:** Tags determine which short-term memory tier content appears in:
-- `[global/*]` → Global Short-Term Memory (loaded every session)
-- `[project-name/*]` → Project Short-Term Memory (loaded when in that project)
-- Untagged content is excluded from short-term (only appears in raw daily files)
+- `scripts/*.py` → `~/.claude/scripts/` (symlinked)
+- `skills/*/` → `~/.claude/skills/` (symlinked)
+- `templates/` → `~/.claude/memory/templates/` (always) + `~/.claude/memory/` (if not exists, copied)
 
 ## Making Changes
 
@@ -88,87 +40,110 @@ Session transcript → /synthesize Phase 1 → Daily summary (Actions, Decisions
 2. Add to `link_scripts()` in `install.py`
 3. If it needs a hook, add in `merge_hooks()` function
 
-### Testing
+## Testing
 
-**Rule: Always add or update unit tests when adding new functions or modifying existing function behavior.** Tests live in `tests/test_<module>.py` matching the script they test. Run `python3 -m pytest tests/ -q` before considering any change complete.
+**Rule: Always add or update unit tests when adding new functions or modifying existing function behavior.**
 
-Test conventions:
+Tests live in `tests/test_<module>.py` matching the script they test.
+
+```bash
+python3 -m pytest tests/ -q                  # Run all (do this first)
+python3 -m pytest tests/ -v                  # Verbose for debugging
+python3 install.py                           # Apply changes
+python3 ~/.claude/scripts/load_memory.py     # Test memory loading
+python3 ~/.claude/scripts/indexing.py list-recent  # Test session listing
+python3 ~/.claude/scripts/decay.py --dry-run # Test decay
+```
+
+**Conventions:**
 - Class per function/feature: `class TestFunctionName`
 - Use pytest `tmp_path` fixture for filesystem isolation (not `tempfile`)
 - Use `unittest.mock.patch` to mock path helpers (`get_projects_dir`, etc.)
 - Use `@pytest.mark.parametrize` for input/output variations instead of separate test methods
-- Put shared factories in `tests/helpers.py`; path setup lives in `tests/conftest.py`
+- Shared factories in `tests/helpers.py`; path setup in `tests/conftest.py`
 - Test happy path, edge cases, and error conditions
-- Never hardcode configurable values — import constants (`DEFAULT_AGE_DAYS`, `DEFAULT_SETTINGS`, etc.) and make test data relative to them (e.g., `timedelta(days=DEFAULT_AGE_DAYS * 2)` not `timedelta(days=60)`)
+- Never hardcode configurable values — import constants (`DEFAULT_AGE_DAYS`, `DEFAULT_SETTINGS`, etc.) and derive test data from them (e.g., `timedelta(days=DEFAULT_AGE_DAYS * 2)` not `timedelta(days=60)`)
 
-```bash
-python3 -m pytest tests/ -q                  # Run all unit tests (do this first)
-python3 -m pytest tests/ -v                  # Verbose output for debugging
-python3 install.py                           # Apply changes
-python3 ~/.claude/scripts/load_memory.py     # Test memory loading
-python3 ~/.claude/scripts/indexing.py list-recent  # Test recent session listing
-python3 ~/.claude/scripts/decay.py --dry-run # Test decay
-```
+## Architecture
 
-## Key Implementation Details
+### Data Model
+
+**Long-term memory** (curated, persistent):
+| Tier | File | Loaded |
+|------|------|--------|
+| Global | `global-long-term-memory.md` | Every session |
+| Project | `project-memory/{project}-long-term-memory.md` | When `$PWD` matches |
+
+**Short-term memory** (recent daily summaries):
+| Tier | Default Days | Filter |
+|------|------|--------|
+| Global | 2 | `[global/*]` tagged entries |
+| Project | 5 | `[project-name/*]` tagged entries |
+
+### Entry Formats
+
+**Daily files:** `- [scope/type] Description`
+**Long-term files:** `- (YYYY-MM-DD) [type] Description`
+**Routed entries:** `- [routed][scope/type] Description` (skipped at load time)
+
+| Category | Types |
+|----------|-------|
+| Actions | `implement`, `improve`, `document`, `analyze` |
+| Decisions | `design`, `tradeoff`, `scope` |
+| Learnings | `gotcha`, `pitfall`, `pattern` |
+| Lessons | `insight`, `tip`, `workaround` |
+
+### Key Pipelines
+
+**Loading** (`load_memory.py`): Reads LTM files + filters daily files by scope tags → assembles context string → outputs to stdout for SessionStart hook injection.
+
+**Synthesis** (`synthesis.py` + `synthesis_cron.py`): Extract transcripts → inject scopes from CWD metadata → LLM summarizes → programmatic daily merge → LTM routing with keyword-overlap dedup (threshold 0.6) + route cap (5/file) → update `.synthesis-state.json` offsets.
+
+**Decay** (`decay.py`): Scan LTM files for `(YYYY-MM-DD)` dated entries → archive entries older than threshold → purge expired archives. `## Pinned` section protected.
+
+## Implementation Details
 
 ### Hooks (defined in `install.py` `merge_hooks()`)
-- `SessionStart` - loads memory context
-- `PreToolUse` - auto-approves memory operations (workaround for subagent permission bug)
-- `SessionEnd` - triggers deferred synthesis via systemd
+- `SessionStart` — loads memory context via `load_memory.py`
+- `PreToolUse` — auto-approves operations targeting `.claude/memory` paths
+- `SessionEnd` — triggers deferred synthesis via systemd
 
-Note: Transcripts are read directly from Claude Code's storage (`~/.claude/projects/`), not copied via hooks.
+Transcripts are read directly from `~/.claude/projects/` (source of truth), not copied via hooks.
 
 ### PreToolUse Auto-Approval
-Subagents don't inherit permissions (GitHub #10906, #11934, #18172, #18950). The PreToolUse hook returns `{"permissionDecision": "allow"}` for operations targeting `.claude/memory` paths.
+Subagents don't inherit permissions (GitHub #10906, #11934, #18172, #18950). The hook returns `{"permissionDecision": "allow"}` for `.claude/memory` path operations.
 
 ### Permission Path Formats
 | Format | Meaning |
 |--------|---------|
 | `~/path` | Home-relative (use this) |
 | `//path` | Absolute filesystem path |
-| `/path` | ❌ Relative from settings file |
+| `/path` | Relative from settings file (avoid) |
 
-Note: Only matters for Read permissions; Edit/Write bypass via PreToolUse hook.
+Only matters for Read permissions; Edit/Write bypass via PreToolUse hook.
 
 ### Cross-Platform
-- Uses `pathlib.Path` for paths, `Path.home()` for home dir
-- Directory-based locking (mkdir is atomic everywhere)
+- `pathlib.Path` for paths, `Path.home()` for home dir
+- Directory-based locking (`mkdir` is atomic everywhere)
 - Hook commands use absolute paths generated at install time
 
-## Settings Reference
+## Settings Defaults
 
-Use `/settings` skill to view/modify. Key settings in `~/.claude/memory/settings.json`:
+Source of truth: `DEFAULT_SETTINGS` in `scripts/memory_utils.py`.
 
-| Setting | Default | Notes |
-|---------|---------|-------|
-| `globalShortTerm.workingDays` | 2 | Days of global daily summaries |
-| `projectShortTerm.workingDays` | 5 | Days of project history |
-| `*LongTerm.tokenLimit` | 3,000 | Fixed limit per long-term file |
-| `synthesis.intervalHours` | 2 | Hours between auto-synthesis |
-| `synthesis.model` | sonnet | Model for synthesis subagent |
-| `synthesis.background` | true | Run auto-synthesis in background |
-| `synthesis.deferred` | true | Enable deferred synthesis (systemd timer instead of in-session) |
-| `synthesis.minSessionMessages` | 10 | Skip sessions with fewer messages during synthesis |
-| `decay.ageDays` | 30 | Global LTM: archive after N calendar days |
-| `decay.projectWorkingDays` | 20 | Project LTM: archive after N project work days |
+| Setting | Default |
+|---------|---------|
+| `globalShortTerm.workingDays` | 2 |
+| `globalLongTerm.tokenLimit` | 3,000 |
+| `projectShortTerm.workingDays` | 5 |
+| `projectLongTerm.tokenLimit` | 3,000 |
+| `synthesis.intervalHours` | 2 |
+| `synthesis.model` | sonnet |
+| `synthesis.background` | true |
+| `synthesis.deferred` | true |
+| `synthesis.minSessionMessages` | 10 |
+| `decay.ageDays` | 30 |
+| `decay.projectWorkingDays` | 20 |
+| `decay.archiveRetentionDays` | 365 |
 
-Short-term token limits calculated as `workingDays × 750` (reduced due to scope filtering).
-
-## Features Summary
-
-| Feature | Implementation |
-|---------|----------------|
-| Tag-based filtering | Short-term memory filtered by `[scope/*]` tags; global loads `[global/*]`, project loads `[project/*]`; pipe-delimited `[scope1\|scope2/type]` for multi-scope |
-| Age-based decay | Entries with `(YYYY-MM-DD)` date prefix archived after 30 days; `## Pinned` section protected |
-| Session exclusion | `--exclude-session` flag prevents active session from being synthesized |
-| Direct transcript reading | Reads from `~/.claude/projects/` (source of truth); `.synthesis-state.json` tracks processing state |
-| Mtime-based recency | Sessions filtered by file modification time (default 7 days); stale state entries auto-pruned |
-| Synthesis scheduling | First session of day + every N hours (default 2); `load_memory.py` parses session_id from stdin |
-| Background synthesis | Auto-synthesis runs in background by default (configurable); embedded prompt eliminates SKILL.md read; `synthesis.py` applies output |
-| Zero-tool synthesis | `synthesis.py` parses structured output, applies daily files + LTM routes; `load_memory.py` embeds all inputs in prompt |
-| Incremental synthesis | `.synthesis-state.json` tracks per-session byte offset + line count; skips unchanged, delta-extracts grown sessions; merge context for existing dailies |
-| Project detection | Matches `$PWD` to `projects-index.json`; loads project memory + project-tagged entries |
-| Worktree-aware detection | `resolve_worktree_to_main_repo()` resolves git worktree paths to main repo via `git rev-parse`; falls back to `/.worktrees/` path pattern for deleted worktrees |
-| Deterministic synthesis | Scope injection from session CWD metadata (`inject_scopes`), programmatic daily merge (`merge_daily_sections`), keyword-overlap dedup in LTM (`is_routed_match` 0.6), route cap (5/file); LLM outputs `[type]` + optional `[GLOBAL]`, code handles structure |
-| Deferred synthesis | `synthesis.deferred` setting gates in-session synthesis; `synthesis_cron.py` + systemd timer runs synthesis out-of-session via `claude -p`; SessionEnd hook triggers on session exit |
+Short-term token limits: `workingDays × 750` (calculated in `_calculate_token_limits()`).

--- a/README.md
+++ b/README.md
@@ -1,24 +1,20 @@
 # Claude Code Memory System
 
-A markdown-based memory system for Claude Code that automatically captures session transcripts and provides tools for managing long-term memory.
+A markdown-based memory system for Claude Code that persists context across sessions. Hooks, scripts, and skills automatically capture session transcripts and synthesize them into structured long-term memory.
 
 ## Features
 
-- **Auto-capture**: Full transcripts saved on session end and before compaction
 - **Two-tier memory**: Global patterns (always loaded) + project-specific learnings (loaded when in project), filtered by `[scope/*]` tags
-- **Self-improvement loop**: Errors, best practices, and decisions are automatically extracted and routed to long-term memory
-- **Age-based decay**: Learnings older than 30 days are automatically archived; pinned sections protected from decay
-- **Project-aware loading**: Automatically loads project-specific history (configurable days) when working in a known project directory
-- **Configurable settings**: Token budgets, working days, synthesis scheduling, and decay via `~/.claude/memory/settings.json`
-- **Proactive recall**: Claude automatically searches older memory when historical context would help
-- **Recovery**: Orphaned transcripts from ungraceful exits are recovered automatically on session start
-- **Auto-synthesis**: Scheduled synthesis (first session of day + every N hours) to keep memory fresh; deferred mode runs via systemd timer outside active sessions
-- **Per-date synthesis**: Multi-day backlogs are processed one date at a time, preventing collapse into a single daily file
-- **Error surfacing**: Synthesis failures are logged and surfaced as alerts on the next session start
-- **Manual notes**: `/remember` for specific highlights
-- **Historical search**: `/recall` for searching older memory
-- **Cross-platform**: Works on Windows, macOS, and Linux (Python 3.9+ required)
-- **Shareable**: One-command installation for teammates
+- **Auto-synthesis**: Deferred mode runs via systemd timer outside active sessions; in-session mode available as fallback. Per-date processing ensures multi-day backlogs produce correct daily files
+- **Incremental processing**: Tracks per-session byte offsets to delta-extract only new content; skips unchanged sessions
+- **Deterministic scoping**: Session CWD metadata determines project scope programmatically — no LLM guessing
+- **Age-based decay**: Learnings older than 30 days are automatically archived; pinned sections protected
+- **Project-aware loading**: Loads project-specific history when working in a known project directory, including git worktree resolution
+- **Tag-based filtering**: Daily entries tagged with `[scope/type]` — only matching entries loaded per tier, reducing token waste
+- **Error surfacing**: Synthesis failures logged and surfaced as alerts on next session start
+- **Configurable**: Token budgets, working days, synthesis scheduling, and decay via settings.json
+- **Manual tools**: `/remember` for notes, `/recall` for historical search, `/synthesize` for on-demand processing
+- **Cross-platform**: Works on Windows, macOS, and Linux (Python 3.9+)
 
 ## Installation
 
@@ -30,44 +26,18 @@ python3 install.py    # or: python install.py
 
 Start a new Claude Code session to activate the memory system.
 
-## Permissions
-
-The memory system uses a **PreToolUse hook** to auto-approve memory operations without prompting. This approach works around a Claude Code limitation where subagents don't inherit permissions from `settings.json` ([GitHub #10906](https://github.com/anthropics/claude-code/issues/10906)).
-
-### How It Works
-
-When Claude (or a subagent) calls a tool that targets memory files:
-
-1. The PreToolUse hook (`~/.claude/hooks/pretooluse-allow-memory.sh`) runs before the tool executes
-2. The hook checks if the operation targets `.claude/memory` paths
-3. If yes, it returns `{"permissionDecision": "allow"}` to auto-approve
-4. If no, normal permission flow applies
-
-### What's Auto-Approved
-
-- **Read/Edit/Write** operations on `~/.claude/memory/**`
-- **Skill invocations** for memory skills (synthesize, remember, recall, settings)
-- **Task tool** calls with memory-related prompts
-- **Bash operations** using `~/.claude/scripts/*` (indexing.py, token_usage.py, etc.)
-
-The installer also adds minimal Read permissions for fallback:
-- `Read(~/.claude/**)` - Read memory and skill files
-- `Read(//{home}/.claude/projects/**)` - Read project transcripts for orphan recovery
-
 ## Requirements
 
-- **Python 3.9+** - Required for all platforms
-- **Claude Code CLI** - Must be installed and run at least once (`~/.claude` must exist)
-
-### Platform Notes
+- **Python 3.9+**
+- **Claude Code CLI** — must be installed and run at least once (`~/.claude` must exist)
 
 | Platform | Notes |
 |----------|-------|
 | **Linux** | Fully supported. Use `python3 install.py`. |
 | **macOS** | Fully supported. Use `python3 install.py`. |
-| **Windows** | Best-effort support. Use `python install.py`. Recommended: Use WSL for guaranteed compatibility. |
+| **Windows** | Best-effort. Use `python install.py`. Recommended: WSL for full compatibility. |
 
-The installer automatically detects your Python command (`python3` vs `python`) and configures hooks with absolute paths for cross-platform compatibility.
+The installer detects your Python command and configures hooks with absolute paths.
 
 ## Commands
 
@@ -77,142 +47,175 @@ The installer automatically detects your Python command (`python3` vs `python`) 
 | `/synthesize` | Process transcripts into daily summaries and update long-term memory |
 | `/recall [query]` | Search through all historical daily memory files |
 | `/settings` | View/modify memory settings and check token usage |
-| `/projects` | Manage project data - list status, merge orphans, cleanup stale entries |
+| `/projects` | Manage project data — list status, merge orphans, cleanup stale entries |
 
 ## How It Works
 
 ### Session Lifecycle
 
-1. **Session Start**: Loads long-term memory, global short-term (`[global/*]` entries from last 2 days), and project short-term (`[project/*]` entries from last 7 days). Also recovers any orphaned transcripts and prompts for synthesis if needed.
-2. **During Session**: Use `/remember` to capture important notes; Claude proactively uses `/recall` when historical context would help
-3. **Before Compaction**: Transcript saved (both manual `/compact` and automatic compaction)
-4. **Session End**: Transcript automatically saved to `~/.claude/memory/transcripts/`
+1. **Session Start**: Loads long-term memory + filtered short-term memory. Checks for synthesis errors to surface.
+2. **During Session**: Use `/remember` to capture notes; Claude proactively uses `/recall` for historical context.
+3. **Session End**: Transcript saved. If deferred synthesis is enabled, systemd timer processes it out-of-session.
 
-### Project-Aware Memory Loading
+### Memory Architecture
 
-When you start a session in a project directory, the system automatically loads relevant context filtered by scope tags:
+**Long-term memory** (curated, persistent):
 
-| Context Type | Default | Filter | Description |
-|--------------|---------|--------|-------------|
-| Global short-term | 2 days | `[global/*]` | Only entries tagged with global scope |
-| Project short-term | 7 days | `[project/*]` | Only entries tagged with current project |
+| Tier | File | Loaded | Content |
+|------|------|--------|---------|
+| Global | `global-long-term-memory.md` | Every session | User profile, global patterns |
+| Project | `project-memory/{project}-long-term-memory.md` | When `$PWD` matches | Project-specific learnings |
 
-**Tag-based filtering**: Daily files contain entries tagged with scopes like `[global/implement]` or `[claude-memory-system/gotcha]`. Only matching entries are loaded - global short-term loads `[global/*]` entries, project short-term loads `[project-name/*]` entries. This keeps context relevant and reduces token usage.
+**Short-term memory** (recent daily summaries, filtered by scope tags):
 
-**Working days**: The system scans for daily files with matching tagged content. Days without matching content are skipped.
+| Tier | Source | Default Days | Filter |
+|------|--------|------|--------|
+| Global | `daily/*.md` | 2 | `[global/*]` tagged entries only |
+| Project | `daily/*.md` | 5 | `[project-name/*]` tagged entries only |
 
-**Project detection**: By default, uses exact path match only. Enable `projectSettings.includeSubdirectories` to match `/project/subdir` to `/project/`.
+**Learning flow:**
+```
+Session transcript → Phase 1 → Daily summary (Actions, Decisions, Learnings, Lessons)
+                   → Phase 2 → Route to long-term memory
+                   → Phase 3 → Age-based decay
+```
 
-**Why "project days"?** If you work on a project sporadically (e.g., Jan 25, then Feb 15), all project days of context come from meaningful work sessions - no wasted context on empty days.
+### Tag-Based Filtering
+
+Daily files contain entries tagged with scopes like `[global/implement]` or `[claude-memory-system/gotcha]`. Only matching entries are loaded:
+- `[global/*]` entries → Global short-term memory (every session)
+- `[project-name/*]` entries → Project short-term memory (when in that project)
+- Pipe-delimited `[scope1|scope2/type]` for multi-scope entries
+- Untagged content only appears in raw daily files
+
+### Project Detection
+
+Uses exact `$PWD` match against `projects-index.json`. Enable `projectSettings.includeSubdirectories` to match subdirectories to parent projects. Git worktree paths are resolved to the main repo via `git rev-parse`.
+
+**Working days**: Days without matching tagged content are skipped, so sporadic projects get all their context from meaningful work sessions.
 
 ### Memory Structure
 
 ```
 ~/.claude/memory/
-├── global-long-term-memory.md  # Global patterns, user profile (always loaded)
-├── settings.json               # Memory system configuration
-├── projects-index.json         # Project-to-work-days mapping
-├── .last-synthesis             # UTC timestamp of last synthesis
-├── .decay-archive.md           # Archived learnings (recoverable)
-├── .migration-complete         # One-time migration marker
+├── global-long-term-memory.md    # Global patterns, user profile (always loaded)
+├── settings.json                 # Memory system configuration
+├── projects-index.json           # Project-to-work-days mapping
+├── .last-synthesis               # UTC timestamp of last synthesis
+├── .synthesis-state.json         # Per-session byte offset + line count tracking
+├── .synthesis-errors.log         # Deferred synthesis error log (cleared after read)
+├── .decay-archive.md             # Archived learnings (recoverable)
 ├── daily/
-│   └── YYYY-MM-DD.md           # Summarized daily entries with learnings
+│   └── YYYY-MM-DD.md             # Summarized daily entries with tagged learnings
 ├── project-memory/
-│   └── {project}-long-term-memory.md  # Project-specific learnings (loaded when in project)
-├── transcripts/
-│   └── YYYY-MM-DD/
-│       └── {session_id}.jsonl  # Raw session transcripts (deduplicated by session ID)
-└── .captured                   # Tracks which sessions were already captured
+│   └── {project}-long-term-memory.md  # Project-specific learnings
+└── templates/                    # Default file templates
 ```
 
-**Two-tier memory**: Global memory contains user profile, patterns, and project-agnostic learnings. Project memory contains project-specific learnings and decisions. Both are updated during `/synthesize`.
+### Entry Format
+
+**Daily files** have four sections:
+- `## Actions` — What was done, tagged `[scope/implement]`, `[scope/improve]`, etc.
+- `## Decisions` — Choices with rationale, tagged `[scope/design]`, `[scope/tradeoff]`, etc.
+- `## Learnings` — Patterns/gotchas, tagged `[scope/gotcha]`, `[scope/pattern]`, etc.
+- `## Lessons` — Actionable takeaways, tagged `[scope/insight]`, `[scope/tip]`, etc.
+
+**Long-term files** mirror with `## Key Actions`, `## Key Decisions`, `## Key Learnings`, `## Key Lessons`.
+
+**Long-term entry format**: `- (YYYY-MM-DD) [type] Description` — date prefix enables age-based decay.
+
+Entries routed from daily to LTM are marked `[routed]` in the daily file and skipped at load time.
 
 ### Settings
 
-Configure the memory system via `~/.claude/memory/settings.json` or `/settings set <path> <value>`:
+Configure via `~/.claude/memory/settings.json` or `/settings set <path> <value>`:
 
 ```json
 {
   "globalShortTerm": { "workingDays": 2 },
-  "globalLongTerm": { "tokenLimit": 5000 },
-  "projectShortTerm": { "workingDays": 7 },
-  "projectLongTerm": { "tokenLimit": 5000 },
+  "globalLongTerm": { "tokenLimit": 3000 },
+  "projectShortTerm": { "workingDays": 5 },
+  "projectLongTerm": { "tokenLimit": 3000 },
   "projectSettings": { "includeSubdirectories": false },
-  "synthesis": { "intervalHours": 2 },
-  "decay": { "ageDays": 30, "archiveRetentionDays": 365 }
+  "synthesis": {
+    "intervalHours": 2,
+    "model": "sonnet",
+    "background": true,
+    "deferred": true,
+    "minSessionMessages": 10
+  },
+  "decay": {
+    "ageDays": 30,
+    "projectWorkingDays": 20,
+    "archiveRetentionDays": 365
+  }
 }
 ```
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `globalShortTerm.workingDays` | 2 | Recent days with activity to load |
-| `globalLongTerm.tokenLimit` | 5,000 | Fixed limit for global long-term memory |
-| `projectShortTerm.workingDays` | 7 | Project-specific days to load |
-| `projectLongTerm.tokenLimit` | 5,000 | Fixed limit for project long-term memory |
-| `projectSettings.includeSubdirectories` | false | Match subdirs to parent project |
-| `synthesis.intervalHours` | 2 | Hours between auto-synthesis prompts |
-| `decay.ageDays` | 30 | Archive learnings older than this |
-| `decay.archiveRetentionDays` | 365 | Purge archived items after this |
+| `globalShortTerm.workingDays` | 2 | Recent days of global daily summaries to load |
+| `globalLongTerm.tokenLimit` | 3,000 | Token limit for global long-term memory |
+| `projectShortTerm.workingDays` | 5 | Project-specific days to load |
+| `projectLongTerm.tokenLimit` | 3,000 | Token limit for project long-term memory |
+| `projectSettings.includeSubdirectories` | false | Match subdirectories to parent project |
+| `synthesis.intervalHours` | 2 | Hours between auto-synthesis checks |
+| `synthesis.model` | sonnet | Model for synthesis LLM calls |
+| `synthesis.background` | true | Run in-session synthesis in background |
+| `synthesis.deferred` | true | Use systemd timer instead of in-session synthesis |
+| `synthesis.minSessionMessages` | 10 | Skip sessions with fewer messages |
+| `decay.ageDays` | 30 | Archive global LTM entries older than N days |
+| `decay.projectWorkingDays` | 20 | Archive project LTM entries after N project work days |
+| `decay.archiveRetentionDays` | 365 | Purge archived items after N days |
 
-**Calculated token limits**: Short-term limits are calculated dynamically in `memory_utils.py`:
+**Calculated token limits** (short-term): `workingDays × 750 tokens/day`
 
 | Component | Calculation | Default |
 |-----------|-------------|---------|
-| Global short-term | workingDays × 750 | 1,500 |
-| Global long-term | fixed | 5,000 |
-| Project short-term | workingDays × 750 | 5,250 |
-| Project long-term | fixed | 5,000 |
-| **Total budget** | sum of above | **16,750** |
+| Global short-term | 2 × 750 | 1,500 |
+| Global long-term | fixed | 3,000 |
+| Project short-term | 5 × 750 | 3,750 |
+| Project long-term | fixed | 3,000 |
+| **Total budget** | | **11,250** |
 
-The 750 tokens/day multiplier is based on ~400-600 observed after scope filtering. Short-term memory is filtered by `[scope/*]` tags, so only relevant entries are loaded. To increase short-term limits, change `workingDays`.
-
-Token limits are soft warnings, not hard caps. Use `/settings usage` to check current token consumption.
+Token limits are soft warnings, not hard caps. Use `/settings usage` to check current consumption.
 
 ### Age-Based Decay
 
-Learnings in long-term memory files are subject to automatic archival:
-
 **Protected from decay (auto-pinned):**
 - `## About Me`, `## Current Projects`, `## Technical Environment`, `## Patterns & Preferences`
-- `## Pinned` - move important learnings here to protect them
+- `## Pinned` — move important learnings here to protect them
 
 **Subject to decay:**
 - `## Key Actions`, `## Key Decisions`, `## Key Learnings`, `## Key Lessons`
 
-Learnings with creation dates older than `decay.ageDays` (default: 30) are moved to `~/.claude/memory/.decay-archive.md`. Archived items older than `decay.archiveRetentionDays` (default: 365) are purged.
+Entries with dates older than `decay.ageDays` (default: 30) are moved to `.decay-archive.md`. Archived items older than `decay.archiveRetentionDays` (default: 365) are purged.
 
-**Entry format**: `- (YYYY-MM-DD) [type] Description`
+### Synthesis
 
-The date prefix enables age tracking. Entries without dates are protected from decay.
+**Deferred mode** (default): A systemd user timer runs `synthesis_cron.py` outside active sessions via `claude -p`. SessionEnd hook triggers on session exit. When multiple dates are pending, each is processed as a separate LLM call.
 
-### Synthesis Workflow
+**In-session mode**: First session of day always checks for pending transcripts. Subsequent sessions check every `synthesis.intervalHours`. Runs as a background subagent.
 
-Synthesis is scheduled to balance freshness with efficiency:
+**Error handling**: Failures are logged to `.synthesis-errors.log` and surfaced as an alert on next session start. Eager timestamps are cleared on failure so the next timer interval can retry.
 
-- **First session of day (UTC)**: Always prompts if transcripts pending
-- **Subsequent sessions**: Only prompts if more than `synthesis.intervalHours` since last synthesis
-- **Deferred mode** (default): Synthesis runs outside active sessions via a systemd user timer, avoiding in-session subagent overhead. When multiple dates are pending, each date is processed as a separate LLM call to ensure correct daily file assignment.
-- **Error handling**: If deferred synthesis fails (e.g., `claude` binary not found), errors are logged to `.synthesis-errors.log` and surfaced as an alert on the next session start.
+The synthesis pipeline:
+1. Update project index (maps projects to work days)
+2. Extract and scope transcripts using session CWD metadata
+3. Synthesize into daily summaries with tagged entries
+4. Route significant learnings to long-term memory (keyword-overlap dedup, route cap of 5/file)
+5. Apply age-based decay
+6. Update synthesis state (per-session byte offsets)
 
-Claude spawns a background Sonnet subagent to process transcripts, keeping the main conversation context lean. The model is configurable via `synthesis.model` in settings.
+### Permissions
 
-The synthesis process:
+The memory system uses a **PreToolUse hook** to auto-approve memory operations without prompting. This works around a Claude Code limitation where subagents don't inherit permissions ([GitHub #10906](https://github.com/anthropics/claude-code/issues/10906)).
 
-1. **Phase 0**: Migration check (one-time: adds Pinned sections, dates to learnings)
-2. **Phase 0.5**: Update project index (maps projects to work days)
-3. **Phase 1**: Convert raw transcripts into daily summaries (1-4 KB each) with tagged learnings
-4. **Phase 2**: Route learnings to appropriate long-term memory:
-   - `[global/*]` → `global-long-term-memory.md`
-   - `[{project}/*]` → `project-memory/{project}-long-term-memory.md`
-5. **Phase 3**: Apply age-based decay (archive old learnings, purge expired archives)
-6. **Phase 4**: Update synthesis timestamp
-
-**Action types:** `implement`, `improve`, `document`, `analyze`
-**Decision types:** `design`, `tradeoff`, `scope`
-**Learning types:** `gotcha`, `pitfall`, `pattern`
-**Lesson types:** `insight`, `tip`, `workaround`
-
-**Manual synthesis**: You can also run `/synthesize` at any time to process pending transcripts immediately.
+**What's auto-approved:**
+- Read/Edit/Write operations on `~/.claude/memory/**`
+- Skill invocations for memory skills
+- Task tool calls with memory-related prompts
+- Bash operations using `~/.claude/scripts/*`
 
 ## Uninstallation
 
@@ -227,21 +230,20 @@ python3 uninstall.py --purge   # Remove everything including memory data
 ```bash
 cd claude-memory-system
 git pull
-python3 install.py    # or: python install.py
+python3 install.py
 ```
 
-The installer is idempotent and preserves your existing memory data.
+The installer is idempotent and preserves existing memory data.
 
 ## File Locations
 
 | Component | Location |
 |-----------|----------|
 | Memory data | `~/.claude/memory/` |
-| Memory settings | `~/.claude/memory/settings.json` |
+| Settings | `~/.claude/memory/settings.json` |
 | Project index | `~/.claude/memory/projects-index.json` |
 | Scripts | `~/.claude/scripts/` |
 | Skills | `~/.claude/skills/` |
-| Claude settings | `~/.claude/settings.json` |
 
 ## License
 


### PR DESCRIPTION
## Summary
- Fix stale defaults in README (tokenLimit 5000→3000, workingDays 7→5, total budget 16750→11250) and add 5 missing settings
- Move user-facing content (features table, verbose architecture) from CLAUDE.md to README; add missing features (incremental processing, deterministic scoping, error surfacing)
- Trim CLAUDE.md to dev-focused guide with Key Pipelines section, compact entry format table, reduced context tax (175→130 lines)

## Test plan
- [x] 662 tests pass
- [x] Verified all defaults match `DEFAULT_SETTINGS` in `scripts/memory_utils.py`
- [x] No code changes — docs only

Co-Authored-By: Claude <noreply@anthropic.com>