### PR TITLE
fix: Phase 2 data integrity audit fixes

### DIFF
--- a/scripts/embeddings.py
+++ b/scripts/embeddings.py
@@ -105,6 +105,8 @@ def ensure_vec_table(conn) -> bool:
         sqlite_vec.load(conn)
     except Exception:
         return False
+    finally:
+        conn.enable_load_extension(False)
     conn.executescript(VEC_CHUNKS_DDL)
     conn.commit()
     return True

--- a/scripts/storage.py
+++ b/scripts/storage.py
@@ -819,13 +819,10 @@ def migrate_markdown_to_db(conn: sqlite3.Connection) -> MigrationStats:
             _insert_chunks(chunks)
             stats.daily_files_processed += 1
 
-    # Backfill last_accessed for newly inserted chunks.
-    # _migrate_salience_data() runs in ensure_db() before chunks are inserted,
-    # so newly migrated chunks have last_accessed=NULL. Fix that here.
-    conn.execute(
-        "UPDATE chunks SET last_accessed = created_at "
-        "WHERE last_accessed IS NULL AND created_at IS NOT NULL"
-    )
+    # _migrate_salience_data() ran in ensure_db() before chunks were inserted,
+    # so newly migrated chunks have last_accessed=NULL. Re-run it now that
+    # chunks exist (idempotent: only rows with NULL are touched).
+    _migrate_salience_data(conn)
 
     conn.commit()
     return stats

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -686,7 +686,6 @@ class TestSalienceDecayIntegration:
         5. Verify: accessed entries have higher salience than unaccessed old entry
         6. Verify: cold old entry decays below archive threshold
         """
-        from unittest import mock  # noqa: I001
         from storage import close_db, ensure_db, migrate_markdown_to_db, query_chunks_with_salience, update_chunk_salience
 
         db_path = tmp_path / "memory.db"


### PR DESCRIPTION
## Summary
- Fix `ensure_vec_table()` missing `conn.enable_load_extension(True)` — sqlite_vec couldn't load
- Rewrite `search_similar()` as two-step query (KNN then JOIN) for vec0 compatibility
- Backfill `last_accessed = created_at` in `migrate_markdown_to_db()` — ordering bug where `_migrate_salience_data()` ran before chunks existed
- Fix `backfill.py` to run `claude -p` from `/tmp` to avoid project context pollution
- Remove unused imports, update decay integration test for realistic timeline
- Add Phase B and Phase C completion docs

## Test plan
- [x] 961 tests pass (0 failures)
- [ ] Verify `memory.db` has `last_accessed` populated after fresh `migrate_markdown_to_db()`
- [ ] Verify `search_similar()` returns results with sqlite_vec loaded
- [ ] Verify `backfill.py` successfully extracts entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)