### PR TITLE
fix(decay): rebuild projects index before decay

### DIFF
--- a/scripts/decay.py
+++ b/scripts/decay.py
@@ -14,6 +14,7 @@ Requirements: Python 3.9+
 """
 
 import argparse
+import io
 import re
 import sys
 from datetime import date, datetime, timedelta
@@ -319,8 +320,33 @@ def purge_old_archives(retention_days: int, dry_run: bool = False) -> int:
     return purged_count
 
 
-def run(dry_run: bool = False) -> int:
-    """Run decay on all memory files. Returns 0 on success."""
+def rebuild_projects_index_quiet() -> None:
+    """Rebuild projects-index.json so work days are current before decay."""
+    try:
+        from indexing import build_projects_index
+
+        old_stdout, old_stderr = sys.stdout, sys.stderr
+        sys.stdout = io.StringIO()
+        sys.stderr = io.StringIO()
+        try:
+            build_projects_index()
+        finally:
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+    except Exception:
+        pass  # Best-effort; decay proceeds with stale index if rebuild fails
+
+
+def run(dry_run: bool = False, skip_index_rebuild: bool = False) -> int:
+    """Run decay on all memory files. Returns 0 on success.
+
+    Args:
+        dry_run: Show what would be archived without making changes.
+        skip_index_rebuild: Skip projects-index rebuild (caller already did it).
+    """
+    if not skip_index_rebuild:
+        rebuild_projects_index_quiet()
+
     settings = load_settings()
     age_days = settings.get("decay", {}).get("ageDays", DEFAULT_AGE_DAYS)
     project_working_days = settings.get("decay", {}).get("projectWorkingDays", DEFAULT_PROJECT_WORKING_DAYS)

--- a/scripts/synthesis.py
+++ b/scripts/synthesis.py
@@ -63,6 +63,7 @@ __all__ = [
     "run_mark_routed",
     "run_validate_ltm",
     "run_decay",
+    "_rebuild_projects_index",
     "run_post_processing",
 ]
 
@@ -775,15 +776,36 @@ def run_validate_ltm() -> None:
         pass  # Non-critical
 
 
+def _rebuild_projects_index() -> None:
+    """Rebuild projects-index.json so decay sees current work days."""
+    try:
+        from indexing import build_projects_index
+
+        old_stdout, old_stderr = sys.stdout, sys.stderr
+        sys.stdout = io.StringIO()
+        sys.stderr = io.StringIO()
+        try:
+            build_projects_index()
+        finally:
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+    except Exception:
+        pass  # Non-critical
+
+
 def run_decay() -> None:
-    """Run decay as function call (no subprocess)."""
+    """Run decay as function call (no subprocess).
+
+    Passes skip_index_rebuild=True because run_post_processing already
+    calls _rebuild_projects_index() before invoking this function.
+    """
     try:
         from decay import run as decay_run
 
         old_stdout = sys.stdout
         sys.stdout = io.StringIO()
         try:
-            decay_run(dry_run=False)
+            decay_run(dry_run=False, skip_index_rebuild=True)
         finally:
             sys.stdout = old_stdout
     except Exception:
@@ -812,6 +834,9 @@ def run_post_processing(
             Path(path).unlink(missing_ok=True)
         except OSError:
             pass
+
+    # Rebuild projects index so decay sees current work days
+    _rebuild_projects_index()
 
     # Direct function calls instead of subprocesses
     run_mark_routed()

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from decay import (  # noqa: I001
     ARCHIVE_HEADER_PATTERN,
     DATE_PATTERN,
@@ -26,6 +25,8 @@ from decay import (  # noqa: I001
     parse_learnings,
     parse_sections,
     purge_old_archives,
+    rebuild_projects_index_quiet,
+    run,
     should_decay_entry,
 )
 
@@ -497,6 +498,55 @@ class TestPurgeOldArchives:
             mock_md.return_value = tmp_path
             purged = purge_old_archives(retention_days=DEFAULT_ARCHIVE_RETENTION_DAYS)
             assert purged == 0
+
+
+class TestRebuildProjectsIndexQuiet:
+    """Tests for rebuild_projects_index_quiet helper."""
+
+    def test_calls_build_projects_index(self):
+        """Calls indexing.build_projects_index and suppresses output."""
+        mock_build = mock.MagicMock()
+        fake_indexing = type("m", (), {"build_projects_index": mock_build})()
+        with mock.patch.dict("sys.modules", {"indexing": fake_indexing}):
+            rebuild_projects_index_quiet()
+        mock_build.assert_called_once()
+
+    def test_swallows_import_error(self):
+        """Does not raise when indexing module is unavailable."""
+        with mock.patch.dict("sys.modules", {"indexing": None}):
+            # Should not raise
+            rebuild_projects_index_quiet()
+
+    def test_swallows_runtime_error(self):
+        """Does not raise when build_projects_index raises."""
+        fake_indexing = type("m", (), {"build_projects_index": staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("boom")))})()
+        with mock.patch.dict("sys.modules", {"indexing": fake_indexing}):
+            # Should not raise
+            rebuild_projects_index_quiet()
+
+
+class TestRunRebuildsBeforeDecay:
+    """Tests that run() rebuilds the projects index before decay."""
+
+    def test_run_calls_rebuild_by_default(self, tmp_path):
+        """run() rebuilds projects index when skip_index_rebuild is False."""
+        with mock.patch("decay.rebuild_projects_index_quiet") as mock_rebuild, \
+             mock.patch("decay.load_settings", return_value={}), \
+             mock.patch("decay.get_global_memory_file", return_value=tmp_path / "g.md"), \
+             mock.patch("decay.get_project_memory_dir", return_value=tmp_path / "pm"), \
+             mock.patch("decay.get_memory_dir", return_value=tmp_path):
+            run(dry_run=True)
+        mock_rebuild.assert_called_once()
+
+    def test_run_skips_rebuild_when_requested(self, tmp_path):
+        """run() skips rebuild when skip_index_rebuild=True."""
+        with mock.patch("decay.rebuild_projects_index_quiet") as mock_rebuild, \
+             mock.patch("decay.load_settings", return_value={}), \
+             mock.patch("decay.get_global_memory_file", return_value=tmp_path / "g.md"), \
+             mock.patch("decay.get_project_memory_dir", return_value=tmp_path / "pm"), \
+             mock.patch("decay.get_memory_dir", return_value=tmp_path):
+            run(dry_run=True, skip_index_rebuild=True)
+        mock_rebuild.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -776,7 +776,8 @@ class TestRunPostProcessing:
         extract = tmp_path / "extract.txt"
         extract.write_text("data")
 
-        with patch("synthesis.run_mark_routed"), \
+        with patch("synthesis._rebuild_projects_index"), \
+             patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay"), \
              patch("synthesis.prune_stale_state_entries"):
@@ -786,7 +787,8 @@ class TestRunPostProcessing:
 
     def test_prunes_stale_state(self):
         """Calls prune_stale_state_entries during post-processing."""
-        with patch("synthesis.run_mark_routed"), \
+        with patch("synthesis._rebuild_projects_index"), \
+             patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay"), \
              patch("synthesis.prune_stale_state_entries") as mock_prune:
@@ -796,7 +798,8 @@ class TestRunPostProcessing:
 
     def test_updates_timestamp(self, tmp_path):
         """Writes .last-synthesis timestamp file."""
-        with patch("synthesis.run_mark_routed"), \
+        with patch("synthesis._rebuild_projects_index"), \
+             patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay"), \
              patch("synthesis.prune_stale_state_entries"), \
@@ -1225,7 +1228,8 @@ class TestRunPostProcessingOffsetsCleanup:
         offsets_file = tmp_path / "offsets.json"
         offsets_file.write_text('{"s1": {"offset": 100}}')
 
-        with patch("synthesis.run_mark_routed"), \
+        with patch("synthesis._rebuild_projects_index"), \
+             patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay"), \
              patch("synthesis.prune_stale_state_entries"), \
@@ -1239,7 +1243,8 @@ class TestRunPostProcessingOffsetsCleanup:
 
     def test_no_offsets_no_error(self, tmp_path):
         """run_post_processing works fine without offsets_json."""
-        with patch("synthesis.run_mark_routed"), \
+        with patch("synthesis._rebuild_projects_index"), \
+             patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay"), \
              patch("synthesis.prune_stale_state_entries"), \
@@ -1263,6 +1268,7 @@ class TestRunPostProcessingNoSubprocess:
         """run_post_processing calls run_mark_routed."""
         with patch("synthesis.prune_stale_state_entries"), \
              patch("synthesis.get_memory_dir", return_value=tmp_path), \
+             patch("synthesis._rebuild_projects_index"), \
              patch("synthesis.run_mark_routed") as mock_mr, \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay"):
@@ -1273,6 +1279,7 @@ class TestRunPostProcessingNoSubprocess:
         """run_post_processing calls run_validate_ltm."""
         with patch("synthesis.prune_stale_state_entries"), \
              patch("synthesis.get_memory_dir", return_value=tmp_path), \
+             patch("synthesis._rebuild_projects_index"), \
              patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm") as mock_vl, \
              patch("synthesis.run_decay"):
@@ -1283,11 +1290,43 @@ class TestRunPostProcessingNoSubprocess:
         """run_post_processing calls run_decay."""
         with patch("synthesis.prune_stale_state_entries"), \
              patch("synthesis.get_memory_dir", return_value=tmp_path), \
+             patch("synthesis._rebuild_projects_index"), \
              patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay") as mock_decay:
             run_post_processing(extract_paths=[])
         mock_decay.assert_called_once()
+
+    def test_calls_rebuild_projects_index(self, tmp_path):
+        """run_post_processing rebuilds projects index before decay."""
+        with patch("synthesis.prune_stale_state_entries"), \
+             patch("synthesis.get_memory_dir", return_value=tmp_path), \
+             patch("synthesis._rebuild_projects_index") as mock_rebuild, \
+             patch("synthesis.run_mark_routed"), \
+             patch("synthesis.run_validate_ltm"), \
+             patch("synthesis.run_decay"):
+            run_post_processing(extract_paths=[])
+        mock_rebuild.assert_called_once()
+
+    def test_rebuild_before_decay_ordering(self, tmp_path):
+        """Projects index rebuild runs before decay."""
+        call_order = []
+
+        def track_rebuild():
+            call_order.append("rebuild")
+
+        def track_decay():
+            call_order.append("decay")
+
+        with patch("synthesis.prune_stale_state_entries"), \
+             patch("synthesis.get_memory_dir", return_value=tmp_path), \
+             patch("synthesis._rebuild_projects_index", side_effect=track_rebuild), \
+             patch("synthesis.run_mark_routed"), \
+             patch("synthesis.run_validate_ltm"), \
+             patch("synthesis.run_decay", side_effect=track_decay):
+            run_post_processing(extract_paths=[])
+
+        assert call_order.index("rebuild") < call_order.index("decay")
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- After synthesis processes multiple dates, `projects-index.json` was stale — decay used outdated work day counts, keeping entries longer than intended
- `run_post_processing()` now calls `_rebuild_projects_index()` before decay runs
- `decay.run()` also rebuilds when called standalone (CLI), with `skip_index_rebuild` param to avoid double-rebuild from synthesis

## Test plan
- [x] 669 tests pass (7 new)
- [x] New tests verify rebuild is called, ordering is correct (before decay), and error swallowing works
- [x] Existing `run_post_processing` tests updated to mock new `_rebuild_projects_index`
- [x] `python3 scripts/decay.py --dry-run` confirms correct work day counts after rebuild
- [x] Lint clean (ruff)

Co-Authored-By: Claude <noreply@anthropic.com>