### PR TITLE
fix(tests): patch SYNTHESIS_ERROR_LOG in two leaking tests

### DIFF
--- a/tests/test_synthesis_cron.py
+++ b/tests/test_synthesis_cron.py
@@ -183,7 +183,8 @@ class TestRunSynthesis:
         with patch("synthesis_cron.should_run_deferred_synthesis", return_value=True), \
              patch("synthesis_cron.write_synthesis_prompt", side_effect=fake_write_prompt), \
              patch("synthesis_cron.subprocess.run") as mock_run, \
-             patch("synthesis_cron.get_last_synthesis_file") as mock_lsf:
+             patch("synthesis_cron.get_last_synthesis_file") as mock_lsf, \
+             patch("synthesis_cron.SYNTHESIS_ERROR_LOG", tmp_path / ".synthesis-errors.log"):
             mock_lsf.return_value = tmp_path / ".last-synthesis"
             mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="some error")
             result = run_synthesis()
@@ -202,7 +203,8 @@ class TestRunSynthesis:
         with patch("synthesis_cron.should_run_deferred_synthesis", return_value=True), \
              patch("synthesis_cron.write_synthesis_prompt", side_effect=fake_write_prompt), \
              patch("synthesis_cron.subprocess.run") as mock_run, \
-             patch("synthesis_cron.get_last_synthesis_file") as mock_lsf:
+             patch("synthesis_cron.get_last_synthesis_file") as mock_lsf, \
+             patch("synthesis_cron.SYNTHESIS_ERROR_LOG", tmp_path / ".synthesis-errors.log"):
             mock_lsf.return_value = tmp_path / ".last-synthesis"
             mock_run.side_effect = real_subprocess.TimeoutExpired(cmd="claude", timeout=300)
             result = run_synthesis()


### PR DESCRIPTION
## Summary
- Two tests (`test_returns_1_on_claude_failure`, `test_returns_1_on_timeout`) wrote to the real `~/.claude/memory/.synthesis-errors.log` because they didn't mock `SYNTHESIS_ERROR_LOG`
- This caused bogus "synthesis-prompt-12345: some error" alerts on session start
- Added missing `patch("synthesis_cron.SYNTHESIS_ERROR_LOG", tmp_path / ...)` to both tests

## Test plan
- [x] 662 tests pass
- [x] Verified no other tests are missing the patch (grep for `run_synthesis` calls without `SYNTHESIS_ERROR_LOG` mock)

Co-Authored-By: Claude <noreply@anthropic.com>