### PR TITLE
refactor: DRY stdout suppression, compile hot-path regexes, fix stale cache

### DIFF
--- a/scripts/decay.py
+++ b/scripts/decay.py
@@ -14,7 +14,6 @@ Requirements: Python 3.9+
 """
 
 import argparse
-import io
 import re
 import sys
 from datetime import date, datetime, timedelta
@@ -36,6 +35,7 @@ from memory_utils import (
     local_today,
     parse_markdown_sections,
     project_name_to_filename,
+    rebuild_projects_index_quiet,
 )
 
 # Default decay thresholds (used as fallbacks when settings.json missing)
@@ -320,33 +320,8 @@ def purge_old_archives(retention_days: int, dry_run: bool = False) -> int:
     return purged_count
 
 
-def rebuild_projects_index_quiet() -> None:
-    """Rebuild projects-index.json so work days are current before decay."""
-    try:
-        from indexing import build_projects_index
-
-        old_stdout, old_stderr = sys.stdout, sys.stderr
-        sys.stdout = io.StringIO()
-        sys.stderr = io.StringIO()
-        try:
-            build_projects_index()
-        finally:
-            sys.stdout = old_stdout
-            sys.stderr = old_stderr
-    except Exception:
-        pass  # Best-effort; decay proceeds with stale index if rebuild fails
-
-
-def run(dry_run: bool = False, skip_index_rebuild: bool = False) -> int:
-    """Run decay on all memory files. Returns 0 on success.
-
-    Args:
-        dry_run: Show what would be archived without making changes.
-        skip_index_rebuild: Skip projects-index rebuild (caller already did it).
-    """
-    if not skip_index_rebuild:
-        rebuild_projects_index_quiet()
-
+def run(dry_run: bool = False) -> int:
+    """Run decay on all memory files. Returns 0 on success."""
     settings = load_settings()
     age_days = settings.get("decay", {}).get("ageDays", DEFAULT_AGE_DAYS)
     project_working_days = settings.get("decay", {}).get("projectWorkingDays", DEFAULT_PROJECT_WORKING_DAYS)
@@ -415,6 +390,7 @@ def main() -> int:
         help="Show what would be archived/purged without making changes"
     )
     args = parser.parse_args()
+    rebuild_projects_index_quiet()
     return run(dry_run=args.dry_run)
 
 

--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -36,6 +36,7 @@ from memory_utils import (
     get_memory_dir,
     get_project_memory_dir,
     get_projects_index_file,
+    get_synthesis_error_log,
     get_working_days,
     load_json_file,
     load_settings,
@@ -71,7 +72,7 @@ SYNTHESIS_PROMPT_DIR = "/tmp"
 # =============================================================================
 
 
-SYNTHESIS_ERROR_LOG = get_memory_dir() / ".synthesis-errors.log"
+SYNTHESIS_ERROR_LOG = get_synthesis_error_log()
 
 
 def get_last_synthesis_file() -> Path:
@@ -694,9 +695,8 @@ def main() -> None:
     print("<memory>")
 
     # Include current local time for context
-    now = datetime.now()
-    utc_now = datetime.now(timezone.utc)
-    utc_offset_hours = (now - utc_now.replace(tzinfo=None)).total_seconds() / 3600
+    now = datetime.now(timezone.utc).astimezone()
+    utc_offset_hours = now.utcoffset().total_seconds() / 3600
     offset_sign = "+" if utc_offset_hours >= 0 else ""
     print(f"Current time: {now.strftime('%Y-%m-%d %H:%M')} (UTC{offset_sign}{utc_offset_hours:.0f})")
     print()

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -8,6 +8,8 @@ and file locking. Used by load_memory.py, indexing.py, and other scripts.
 Requirements: Python 3.9+
 """
 
+import contextlib
+import io
 import json
 import os
 import re
