### PR TITLE
feat(hooks): add PreCompact hook to synthesize before compaction

### DIFF
--- a/install.py
+++ b/install.py
@@ -492,17 +492,17 @@ def merge_hooks(settings: dict, python_cmd: str) -> dict:
 
     # Remove existing synthesis SessionEnd/PreCompact hooks (handles platform migration)
     # Match both systemd ("claude-memory-synthesis") and launchd ("com.claude.memory-synthesis")
-    for _event in ("SessionEnd", "PreCompact"):
-        if _event in settings.get("hooks", {}):
-            settings["hooks"][_event] = [
-                entry for entry in settings["hooks"][_event]
+    for event in ("SessionEnd", "PreCompact"):
+        if event in settings.get("hooks", {}):
+            settings["hooks"][event] = [
+                entry for entry in settings["hooks"][event]
                 if not any(
                     "memory-synthesis" in h.get("command", "")
                     for h in entry.get("hooks", [])
                 )
             ]
-            if not settings["hooks"][_event]:
-                del settings["hooks"][_event]
+            if not settings["hooks"][event]:
+                del settings["hooks"][event]
 
     for event, new_entries in hooks_to_add.items():
         if event not in settings["hooks"]:

--- a/install.py
+++ b/install.py
@@ -467,23 +467,42 @@ def merge_hooks(settings: dict, python_cmd: str) -> dict:
                 ],
             }
         ],
+        # PreCompact: same as SessionEnd — synthesize and write recall before transcript is compacted
+        "PreCompact": [
+            {
+                "matcher": "",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": f"{python_cmd} {scripts_dir}/session_end_recall.py",
+                        "timeout": 10,
+                    },
+                    {
+                        "type": "command",
+                        "command": _session_end_command(),
+                        "timeout": 5,
+                    },
+                ],
+            }
+        ],
     }
 
     if "hooks" not in settings:
         settings["hooks"] = {}
 
-    # Remove existing synthesis SessionEnd hooks (handles platform migration)
+    # Remove existing synthesis SessionEnd/PreCompact hooks (handles platform migration)
     # Match both systemd ("claude-memory-synthesis") and launchd ("com.claude.memory-synthesis")
-    if "SessionEnd" in settings.get("hooks", {}):
-        settings["hooks"]["SessionEnd"] = [
-            entry for entry in settings["hooks"]["SessionEnd"]
-            if not any(
-                "memory-synthesis" in h.get("command", "")
-                for h in entry.get("hooks", [])
-            )
-        ]
-        if not settings["hooks"]["SessionEnd"]:
-            del settings["hooks"]["SessionEnd"]
+    for _event in ("SessionEnd", "PreCompact"):
+        if _event in settings.get("hooks", {}):
+            settings["hooks"][_event] = [
+                entry for entry in settings["hooks"][_event]
+                if not any(
+                    "memory-synthesis" in h.get("command", "")
+                    for h in entry.get("hooks", [])
+                )
+            ]
+            if not settings["hooks"][_event]:
+                del settings["hooks"][_event]
 
     for event, new_entries in hooks_to_add.items():
         if event not in settings["hooks"]:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -598,9 +598,7 @@ class TestPreCompactHook:
         hooks = settings["hooks"]["PreCompact"]
         for entry in hooks:
             for h in entry.get("hooks", []):
-                cmd = h.get("command", "")
-                if "claude-memory-synthesis" in cmd:
-                    assert h.get("timeout", 999) <= 5
+                assert h.get("timeout", 999) <= 10
 
     def test_precompact_hook_not_duplicated(self):
         """Running merge_hooks twice does not duplicate PreCompact entries."""
@@ -641,7 +639,11 @@ class TestPreCompactHook:
                 ]
             }
         }
