### PR TITLE
feat: entity backfill script for existing chunks (#48)

### DIFF
--- a/install.py
+++ b/install.py
@@ -155,6 +155,7 @@ def link_scripts(script_dir: Path) -> None:
         "simhash.py",  # SimHash fingerprinting for near-duplicate detection
         "chunking.py",  # Chunk LTM and daily files for text processing
         "embeddings.py",  # Vector embedding and semantic search
+        "backfill.py",  # One-time entity re-extraction for existing chunks
     ]
 
     for script_name in scripts_to_link:

--- a/scripts/backfill.py
+++ b/scripts/backfill.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""One-time entity backfill for existing chunks.
+
+Re-extracts entities for all chunks in memory.db where the entities
+column is NULL. Uses Sonnet via 'claude -p' for high-quality extraction.
+
+Idempotent: safe to re-run (skips chunks with entities already set).
+
+Usage:
+    python3 backfill.py              # Run entity extraction
+    python3 backfill.py --dry-run    # Show what would be processed
+    python3 backfill.py --batch-size 25  # Custom batch size
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from storage import ensure_db, close_db, query_chunk_by_id  # noqa: E402
+
+BATCH_SIZE = 50
+MODEL = "sonnet"
+
+
+def get_chunks_needing_entities(conn) -> list[tuple[str, str]]:
+    """Query chunks where entities IS NULL. Returns list of (id, content)."""
+    rows = conn.execute(
+        "SELECT id, content FROM chunks WHERE entities IS NULL"
+    ).fetchall()
+    return [(r[0], r[1]) for r in rows]
+
+
+def build_extraction_prompt(chunks: list[tuple[str, str]]) -> str:
+    """Build a prompt for entity extraction from a batch of chunks."""
+    chunk_lines = []
+    for cid, content in chunks:
+        chunk_lines.append(f"[{cid}] {content}")
+    chunks_block = "\n".join(chunk_lines)
+
+    return (
+        "Extract structured entities from each memory chunk below.\n"
+        "For each chunk ID, return a JSON object with the chunk_id and an entities array.\n"
+        "\n"
+        "Entities to extract: project names, library/tool names, programming languages,\n"
+        "concepts, people, URLs, dates, file paths.\n"
+        "\n"
+        "Output ONLY valid JSON, no prose:\n"
+        '{"results": [\n'
+        '  {"chunk_id": "abc123", "entities": ["Python", "pytest", "TDD"]},\n'
+        "  ...\n"
+        "]}\n"
+        "\n"
+        f"Chunks:\n{chunks_block}"
+    )
+
+
+def extract_entities_batch(chunks: list[tuple[str, str]]) -> dict[str, list[str]]:
+    """Call Sonnet to extract entities for a batch of chunks.
+
+    Returns dict mapping chunk_id -> entities list.
+    """
+    prompt = build_extraction_prompt(chunks)
+    try:
+        result = subprocess.run(
+            ["claude", "-p", "--model", MODEL, "--no-session-persistence"],
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            print(f"Warning: claude -p failed: {result.stderr[:200]}", file=sys.stderr)
+            return {}
+
+        output = result.stdout.strip()
+        parsed = json.loads(output)
+        return {
+            r["chunk_id"]: r.get("entities", [])
+            for r in parsed.get("results", [])
+        }
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, KeyError) as e:
+        print(f"Warning: Entity extraction failed: {e}", file=sys.stderr)
+        return {}
+
+
+def run_backfill(dry_run: bool = False, batch_size: int = BATCH_SIZE) -> int:
+    """Run entity backfill on all chunks missing entities."""
+    conn = ensure_db()
+    try:
+        chunks = get_chunks_needing_entities(conn)
+        total = len(chunks)
+
+        if total == 0:
+            print("No chunks need entity extraction.")
+            return 0
+
+        if dry_run:
+            num_batches = (total + batch_size - 1) // batch_size
+            print(f"DRY RUN: {total} chunks would be processed in "
+                  f"{num_batches} batches")
+            return 0
+
+        processed = 0
+        for i in range(0, total, batch_size):
+            batch = chunks[i:i + batch_size]
+            results = extract_entities_batch(batch)
+
+            for cid, entities in results.items():
+                entities_json = json.dumps(entities)
+                conn.execute(
+                    "UPDATE chunks SET entities = ? WHERE id = ?",
+                    (entities_json, cid),
+                )
+                processed += 1
+
+            conn.commit()
+            print(f"Processed {min(i + batch_size, total)}/{total} chunks")
+
+        print(f"Backfill complete: {processed}/{total} chunks updated")
+        return 0
+
+    finally:
+        close_db(conn)
+
+
+def main() -> int:
+    """CLI entry point for entity backfill."""
+    parser = argparse.ArgumentParser(
+        description="Entity backfill for memory chunks"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be processed without changes",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=BATCH_SIZE,
+        help=f"Chunks per LLM call (default {BATCH_SIZE})",
+    )
+    args = parser.parse_args()
+    return run_backfill(dry_run=args.dry_run, batch_size=args.batch_size)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""
+Unit tests for scripts/backfill.py entity re-extraction.
+
+Tests cover: idempotent skip, progress reporting, Sonnet model selection,
+batch processing, dry-run mode, and LLM failure handling.
+
+Run with: python3 -m pytest tests/test_backfill.py -v
+"""
+
+import json
+from unittest import mock
+
+import pytest
+
+from storage import ChunkRow, close_db, ensure_db, insert_chunk, query_chunk_by_id
+from backfill import (
+    BATCH_SIZE,
+    MODEL,
+    build_extraction_prompt,
+    extract_entities_batch,
+    get_chunks_needing_entities,
+    run_backfill,
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def db_dir(tmp_path):
+    """Provide a temporary directory for the DB and patch get_db_path."""
+    db_path = tmp_path / "memory.db"
+    with mock.patch("storage.get_db_path", return_value=db_path), \
+         mock.patch("backfill.ensure_db") as mock_ensure, \
+         mock.patch("backfill.close_db"):
+        conn = ensure_db()
+        mock_ensure.return_value = conn
+        yield tmp_path, conn
+    close_db(conn)
+
+
+@pytest.fixture
+def db(db_dir):
+    """Return the connection from db_dir fixture."""
+    return db_dir[1]
+
+
+def _insert_test_chunk(conn, chunk_id, content, entities=None):
+    """Helper to insert a chunk with specific id and optional entities."""
+    chunk = ChunkRow(
+        id=chunk_id,
+        content=content,
+        source_file="test.md",
+        source_type="ltm",
+        scope="global",
+        entities=entities,
+    )
+    insert_chunk(conn, chunk)
+    conn.commit()
+
+
+def _make_llm_response(chunk_entity_map):
+    """Build a mock LLM JSON response from a dict of {chunk_id: [entities]}."""
+    results = [
+        {"chunk_id": cid, "entities": ents}
+        for cid, ents in chunk_entity_map.items()
+    ]
+    return json.dumps({"results": results})
+
+
+# ============================================================================
+# get_chunks_needing_entities
+# ============================================================================
+
+
+class TestGetChunksNeedingEntities:
+    """Tests for get_chunks_needing_entities query."""
+
+    def test_returns_only_null_entities(self, db_dir):
+        db = db_dir[1]
+        _insert_test_chunk(db, "c1", "chunk one", entities=None)
+        _insert_test_chunk(db, "c2", "chunk two", entities=json.dumps(["Python"]))
+        _insert_test_chunk(db, "c3", "chunk three", entities=None)
+
+        result = get_chunks_needing_entities(db)
+        ids = [r[0] for r in result]
+
+        assert "c1" in ids
+        assert "c3" in ids
+        assert "c2" not in ids
+
+    def test_returns_empty_when_all_have_entities(self, db_dir):
+        db = db_dir[1]
+        _insert_test_chunk(db, "c1", "chunk one", entities=json.dumps(["A"]))
+
+        result = get_chunks_needing_entities(db)
+        assert result == []
+
+
+# ============================================================================
+# build_extraction_prompt
+# ============================================================================
+
+
+class TestBuildExtractionPrompt:
+    """Tests for the prompt builder."""
+
+    def test_includes_chunk_ids_and_content(self):
+        chunks = [("id1", "some content"), ("id2", "other content")]
+        prompt = build_extraction_prompt(chunks)
+
+        assert "[id1] some content" in prompt
+        assert "[id2] other content" in prompt
+
+    def test_includes_json_format_instruction(self):
+        prompt = build_extraction_prompt([("x", "y")])
+        assert "JSON" in prompt
+        assert "chunk_id" in prompt
+        assert "entities" in prompt
+
+
+# ============================================================================
+# extract_entities_batch
+# ============================================================================
+
+
+class TestExtractEntitiesBatch:
+    """Tests for LLM entity extraction."""
+
+    def test_uses_sonnet_model(self):
+        """Backfill command uses Sonnet model specifically."""
+        assert MODEL == "sonnet"
+
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = _make_llm_response({"c1": ["Python"]})
+        mock_result.stderr = ""
+
+        with mock.patch("backfill.subprocess.run", return_value=mock_result) as mock_run:
+            extract_entities_batch([("c1", "content")])
+            call_args = mock_run.call_args[0][0]
+            assert "--model" in call_args
+            model_idx = call_args.index("--model")
+            assert call_args[model_idx + 1] == MODEL
+
+    def test_returns_entity_map(self):
+        """Successful LLM call returns chunk_id -> entities mapping."""
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = _make_llm_response({
+            "c1": ["Python", "pytest"],
+            "c2": ["JavaScript"],
+        })
+        mock_result.stderr = ""
+
+        with mock.patch("backfill.subprocess.run", return_value=mock_result):
+            result = extract_entities_batch([("c1", "content1"), ("c2", "content2")])
+
+        assert result == {"c1": ["Python", "pytest"], "c2": ["JavaScript"]}
+
+    def test_returns_empty_on_nonzero_exit(self):
+        """Non-zero exit code returns empty dict."""
+        mock_result = mock.Mock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "error"
+
+        with mock.patch("backfill.subprocess.run", return_value=mock_result):
+            result = extract_entities_batch([("c1", "content")])
+
+        assert result == {}
+
+    def test_returns_empty_on_invalid_json(self):
+        """Invalid JSON output returns empty dict."""
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = "not valid json"
+        mock_result.stderr = ""
+
+        with mock.patch("backfill.subprocess.run", return_value=mock_result):
+            result = extract_entities_batch([("c1", "content")])
+
+        assert result == {}
+
+    def test_returns_empty_on_timeout(self):
+        """Timeout returns empty dict."""
+        import subprocess as sp
+        with mock.patch("backfill.subprocess.run", side_effect=sp.TimeoutExpired("cmd", 120)):
+            result = extract_entities_batch([("c1", "content")])
+
+        assert result == {}
+
+
+# ============================================================================
+# run_backfill
+# ============================================================================
+
+
+class TestRunBackfill:
+    """Tests for the main backfill orchestrator."""
+
+    def test_skips_chunks_with_entities(self, db_dir, capsys):
+        """Idempotent: chunks where entities IS NOT NULL are skipped."""
+        db = db_dir[1]
+        _insert_test_chunk(db, "c1", "chunk one", entities=None)
+        _insert_test_chunk(db, "c2", "chunk two", entities=json.dumps(["Python"]))
+        _insert_test_chunk(db, "c3", "chunk three", entities=None)
+
+        llm_response = _make_llm_response({
+            "c1": ["Go", "concurrency"],
+            "c3": ["Rust", "async"],
+        })
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = llm_response
+        mock_result.stderr = ""
+
+        with mock.patch("backfill.subprocess.run", return_value=mock_result):
+            rc = run_backfill()
+
+        assert rc == 0
+        assert query_chunk_by_id(db, "c1").entities == json.dumps(["Go", "concurrency"])
+        assert query_chunk_by_id(db, "c3").entities == json.dumps(["Rust", "async"])
+        assert query_chunk_by_id(db, "c2").entities == json.dumps(["Python"])
+
+    def test_processes_chunks_without_entities(self, db_dir):
+        """Chunks where entities IS NULL are sent for extraction."""
+        db = db_dir[1]
+        _insert_test_chunk(db, "c1", "chunk about Python", entities=None)
+        _insert_test_chunk(db, "c2", "chunk about JS", entities=None)
+
+        llm_response = _make_llm_response({
+            "c1": ["Python"],
+            "c2": ["JavaScript"],
+        })
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = llm_response
+        mock_result.stderr = ""
+
+        with mock.patch("backfill.subprocess.run", return_value=mock_result):
+            rc = run_backfill()
+
+        assert rc == 0
+        assert query_chunk_by_id(db, "c1").entities == json.dumps(["Python"])
+        assert query_chunk_by_id(db, "c2").entities == json.dumps(["JavaScript"])
+
+    def test_progress_reporting(self, db_dir, capsys):
+        """Prints progress: 'Processed N/M chunks'."""
+        db = db_dir[1]
+        for i in range(5):
+            _insert_test_chunk(db, f"c{i}", f"chunk {i}", entities=None)
+
+        entity_map = {f"c{i}": [f"entity{i}"] for i in range(5)}
+        llm_response = _make_llm_response(entity_map)
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = llm_response
+        mock_result.stderr = ""
+
+        with mock.patch("backfill.subprocess.run", return_value=mock_result):
+            run_backfill()
+
+        output = capsys.readouterr().out
+        assert "5/5 chunks" in output
+
+    def test_batch_size_respected(self, db_dir):
+        """Chunks are batched (max BATCH_SIZE per LLM call)."""
+        db = db_dir[1]
+        chunk_count = BATCH_SIZE * 2 + 10
+        for i in range(chunk_count):
+            _insert_test_chunk(db, f"c{i}", f"chunk {i}", entities=None)
+
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            prompt_input = kwargs.get("input", "")
+            chunk_ids = []
+            for line in prompt_input.split("\n"):
+                if line.startswith("[c"):
+                    cid = line.split("]")[0].lstrip("[")
+                    chunk_ids.append(cid)
+            entity_map = {cid: ["entity"] for cid in chunk_ids}
+            mock_result.stdout = _make_llm_response(entity_map)
+            return mock_result
+
+        with mock.patch("backfill.subprocess.run", side_effect=side_effect):
+            run_backfill(batch_size=BATCH_SIZE)
+
+        expected_batches = (chunk_count + BATCH_SIZE - 1) // BATCH_SIZE
+        assert call_count == expected_batches
+
+    def test_idempotent_rerun(self, db_dir):
+        """Running backfill twice processes zero chunks on second run."""
+        db = db_dir[1]
+        _insert_test_chunk(db, "c1", "chunk one", entities=None)
+
+        llm_response = _make_llm_response({"c1": ["Python"]})
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = llm_response
+        mock_result.stderr = ""
+
+        with mock.patch("backfill.subprocess.run", return_value=mock_result) as mock_run:
+            run_backfill()
+            mock_run.reset_mock()
+
+            run_backfill()
+            mock_run.assert_not_called()
+
+    def test_handles_llm_failure_gracefully(self, db_dir, capsys):
+        """LLM call failure logs warning, continues with next batch."""
+        db = db_dir[1]
+        for i in range(BATCH_SIZE + 5):
+            _insert_test_chunk(db, f"c{i}", f"chunk {i}", entities=None)
+
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = mock.Mock()
+            result.stderr = ""
+            if call_count == 1:
+                result.returncode = 1
+                result.stdout = ""
+                result.stderr = "API error"
+            else:
+                prompt_input = kwargs.get("input", "")
+                chunk_ids = []
+                for line in prompt_input.split("\n"):
+                    if line.startswith("[c"):
+                        cid = line.split("]")[0].lstrip("[")
+                        chunk_ids.append(cid)
+                entity_map = {cid: ["entity"] for cid in chunk_ids}
+                result.returncode = 0
+                result.stdout = _make_llm_response(entity_map)
+            return result
+
+        with mock.patch("backfill.subprocess.run", side_effect=side_effect):
+            rc = run_backfill(batch_size=BATCH_SIZE)
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err or "Backfill complete" in captured.out
+
+    def test_dry_run_mode(self, db_dir, capsys):
+        """--dry-run shows what would be processed without changes."""
+        db = db_dir[1]
+        _insert_test_chunk(db, "c1", "chunk one", entities=None)
+        _insert_test_chunk(db, "c2", "chunk two", entities=None)
+
+        with mock.patch("backfill.subprocess.run") as mock_run:
+            rc = run_backfill(dry_run=True)
+
+        assert rc == 0
+        mock_run.assert_not_called()
+
+        output = capsys.readouterr().out
+        assert "DRY RUN" in output
+        assert "2 chunks" in output
+
+        assert query_chunk_by_id(db, "c1").entities is None
+        assert query_chunk_by_id(db, "c2").entities is None
+
+    def test_no_chunks_need_processing(self, db_dir, capsys):
+        """When all chunks have entities, reports nothing to do."""
+        db = db_dir[1]
+        _insert_test_chunk(db, "c1", "chunk one", entities=json.dumps(["A"]))
+
+        with mock.patch("backfill.subprocess.run") as mock_run:
+            rc = run_backfill()
+
+        assert rc == 0
+        mock_run.assert_not_called()
+
+        output = capsys.readouterr().out
+        assert "No chunks need entity extraction" in output


### PR DESCRIPTION
## Summary

- `scripts/backfill.py` — one-time CLI script to re-extract entities for existing chunks using Sonnet
- Idempotent: skips chunks where `entities IS NOT NULL`
- Batched processing (default 50/batch, configurable via `--batch-size`)
- Progress reporting, `--dry-run` mode, graceful error handling
- Added to `install.py` link_scripts()

## Details

- 17 new tests (949 total)
- Uses `claude -p --model sonnet --no-session-persistence` for headless LLM calls
- Parses JSON entity arrays from LLM response
- Continues on LLM failure (logs warning, moves to next batch)

## Test plan

- [x] 949 passed, 12 skipped
- [x] Idempotent skip verified
- [x] Batch size enforcement verified
- [x] LLM calls mocked (no real API calls in tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)