@@ -40,6 +42,7 @@ __all__ = [
     "get_settings_file",
     "get_projects_index_file",
     "get_global_memory_file",
+    "get_synthesis_error_log",
     "collect_ltm_files",
     "resolve_worktree_to_main_repo",
     # Settings
@@ -70,6 +73,7 @@ __all__ = [
     "project_name_to_filename",
     "extract_entry_keywords",
     "is_routed_match",
+    "rebuild_projects_index_quiet",
     "FileLock",
 ]
 
@@ -194,6 +198,11 @@ def get_global_memory_file() -> Path:
     return get_memory_dir() / "global-long-term-memory.md"
 
 
+def get_synthesis_error_log() -> Path:
+    """Get the synthesis error log file path."""
+    return get_memory_dir() / ".synthesis-errors.log"
+
+
 # Token limit formulas
 SHORT_TERM_TOKENS_PER_DAY = 750  # With scope filtering, ~400-600 observed per day
 
@@ -315,6 +324,19 @@ def estimate_tokens(text: str) -> int:
     This is a rough estimate that works reasonably well for English text.
     """
     return len(text) // 4
+
+
+def rebuild_projects_index_quiet() -> None:
+    """Rebuild projects-index.json, suppressing output. Best-effort."""
+    try:
+        from indexing import build_projects_index
+
+        with contextlib.redirect_stdout(io.StringIO()), \
+             contextlib.redirect_stderr(io.StringIO()):
+            build_projects_index()
+    except Exception:
+        pass
+    _clear_projects_index_cache()
 
 
 class FileLock:
@@ -513,6 +535,11 @@ def get_working_days(days_limit: int) -> list[str]:
 # Regex to extract scope(s) from tagged entries: [scope/type] or [scope1|scope2/type]
 TAG_PATTERN = re.compile(r"^\s*-\s*\[([^\]/]+(?:\|[^\]/]+)*)(?:/[^\]]+)?\]")
 
+# Pre-compiled patterns for filter_daily_content hot path (runs every SessionStart)
+_COMMENT_LINE_RE = re.compile(r"^\s*<!--.*-->\s*$")
+_ROUTED_PREFIX_RE = re.compile(r"^\s*-\s*\[routed\]")
+_DATE_ONLY_RE = re.compile(r"^#\s+\d{4}-\d{2}-\d{2}\s*$")
+
 
 def filter_daily_content(content: str, scope: str) -> str:
     """
@@ -558,11 +585,11 @@ def filter_daily_content(content: str, scope: str) -> str:
         # If we're in a section, process the line
         if current_section:
             # Skip HTML comments (template hints, not useful at load time)
-            if re.match(r"^\s*<!--.*-->\s*$", line):
+            if _COMMENT_LINE_RE.match(line):
                 continue
 
             # Skip entries marked as routed to LTM
-            if re.match(r"^\s*-\s*\[routed\]", line):
+            if _ROUTED_PREFIX_RE.match(line):
                 continue
 
             # Check if this is a tagged entry
@@ -593,7 +620,7 @@ def filter_daily_content(content: str, scope: str) -> str:
     filtered = "\n".join(result_lines)
 
     # Only return content if we have more than just the date header
-    if filtered.strip() and not re.match(r"^#\s+\d{4}-\d{2}-\d{2}\s*$", filtered.strip()):
+    if filtered.strip() and not _DATE_ONLY_RE.match(filtered.strip()):
         return filtered
     return ""
 

--- a/scripts/synthesis.py
+++ b/scripts/synthesis.py
@@ -15,6 +15,7 @@ Requirements: Python 3.9+
 """
 
 import argparse
+import contextlib
 import io
 import json
 import re
@@ -37,6 +38,7 @@ from memory_utils import (  # noqa: E402
     is_routed_match,
     parse_markdown_sections,
     prune_stale_state_entries,
+    rebuild_projects_index_quiet,
     update_synthesis_state,
 )
 
@@ -63,7 +65,6 @@ __all__ = [
     "run_mark_routed",
     "run_validate_ltm",
     "run_decay",
-    "_rebuild_projects_index",
     "run_post_processing",
 ]
 
@@ -749,13 +750,8 @@ def run_mark_routed() -> None:
     try:
         from devtools import cmd_mark_routed
 
-        old_stdout = sys.stdout
-        sys.stdout = io.StringIO()
-        try:
-            args = argparse.Namespace(dry_run=False)
-            cmd_mark_routed(args)
-        finally:
-            sys.stdout = old_stdout
+        with contextlib.redirect_stdout(io.StringIO()):
+            cmd_mark_routed(argparse.Namespace(dry_run=False))
     except Exception:
         pass  # Non-critical
 
@@ -765,49 +761,19 @@ def run_validate_ltm() -> None:
     try:
         from devtools import cmd_validate_ltm
 
-        old_stdout = sys.stdout
-        sys.stdout = io.StringIO()
-        try:
-            args = argparse.Namespace()
-            cmd_validate_ltm(args)
-        finally:
-            sys.stdout = old_stdout
-    except Exception:
-        pass  # Non-critical
-
-
-def _rebuild_projects_index() -> None:
-    """Rebuild projects-index.json so decay sees current work days."""
-    try:
-        from indexing import build_projects_index
-
-        old_stdout, old_stderr = sys.stdout, sys.stderr
-        sys.stdout = io.StringIO()
-        sys.stderr = io.StringIO()
-        try:
-            build_projects_index()
-        finally:
-            sys.stdout = old_stdout
-            sys.stderr = old_stderr
+        with contextlib.redirect_stdout(io.StringIO()):
+            cmd_validate_ltm(argparse.Namespace())
     except Exception:
         pass  # Non-critical
 
 
 def run_decay() -> None:
-    """Run decay as function call (no subprocess).
-
-    Passes skip_index_rebuild=True because run_post_processing already
-    calls _rebuild_projects_index() before invoking this function.
-    """
+    """Run decay as function call (no subprocess)."""
     try:
         from decay import run as decay_run
 
-        old_stdout = sys.stdout
-        sys.stdout = io.StringIO()
-        try:
-            decay_run(dry_run=False, skip_index_rebuild=True)
-        finally:
-            sys.stdout = old_stdout
+        with contextlib.redirect_stdout(io.StringIO()):
+            decay_run(dry_run=False)
     except Exception:
         pass  # Non-critical
 
@@ -836,7 +802,7 @@ def run_post_processing(
             pass
 
     # Rebuild projects index so decay sees current work days
-    _rebuild_projects_index()
+    rebuild_projects_index_quiet()
 
     # Direct function calls instead of subprocesses
     run_mark_routed()

--- a/scripts/synthesis_cron.py
+++ b/scripts/synthesis_cron.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 import argparse
+import contextlib
 import io
 import os
 import subprocess
@@ -25,9 +26,9 @@ from load_memory import (
     should_synthesize,
     write_synthesis_prompt,
 )
-from memory_utils import get_memory_dir, load_settings
+from memory_utils import get_synthesis_error_log, load_settings
 
-SYNTHESIS_ERROR_LOG = get_memory_dir() / ".synthesis-errors.log"
+SYNTHESIS_ERROR_LOG = get_synthesis_error_log()
 
 
 def should_run_deferred_synthesis() -> bool:
@@ -103,12 +104,9 @@ def run_synthesis(force: bool = False) -> int:
         return 0
 
     # Capture write_synthesis_prompt output to parse model + prompt_file
-    old_stdout = sys.stdout
-    sys.stdout = captured = io.StringIO()
-    try:
+    captured = io.StringIO()
+    with contextlib.redirect_stdout(captured):
         write_synthesis_prompt()
-    finally:
-        sys.stdout = old_stdout
 
     output = captured.getvalue()
 

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -21,14 +21,14 @@ from decay import (  # noqa: I001
     decay_file,
     is_decay_eligible,
     is_protected_section,
+    main,
     parse_learning_date,
     parse_learnings,
     parse_sections,
     purge_old_archives,
-    rebuild_projects_index_quiet,
-    run,
     should_decay_entry,
 )
+from memory_utils import rebuild_projects_index_quiet
 
 # =============================================================================
 # Date Parsing Tests
@@ -519,34 +519,23 @@ class TestRebuildProjectsIndexQuiet:
 
     def test_swallows_runtime_error(self):
         """Does not raise when build_projects_index raises."""
-        fake_indexing = type("m", (), {"build_projects_index": staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("boom")))})()
+        mock_build = mock.MagicMock(side_effect=RuntimeError("boom"))
+        fake_indexing = type("m", (), {"build_projects_index": mock_build})()
         with mock.patch.dict("sys.modules", {"indexing": fake_indexing}):
-            # Should not raise
             rebuild_projects_index_quiet()
 
 
-class TestRunRebuildsBeforeDecay:
-    """Tests that run() rebuilds the projects index before decay."""
+class TestMainCallsRebuild:
+    """Tests that main() calls rebuild_projects_index_quiet before run()."""
 
-    def test_run_calls_rebuild_by_default(self, tmp_path):
-        """run() rebuilds projects index when skip_index_rebuild is False."""
+    def test_main_calls_rebuild_before_run(self, tmp_path):
+        """main() rebuilds projects index before invoking run()."""
         with mock.patch("decay.rebuild_projects_index_quiet") as mock_rebuild, \
-             mock.patch("decay.load_settings", return_value={}), \
-             mock.patch("decay.get_global_memory_file", return_value=tmp_path / "g.md"), \
-             mock.patch("decay.get_project_memory_dir", return_value=tmp_path / "pm"), \
-             mock.patch("decay.get_memory_dir", return_value=tmp_path):
-            run(dry_run=True)
+             mock.patch("decay.run", return_value=0) as mock_run, \
+             mock.patch("sys.argv", ["decay.py"]):
+            main()
         mock_rebuild.assert_called_once()
-
-    def test_run_skips_rebuild_when_requested(self, tmp_path):
-        """run() skips rebuild when skip_index_rebuild=True."""
-        with mock.patch("decay.rebuild_projects_index_quiet") as mock_rebuild, \
-             mock.patch("decay.load_settings", return_value={}), \
-             mock.patch("decay.get_global_memory_file", return_value=tmp_path / "g.md"), \
-             mock.patch("decay.get_project_memory_dir", return_value=tmp_path / "pm"), \
-             mock.patch("decay.get_memory_dir", return_value=tmp_path):
-            run(dry_run=True, skip_index_rebuild=True)
-        mock_rebuild.assert_not_called()
+        mock_run.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -776,7 +776,7 @@ class TestRunPostProcessing:
         extract = tmp_path / "extract.txt"
         extract.write_text("data")
 
-        with patch("synthesis._rebuild_projects_index"), \
+        with patch("synthesis.rebuild_projects_index_quiet"), \
              patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay"), \
@@ -787,7 +787,7 @@ class TestRunPostProcessing:
 
     def test_prunes_stale_state(self):
         """Calls prune_stale_state_entries during post-processing."""
-        with patch("synthesis._rebuild_projects_index"), \
+        with patch("synthesis.rebuild_projects_index_quiet"), \
              patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay"), \
@@ -798,7 +798,7 @@ class TestRunPostProcessing:
 
     def test_updates_timestamp(self, tmp_path):
         """Writes .last-synthesis timestamp file."""
-        with patch("synthesis._rebuild_projects_index"), \
+        with patch("synthesis.rebuild_projects_index_quiet"), \
              patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay"), \
@@ -1228,7 +1228,7 @@ class TestRunPostProcessingOffsetsCleanup:
         offsets_file = tmp_path / "offsets.json"
         offsets_file.write_text('{"s1": {"offset": 100}}')
 
-        with patch("synthesis._rebuild_projects_index"), \
+        with patch("synthesis.rebuild_projects_index_quiet"), \
              patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay"), \
@@ -1243,7 +1243,7 @@ class TestRunPostProcessingOffsetsCleanup:
 
     def test_no_offsets_no_error(self, tmp_path):
         """run_post_processing works fine without offsets_json."""
-        with patch("synthesis._rebuild_projects_index"), \
+        with patch("synthesis.rebuild_projects_index_quiet"), \
              patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay"), \
@@ -1268,7 +1268,7 @@ class TestRunPostProcessingNoSubprocess:
         """run_post_processing calls run_mark_routed."""
         with patch("synthesis.prune_stale_state_entries"), \
              patch("synthesis.get_memory_dir", return_value=tmp_path), \
-             patch("synthesis._rebuild_projects_index"), \
+             patch("synthesis.rebuild_projects_index_quiet"), \
              patch("synthesis.run_mark_routed") as mock_mr, \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay"):
@@ -1279,7 +1279,7 @@ class TestRunPostProcessingNoSubprocess:
         """run_post_processing calls run_validate_ltm."""
         with patch("synthesis.prune_stale_state_entries"), \
              patch("synthesis.get_memory_dir", return_value=tmp_path), \
-             patch("synthesis._rebuild_projects_index"), \
+             patch("synthesis.rebuild_projects_index_quiet"), \
              patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm") as mock_vl, \
              patch("synthesis.run_decay"):
@@ -1290,7 +1290,7 @@ class TestRunPostProcessingNoSubprocess:
         """run_post_processing calls run_decay."""
         with patch("synthesis.prune_stale_state_entries"), \
              patch("synthesis.get_memory_dir", return_value=tmp_path), \
-             patch("synthesis._rebuild_projects_index"), \
+             patch("synthesis.rebuild_projects_index_quiet"), \
              patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay") as mock_decay:
@@ -1301,7 +1301,7 @@ class TestRunPostProcessingNoSubprocess:
         """run_post_processing rebuilds projects index before decay."""
         with patch("synthesis.prune_stale_state_entries"), \
              patch("synthesis.get_memory_dir", return_value=tmp_path), \
-             patch("synthesis._rebuild_projects_index") as mock_rebuild, \
+             patch("synthesis.rebuild_projects_index_quiet") as mock_rebuild, \
              patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay"):
@@ -1320,7 +1320,7 @@ class TestRunPostProcessingNoSubprocess:
 
         with patch("synthesis.prune_stale_state_entries"), \
              patch("synthesis.get_memory_dir", return_value=tmp_path), \
-             patch("synthesis._rebuild_projects_index", side_effect=track_rebuild), \
+             patch("synthesis.rebuild_projects_index_quiet", side_effect=track_rebuild), \
              patch("synthesis.run_mark_routed"), \
              patch("synthesis.run_validate_ltm"), \
              patch("synthesis.run_decay", side_effect=track_decay):


### PR DESCRIPTION
## Summary
- Replace manual stdout save/redirect/restore with `contextlib.redirect_stdout/stderr` across 5 call sites
- Compile 3 regexes at module level in `filter_daily_content()` (SessionStart hot path)
- Fix stale `_projects_index_cache` after `rebuild_projects_index_quiet()` — was serving pre-rebuild data in same process
- Consolidate `SYNTHESIS_ERROR_LOG` path into `get_synthesis_error_log()` in `memory_utils` (was duplicated)
- Replace two `datetime.now()` calls with one in `load_memory.main()`
- Add missing test for `decay.main()` calling rebuild

## Test plan
- [x] 668 tests pass
- [x] Lint checks pass (stop hook)
- [x] Net -44 lines (75 insertions, 119 deletions)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>