-        result = install.merge_hooks(settings, "python3")
+        with mock.patch("install.sys") as mock_sys, \
+             mock.patch("install.os") as mock_os:
+            mock_sys.platform = "darwin"
+            mock_os.getuid.return_value = 501
+            result = install.merge_hooks(settings, "python3")
         commands = [
             h.get("command", "")
             for entry in result["hooks"]["PreCompact"]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -579,6 +579,107 @@ class TestSessionEndRecallHook:
 
 
 # ---------------------------------------------------------------------------
+# PreCompact hook
+# ---------------------------------------------------------------------------
+
+
+class TestPreCompactHook:
+    def test_precompact_hook_added_to_settings(self):
+        """merge_hooks adds a PreCompact hook."""
+        settings = {"hooks": {}}
+        result = install.merge_hooks(settings, "python3")
+        assert "PreCompact" in result["hooks"]
+        hooks = result["hooks"]["PreCompact"]
+        assert len(hooks) >= 1
+
+    def test_precompact_hook_has_short_timeout(self):
+        """PreCompact synthesis trigger has a short timeout since it's fire-and-forget."""
+        settings = install.merge_hooks({}, "python3")
+        hooks = settings["hooks"]["PreCompact"]
+        for entry in hooks:
+            for h in entry.get("hooks", []):
+                cmd = h.get("command", "")
+                if "claude-memory-synthesis" in cmd:
+                    assert h.get("timeout", 999) <= 5
+
+    def test_precompact_hook_not_duplicated(self):
+        """Running merge_hooks twice does not duplicate PreCompact entries."""
+        settings = install.merge_hooks({}, "python3")
+        count_before = len(settings["hooks"]["PreCompact"])
+        settings = install.merge_hooks(settings, "python3")
+        count_after = len(settings["hooks"]["PreCompact"])
+        assert count_before == count_after
+
+    def test_precompact_hook_has_two_hooks(self):
+        """PreCompact hook has recall script first, then deferred synthesis."""
+        settings = {"hooks": {}}
+        result = install.merge_hooks(settings, "python3")
+        precompact = result["hooks"]["PreCompact"]
+        assert len(precompact) == 1
+        hooks = precompact[0]["hooks"]
+        assert len(hooks) == 2
+        assert "session_end_recall.py" in hooks[0]["command"]
+        assert hooks[0]["timeout"] == 10
+        assert "memory-synthesis" in hooks[1]["command"]
+        assert hooks[1]["timeout"] == 5
+
+    def test_migration_removes_old_synthesis_precompact_hook(self):
+        """Existing PreCompact synthesis hooks are replaced on re-install."""
+        settings = {
+            "hooks": {
+                "PreCompact": [
+                    {
+                        "matcher": "",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "systemctl --user start --no-block claude-memory-synthesis.service",
+                                "timeout": 5,
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        result = install.merge_hooks(settings, "python3")
+        commands = [
+            h.get("command", "")
+            for entry in result["hooks"]["PreCompact"]
+            for h in entry.get("hooks", [])
+        ]
+        assert not any("systemctl --user start --no-block claude-memory-synthesis" in c for c in commands)
+
+    def test_preserves_non_synthesis_precompact_hooks(self):
+        """Migration only removes synthesis hooks, not other PreCompact hooks."""
+        settings = {
+            "hooks": {
+                "PreCompact": [
+                    {
+                        "matcher": "",
+                        "hooks": [{"type": "command", "command": "echo compacting"}],
+                    },
+                    {
+                        "matcher": "",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "systemctl --user start --no-block claude-memory-synthesis.service",
+                            }
+                        ],
+                    },
+                ]
+            }
+        }
+        result = install.merge_hooks(settings, "python3")
+        commands = [
+            h.get("command", "")
+            for entry in result["hooks"]["PreCompact"]
+            for h in entry.get("hooks", [])
+        ]
+        assert any("echo compacting" in c for c in commands)
+
+
+# ---------------------------------------------------------------------------
 # install_launchd_agent
 # ---------------------------------------------------------------------------
 

--- a/uninstall.py
+++ b/uninstall.py
@@ -58,7 +58,8 @@ def remove_hooks(settings: dict) -> dict:
         "load_memory.py",
         "save_session.py",
         "pretooluse-allow-memory.sh",
-        "memory-synthesis",  # SessionEnd hook: matches both systemctl and launchctl commands
+        "session_end_recall.py",
+        "memory-synthesis",  # SessionEnd/PreCompact hook: matches both systemctl and launchctl commands
     ]
 
     removed_count = 0


### PR DESCRIPTION
## Summary
- Adds a `PreCompact` hook that mirrors `SessionEnd` — runs `session_end_recall.py` and triggers deferred synthesis before the transcript is compacted
- Without this, long sessions that hit compaction would lose the pre-compaction content from synthesis until true session end
- Refactors migration cleanup to loop over both `SessionEnd` and `PreCompact` events instead of handling them separately

## Test plan
- Added `TestPreCompactHook` with 5 tests: hook added, short timeout, no duplication, two-hook structure, migration cleanup, non-synthesis hook preservation
- All 734 tests pass

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new PreCompact hook event that runs a short recall step followed by a deferred memory-synthesis step, with configured timeouts.

* **Bug Fixes / Migration**
  * Installation now migrates and cleans up legacy synthesis hooks from both SessionEnd and PreCompact to avoid duplicates.

* **Uninstall**
  * Uninstall cleanup now removes both synthesis-related and recall-related hook entries.

* **Tests**
  * Added tests validating PreCompact creation, ordering, timeouts, idempotency, and migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->