### PR TITLE
feat(indexing): detect and correct stale project paths

### DIFF
--- a/scripts/indexing.py
+++ b/scripts/indexing.py
@@ -356,19 +356,28 @@ def _suggest_path_correction(
     # Strategy 3: Basename scan under $HOME (3 levels deep, skip hidden dirs)
     basename = project_data.get("name", Path(stale_path).name)
     home_path = Path(home)
-    for depth1 in home_path.iterdir():
-        if not depth1.is_dir() or depth1.name.startswith("."):
-            continue
-        if depth1.name == basename:
-            return str(depth1), f"basename match in {home}"
-        for depth2 in depth1.iterdir():
-            if not depth2.is_dir() or depth2.name.startswith("."):
+    try:
+        for depth1 in home_path.iterdir():
+            if not depth1.is_dir() or depth1.name.startswith("."):
                 continue
-            if depth2.name == basename:
-                return str(depth2), f"basename match in {depth1}"
-            for depth3 in depth2.iterdir():
-                if depth3.is_dir() and not depth3.name.startswith(".") and depth3.name == basename:
-                    return str(depth3), f"basename match in {depth2}"
+            if depth1.name == basename:
+                return str(depth1), f"basename match in {home}"
+            try:
+                for depth2 in depth1.iterdir():
+                    if not depth2.is_dir() or depth2.name.startswith("."):
+                        continue
+                    if depth2.name == basename:
+                        return str(depth2), f"basename match in {depth1}"
+                    try:
+                        for depth3 in depth2.iterdir():
+                            if depth3.is_dir() and not depth3.name.startswith(".") and depth3.name == basename:
+                                return str(depth3), f"basename match in {depth2}"
+                    except OSError:
+                        continue
+            except OSError:
+                continue
+    except OSError:
+        pass
 
     return None, None
 
@@ -520,7 +529,6 @@ def build_projects_index(fix_paths: bool = False) -> dict:
             })
 
     # Apply corrections if --fix-paths was requested
-    fixed_count = 0
     if fix_paths and stale_projects:
         for stale in stale_projects:
             suggested = stale["suggested_path"]
@@ -541,7 +549,6 @@ def build_projects_index(fix_paths: bool = False) -> dict:
                         existing["encodedPaths"].append(ep)
             else:
                 projects[new_key] = entry
-            fixed_count += 1
 
     # Emit warnings for stale paths
     if stale_projects:

--- a/scripts/indexing.py
+++ b/scripts/indexing.py
@@ -295,7 +295,13 @@ def _extract_from_jsonl(folder: Path) -> tuple[str, set[str]]:
     original_path = ""
     work_days: set[str] = set()
 
-    for jsonl_file in sorted(folder.glob("*.jsonl"), key=lambda f: f.stat().st_mtime, reverse=True):
+    def _safe_mtime(path: Path) -> float:
+        try:
+            return path.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    for jsonl_file in sorted(folder.glob("*.jsonl"), key=_safe_mtime, reverse=True):
         try:
             with open(jsonl_file, "r", encoding="utf-8") as f:
                 first_line = f.readline().strip()
@@ -347,37 +353,43 @@ def _suggest_path_correction(
 
     # Strategy 2: Home directory substitution
     home = str(Path.home())
-    m = re.match(r"/home/[^/]+/(.*)", stale_path)
+    m = re.match(r"(?:/home|/Users)/[^/]+/(.*)", stale_path)
     if m:
         candidate = os.path.join(home, m.group(1))
         if Path(candidate).exists():
             return candidate, "home directory match"
 
     # Strategy 3: Basename scan under $HOME (3 levels deep, skip hidden dirs)
+    # Collects all matches and only returns when exactly 1 found (avoids
+    # non-deterministic first-match when multiple dirs share the basename).
     basename = project_data.get("name", Path(stale_path).name)
     home_path = Path(home)
+    matches: list[tuple[str, str]] = []
     try:
         for depth1 in home_path.iterdir():
             if not depth1.is_dir() or depth1.name.startswith("."):
                 continue
             if depth1.name == basename:
-                return str(depth1), f"basename match in {home}"
+                matches.append((str(depth1), f"basename match in {home}"))
             try:
                 for depth2 in depth1.iterdir():
                     if not depth2.is_dir() or depth2.name.startswith("."):
                         continue
                     if depth2.name == basename:
-                        return str(depth2), f"basename match in {depth1}"
+                        matches.append((str(depth2), f"basename match in {depth1}"))
                     try:
                         for depth3 in depth2.iterdir():
                             if depth3.is_dir() and not depth3.name.startswith(".") and depth3.name == basename:
-                                return str(depth3), f"basename match in {depth2}"
+                                matches.append((str(depth3), f"basename match in {depth2}"))
                     except OSError:
                         continue
             except OSError:
                 continue
     except OSError:
         pass
+
+    if len(matches) == 1:
+        return matches[0]
 
     return None, None
 

--- a/scripts/indexing.py
+++ b/scripts/indexing.py
@@ -20,6 +20,8 @@ Requirements: Python 3.9+
 
 import argparse
 import json
+import os
+import re
 import sys
 from collections import defaultdict
 from dataclasses import dataclass
@@ -284,13 +286,16 @@ def _extract_from_jsonl(folder: Path) -> tuple[str, set[str]]:
     Extract original path and work days from JSONL transcript files.
 
     Reads the first line of each .jsonl file to get cwd and timestamp.
+    Sorts by mtime descending so the newest session's cwd wins (handles
+    cross-platform migration where older sessions have stale paths).
+
     Returns (original_path, work_days_set). original_path may be empty
     if no cwd field is found.
     """
     original_path = ""
     work_days: set[str] = set()
 
-    for jsonl_file in sorted(folder.glob("*.jsonl")):
+    for jsonl_file in sorted(folder.glob("*.jsonl"), key=lambda f: f.stat().st_mtime, reverse=True):
         try:
             with open(jsonl_file, "r", encoding="utf-8") as f:
                 first_line = f.readline().strip()
@@ -314,7 +319,61 @@ def _extract_from_jsonl(folder: Path) -> tuple[str, set[str]]:
     return original_path, work_days
 
 
-def build_projects_index() -> dict:
+def _suggest_path_correction(
+    stale_path: str,
+    project_data: dict,
+    jsonl_paths: dict[str, str],
+) -> tuple[str, str] | tuple[None, None]:
+    """Suggest a corrected path for a stale project path.
+
+    Tries three strategies in priority order:
+    1. JSONL cwd — direct evidence from recent sessions on this machine
+    2. Home substitution — replace /home/<user>/ prefix with $HOME/
+    3. Basename scan — shallow search under $HOME and $HOME/*/
+
+    Args:
+        stale_path: The path that doesn't exist on disk
+        project_data: Project dict with encodedPaths, name, etc.
+        jsonl_paths: Mapping of encoded folder name -> resolved JSONL cwd
+
+    Returns:
+        (suggested_path, strategy_name) or (None, None) if no match found.
+    """
+    # Strategy 1: JSONL cwd from this project's encoded folders
+    for encoded_path in project_data.get("encodedPaths", []):
+        candidate = jsonl_paths.get(encoded_path)
+        if candidate and Path(candidate).exists():
+            return candidate, "JSONL cwd"
+
+    # Strategy 2: Home directory substitution
+    home = str(Path.home())
+    m = re.match(r"/home/[^/]+/(.*)", stale_path)
+    if m:
+        candidate = os.path.join(home, m.group(1))
+        if Path(candidate).exists():
+            return candidate, "home directory match"
+
+    # Strategy 3: Basename scan under $HOME (3 levels deep, skip hidden dirs)
+    basename = project_data.get("name", Path(stale_path).name)
+    home_path = Path(home)
+    for depth1 in home_path.iterdir():
+        if not depth1.is_dir() or depth1.name.startswith("."):
+            continue
+        if depth1.name == basename:
+            return str(depth1), f"basename match in {home}"
+        for depth2 in depth1.iterdir():
+            if not depth2.is_dir() or depth2.name.startswith("."):
+                continue
+            if depth2.name == basename:
+                return str(depth2), f"basename match in {depth1}"
+            for depth3 in depth2.iterdir():
+                if depth3.is_dir() and not depth3.name.startswith(".") and depth3.name == basename:
+                    return str(depth3), f"basename match in {depth2}"
+
+    return None, None
+
+
+def build_projects_index(fix_paths: bool = False) -> dict:
     """
     Build a project-to-work-days index from Claude Code's project data.
 
@@ -336,6 +395,9 @@ def build_projects_index() -> dict:
     # Key: lowercase project path for consistent lookup
     # Value: project metadata
     projects: dict[str, dict] = {}
+
+    # Track resolved JSONL cwd per encoded folder (for stale-path suggestions)
+    jsonl_paths: dict[str, str] = {}
 
     # Also track path variations (case differences) that map to same project
     path_variations: dict[str, set[str]] = defaultdict(set)
@@ -370,6 +432,9 @@ def build_projects_index() -> dict:
 
         # Supplement with JSONL transcripts (fallback for path, additional work days)
         jsonl_path, jsonl_days = _extract_from_jsonl(project_folder)
+        if jsonl_path:
+            resolved_jsonl = resolve_session_path(jsonl_path)
+            jsonl_paths[project_folder.name] = resolved_jsonl
         if not original_path:
             original_path = jsonl_path
             if original_path:
@@ -438,22 +503,69 @@ def build_projects_index() -> dict:
         del projects[key]
 
     # Check for remaining stale paths (no live entry to merge into)
-    stale_projects = []
+    stale_projects: list[dict] = []
     for canonical_path, data in projects.items():
         original_path = data.get("originalPath", "")
         if original_path and not Path(original_path).exists():
+            suggested, strategy = _suggest_path_correction(
+                original_path, data, jsonl_paths,
+            )
             stale_projects.append({
+                "canonical_path": canonical_path,
                 "name": data.get("name", "unknown"),
                 "original_path": original_path,
                 "work_days": len(data.get("workDays", [])),
+                "suggested_path": suggested,
+                "strategy": strategy,
             })
+
+    # Apply corrections if --fix-paths was requested
+    fixed_count = 0
+    if fix_paths and stale_projects:
+        for stale in stale_projects:
+            suggested = stale["suggested_path"]
+            if not suggested:
+                continue
+            old_key = stale["canonical_path"]
+            new_key = suggested.lower()
+            entry = projects.pop(old_key)
+            entry["originalPath"] = suggested
+            entry["name"] = Path(suggested).name
+            if new_key in projects:
+                existing = projects[new_key]
+                existing_days = set(existing["workDays"])
+                existing_days.update(entry.get("workDays", []))
+                existing["workDays"] = sorted(existing_days)
+                for ep in entry.get("encodedPaths", []):
+                    if ep not in existing["encodedPaths"]:
+                        existing["encodedPaths"].append(ep)
+            else:
+                projects[new_key] = entry
+            fixed_count += 1
 
     # Emit warnings for stale paths
     if stale_projects:
-        print(f"\nWarning: {len(stale_projects)} project(s) have missing paths:", file=sys.stderr)
-        for stale in stale_projects:
-            print(f"  - {stale['name']}: {stale['original_path']} ({stale['work_days']} work days)", file=sys.stderr)
-        print("  Consider using /projects to migrate or cleanup stale data.\n", file=sys.stderr)
+        unfixed = [s for s in stale_projects if not fix_paths or not s["suggested_path"]]
+        fixed = [s for s in stale_projects if fix_paths and s["suggested_path"]]
+
+        if fixed:
+            print(f"\nFixed {len(fixed)} stale path(s):", file=sys.stderr)
+            for s in fixed:
+                print(f"  {s['name']}: {s['original_path']}", file=sys.stderr)
+                print(f"    -> {s['suggested_path']} ({s['strategy']})", file=sys.stderr)
+
+        if unfixed:
+            print(f"\nWarning: {len(unfixed)} project(s) have stale paths:", file=sys.stderr)
+            for s in unfixed:
+                print(f"  - {s['name']}: {s['original_path']} ({s['work_days']} work days)", file=sys.stderr)
+                if s["suggested_path"]:
+                    print(f"    Suggested: {s['suggested_path']} ({s['strategy']})", file=sys.stderr)
+                else:
+                    print("    No suggestion found", file=sys.stderr)
+            if any(s["suggested_path"] for s in unfixed):
+                print("  Run `python indexing.py build-index --fix-paths` to apply suggestions.\n", file=sys.stderr)
+            else:
+                print("  Consider using /projects to migrate or cleanup stale data.\n", file=sys.stderr)
 
     # Build output structure
     output = {
@@ -492,7 +604,7 @@ def print_index_summary(index: dict) -> None:
 
 def cmd_build_index(args: argparse.Namespace) -> int:
     """Handle build-index command."""
-    index = build_projects_index()
+    index = build_projects_index(fix_paths=args.fix_paths)
     print_index_summary(index)
     return 0
 
@@ -522,6 +634,10 @@ def main() -> int:
     # Build-index command
     build_parser = subparsers.add_parser(
         "build-index", help="Build/rebuild project index"
+    )
+    build_parser.add_argument(
+        "--fix-paths", action="store_true",
+        help="Auto-apply suggested corrections for stale project paths",
     )
     build_parser.set_defaults(func=cmd_build_index)
 

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -929,7 +929,6 @@ def find_current_project(projects_index: dict, pwd: str) -> dict | None:
                 break
         # Persist the corrected index to disk
         _persist_projects_index(projects_index)
-        import sys
         print(
             f"Auto-corrected stale project path: {old_path} -> {pwd}",
             file=sys.stderr,
@@ -941,10 +940,8 @@ def find_current_project(projects_index: dict, pwd: str) -> dict | None:
 
 def _persist_projects_index(projects_index: dict) -> None:
     """Write corrected projects index back to disk."""
-    import json
-    from datetime import datetime, timezone
     output_file = get_projects_index_file()
-    projects_index["lastUpdated"] = datetime.now(timezone.utc).isoformat() + "Z"
+    projects_index["lastUpdated"] = to_iso_z(datetime.now(timezone.utc))
     try:
         with open(output_file, "w", encoding="utf-8") as f:
             json.dump(projects_index, f, indent=2)

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -939,14 +939,18 @@ def find_current_project(projects_index: dict, pwd: str) -> dict | None:
 
 
 def _persist_projects_index(projects_index: dict) -> None:
-    """Write corrected projects index back to disk."""
+    """Write corrected projects index back to disk (atomic via tmp+replace)."""
     output_file = get_projects_index_file()
+    tmp_file = output_file.with_suffix(".tmp")
     projects_index["lastUpdated"] = to_iso_z(datetime.now(timezone.utc))
     try:
-        with open(output_file, "w", encoding="utf-8") as f:
+        with open(tmp_file, "w", encoding="utf-8") as f:
             json.dump(projects_index, f, indent=2)
-    except IOError:
-        pass
+        tmp_file.replace(output_file)
+    except (IOError, OSError):
+        if tmp_file.exists():
+            tmp_file.unlink()
+
 
 
 # Cache for resolve_project_path_to_name to avoid repeated file reads

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -885,13 +885,71 @@ def find_current_project(projects_index: dict, pwd: str) -> dict | None:
     """
     Find the project matching the current working directory.
 
-    Case-insensitive: normalizes both keys and pwd to lowercase.
+    Two-tier lookup:
+    1. Direct path match (case-insensitive)
+    2. Basename match — if pwd's basename matches exactly one project name
+       whose indexed path doesn't exist on disk (stale path from platform
+       migration). Updates the index entry in-place when matched.
+
     Subdirectory resolution is handled upstream by resolve_session_path().
 
     Returns project dict with 'name', 'originalPath', 'workDays' or None.
     """
     projects = _normalize_projects_keys(projects_index.get("projects", {}))
-    return projects.get(pwd.lower())
+
+    # Tier 1: direct path match
+    result = projects.get(pwd.lower())
+    if result is not None:
+        return result
+
+    # Tier 2: basename match against stale entries
+    basename = Path(pwd).name.lower()
+    candidates = []
+    for key, data in projects.items():
+        if data.get("name", "").lower() == basename:
+            original = data.get("originalPath", "")
+            if original and not Path(original).exists():
+                candidates.append((key, data))
+
+    if len(candidates) == 1:
+        key, data = candidates[0]
+        old_path = data.get("originalPath", "")
+        # Update the entry to the current path
+        data["originalPath"] = pwd
+        data["name"] = Path(pwd).name
+        # Also update the raw index so the fix persists on next write
+        raw_projects = projects_index.get("projects", {})
+        for raw_key, raw_data in list(raw_projects.items()):
+            if raw_key.lower() == key:
+                raw_projects[pwd.lower()] = raw_data
+                raw_data["originalPath"] = pwd
+                raw_data["name"] = Path(pwd).name
+                if raw_key.lower() != pwd.lower():
+                    del raw_projects[raw_key]
+                break
+        # Persist the corrected index to disk
+        _persist_projects_index(projects_index)
+        import sys
+        print(
+            f"Auto-corrected stale project path: {old_path} -> {pwd}",
+            file=sys.stderr,
+        )
+        return data
+
+    return None
+
+
+def _persist_projects_index(projects_index: dict) -> None:
+    """Write corrected projects index back to disk."""
+    import json
+    from datetime import datetime, timezone
+    output_file = get_projects_index_file()
+    projects_index["lastUpdated"] = datetime.now(timezone.utc).isoformat() + "Z"
+    try:
+        with open(output_file, "w", encoding="utf-8") as f:
+            json.dump(projects_index, f, indent=2)
+    except IOError:
+        pass
 
 
 # Cache for resolve_project_path_to_name to avoid repeated file reads

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -880,12 +880,13 @@ class TestSuggestPathCorrection:
         assert suggested == str(live_dir)
         assert "basename match" in strategy
 
-    def test_no_match_returns_none(self):
+    def test_no_match_returns_none(self, tmp_path):
         """No strategies match -> (None, None)."""
         project_data = {"encodedPaths": [], "name": "nonexistent-proj"}
-        suggested, strategy = _suggest_path_correction(
-            "/home/old/nonexistent-proj", project_data, {},
-        )
+        with mock.patch("indexing.Path.home", return_value=tmp_path):
+            suggested, strategy = _suggest_path_correction(
+                "/home/old/nonexistent-proj", project_data, {},
+            )
         assert suggested is None
         assert strategy is None
 

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -15,6 +15,7 @@ from helpers import make_jsonl_line, make_session_info  # noqa: I001
 from indexing import (
     DEFAULT_RECENCY_WINDOW_DAYS,
     MIN_SESSION_SIZE_BYTES,
+    _suggest_path_correction,
     build_projects_index,
     get_session_date,
     has_assistant_message,
@@ -809,6 +810,213 @@ class TestBuildProjectsIndex:
         assert len(result["projects"]) == 1
         data = list(result["projects"].values())[0]
         assert data["name"] == "unique-project"
+
+
+class TestSuggestPathCorrection:
+    """Tests for _suggest_path_correction fuzzy matching."""
+
+    def test_jsonl_cwd_strategy(self, tmp_path):
+        """Strategy 1: JSONL cwd from encoded folder matches."""
+        live_dir = tmp_path / "myproject"
+        live_dir.mkdir()
+        project_data = {"encodedPaths": ["enc-a"], "name": "myproject"}
+        jsonl_paths = {"enc-a": str(live_dir)}
+
+        suggested, strategy = _suggest_path_correction(
+            "/home/old/myproject", project_data, jsonl_paths,
+        )
+        assert suggested == str(live_dir)
+        assert strategy == "JSONL cwd"
+
+    def test_jsonl_cwd_nonexistent_skipped(self, tmp_path):
+        """JSONL cwd that doesn't exist on disk is skipped."""
+        project_data = {"encodedPaths": ["enc-a"], "name": "myproject"}
+        jsonl_paths = {"enc-a": "/nonexistent/path/myproject"}
+
+        suggested, strategy = _suggest_path_correction(
+            "/home/old/myproject", project_data, jsonl_paths,
+        )
+        # Should fall through to other strategies (which also won't match)
+        assert suggested is None
+
+    def test_home_substitution_strategy(self, tmp_path):
+        """Strategy 2: /home/<user>/ replaced with $HOME/."""
+        live_dir = tmp_path / "myproject"
+        live_dir.mkdir()
+        project_data = {"encodedPaths": [], "name": "myproject"}
+
+        with mock.patch("indexing.Path.home", return_value=tmp_path):
+            suggested, strategy = _suggest_path_correction(
+                "/home/olduser/myproject", project_data, {},
+            )
+        assert suggested == str(live_dir)
+        assert strategy == "home directory match"
+
+    def test_basename_scan_strategy_direct_child(self, tmp_path):
+        """Strategy 3: basename found as direct child of $HOME."""
+        live_dir = tmp_path / "myproject"
+        live_dir.mkdir()
+        project_data = {"encodedPaths": [], "name": "myproject"}
+
+        with mock.patch("indexing.Path.home", return_value=tmp_path):
+            suggested, strategy = _suggest_path_correction(
+                "/some/other/path/myproject", project_data, {},
+            )
+        assert suggested == str(live_dir)
+        assert "basename match" in strategy
+
+    def test_basename_scan_strategy_grandchild(self, tmp_path):
+        """Strategy 3: basename found as grandchild of $HOME."""
+        parent = tmp_path / "personal"
+        parent.mkdir()
+        live_dir = parent / "myproject"
+        live_dir.mkdir()
+        project_data = {"encodedPaths": [], "name": "myproject"}
+
+        with mock.patch("indexing.Path.home", return_value=tmp_path):
+            suggested, strategy = _suggest_path_correction(
+                "/some/other/path/myproject", project_data, {},
+            )
+        assert suggested == str(live_dir)
+        assert "basename match" in strategy
+
+    def test_no_match_returns_none(self):
+        """No strategies match -> (None, None)."""
+        project_data = {"encodedPaths": [], "name": "nonexistent-proj"}
+        suggested, strategy = _suggest_path_correction(
+            "/home/old/nonexistent-proj", project_data, {},
+        )
+        assert suggested is None
+        assert strategy is None
+
+    def test_priority_order_jsonl_over_home_sub(self, tmp_path):
+        """JSONL cwd is preferred over home substitution when both match."""
+        jsonl_dir = tmp_path / "jsonl-location" / "myproject"
+        jsonl_dir.mkdir(parents=True)
+        home_dir = tmp_path / "home-location"
+        home_dir.mkdir()
+        (home_dir / "myproject").mkdir()
+
+        project_data = {"encodedPaths": ["enc-a"], "name": "myproject"}
+        jsonl_paths = {"enc-a": str(jsonl_dir)}
+
+        with mock.patch("indexing.Path.home", return_value=home_dir):
+            suggested, strategy = _suggest_path_correction(
+                "/home/old/myproject", project_data, jsonl_paths,
+            )
+        assert suggested == str(jsonl_dir)
+        assert strategy == "JSONL cwd"
+
+
+class TestExtractFromJsonlMtimeOrdering:
+    """Tests that _extract_from_jsonl prefers the newest file's cwd."""
+
+    def test_newest_cwd_wins(self, tmp_path):
+        """Newest JSONL file's cwd is used, not the first alphabetically."""
+        import time
+
+        from indexing import _extract_from_jsonl
+
+        folder = tmp_path / "project"
+        folder.mkdir()
+
+        # Older file with stale path (alphabetically first: aaa < zzz)
+        old_file = folder / "aaa-old-session.jsonl"
+        old_file.write_text(json.dumps({
+            "cwd": "/home/olduser/myproject",
+            "timestamp": "2026-01-01T10:00:00Z",
+            "type": "user",
+        }) + "\n")
+
+        time.sleep(0.05)
+
+        # Newer file with current path
+        new_file = folder / "zzz-new-session.jsonl"
+        new_file.write_text(json.dumps({
+            "cwd": "/Users/newuser/myproject",
+            "timestamp": "2026-02-01T10:00:00Z",
+            "type": "user",
+        }) + "\n")
+
+        original_path, work_days = _extract_from_jsonl(folder)
+        assert original_path == "/Users/newuser/myproject"
+        assert "2026-01-01" in work_days
+        assert "2026-02-01" in work_days
+
+
+class TestBuildProjectsIndexFixPaths:
+    """Tests for the --fix-paths flag in build_projects_index."""
+
+    @pytest.fixture()
+    def env(self, tmp_path):
+        projects_dir = tmp_path / "projects"
+        memory_dir = tmp_path / "memory"
+        index_file = memory_dir / "projects-index.json"
+        with mock.patch("indexing.get_projects_dir", return_value=projects_dir), \
+             mock.patch("indexing.get_memory_dir", return_value=memory_dir), \
+             mock.patch("indexing.get_projects_index_file", return_value=index_file):
+            yield projects_dir, memory_dir, index_file
+
+    def _make_jsonl_file(self, folder, session_id, cwd, timestamp):
+        line = json.dumps({
+            "cwd": cwd, "timestamp": timestamp,
+            "type": "user", "sessionId": session_id,
+            "message": {"role": "user", "content": "hello"},
+        })
+        jsonl_path = folder / f"{session_id}.jsonl"
+        jsonl_path.write_text(line + "\n", encoding="utf-8")
+        return jsonl_path
+
+    def test_fix_paths_corrects_stale_entry(self, env):
+        """--fix-paths replaces stale path with suggested correction."""
+        projects_dir, memory_dir, index_file = env
+
+        # Create a live directory to match
+        live_dir = env[0].parent / "myproject"
+        live_dir.mkdir(parents=True, exist_ok=True)
+
+        # Project folder with stale sessions-index but correct JSONL cwd
+        folder = projects_dir / "-enc-myproject"
+        folder.mkdir(parents=True)
+        sessions_index = {
+            "originalPath": "/home/stale/myproject",
+            "entries": [{"created": "2026-01-15T10:00:00Z",
+                         "projectPath": "/home/stale/myproject"}],
+        }
+        (folder / "sessions-index.json").write_text(json.dumps(sessions_index))
+        self._make_jsonl_file(folder, "s1", str(live_dir), "2026-01-15T10:00:00Z")
+
+        result = build_projects_index(fix_paths=True)
+
+        projects = result["projects"]
+        assert len(projects) == 1
+        data = list(projects.values())[0]
+        assert data["originalPath"] == str(live_dir)
+        assert data["name"] == "myproject"
+
+    def test_no_fix_without_flag(self, env):
+        """Without --fix-paths, stale entries are preserved with warnings."""
+        projects_dir, memory_dir, index_file = env
+
+        live_dir = env[0].parent / "myproject"
+        live_dir.mkdir(parents=True, exist_ok=True)
+
+        folder = projects_dir / "-enc-myproject"
+        folder.mkdir(parents=True)
+        sessions_index = {
+            "originalPath": "/home/stale/myproject",
+            "entries": [{"created": "2026-01-15T10:00:00Z",
+                         "projectPath": "/home/stale/myproject"}],
+        }
+        (folder / "sessions-index.json").write_text(json.dumps(sessions_index))
+        self._make_jsonl_file(folder, "s1", str(live_dir), "2026-01-15T10:00:00Z")
+
+        result = build_projects_index(fix_paths=False)
+
+        projects = result["projects"]
+        data = list(projects.values())[0]
+        # Path should still be stale
+        assert data["originalPath"] == "/home/stale/myproject"
 
 
 if __name__ == "__main__":

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -914,7 +914,7 @@ class TestExtractFromJsonlMtimeOrdering:
 
     def test_newest_cwd_wins(self, tmp_path):
         """Newest JSONL file's cwd is used, not the first alphabetically."""
-        import time
+        import os
 
         from indexing import _extract_from_jsonl
 
@@ -929,8 +929,6 @@ class TestExtractFromJsonlMtimeOrdering:
             "type": "user",
         }) + "\n")
 
-        time.sleep(0.05)
-
         # Newer file with current path
         new_file = folder / "zzz-new-session.jsonl"
         new_file.write_text(json.dumps({
@@ -938,6 +936,10 @@ class TestExtractFromJsonlMtimeOrdering:
             "timestamp": "2026-02-01T10:00:00Z",
             "type": "user",
         }) + "\n")
+
+        # Set explicit mtimes for deterministic ordering
+        os.utime(old_file, (1000, 1000))
+        os.utime(new_file, (2000, 2000))
 
         original_path, work_days = _extract_from_jsonl(folder)
         assert original_path == "/Users/newuser/myproject"

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -480,6 +480,107 @@ class TestFindCurrentProject:
         assert sorted(result["workDays"]) == ["2026-01-01", "2026-01-02"]
         assert sorted(result["encodedPaths"]) == ["enc-a", "enc-b"]
 
+    def test_basename_fallback_corrects_stale_path(self, tmp_path):
+        """Tier 2: basename match against stale entry auto-corrects the path."""
+        live_dir = tmp_path / "myproject"
+        live_dir.mkdir()
+        index_file = tmp_path / "projects-index.json"
+
+        index = {
+            "projects": {
+                "/home/olduser/myproject": {
+                    "name": "myproject",
+                    "originalPath": "/home/olduser/myproject",
+                    "workDays": ["2026-01-01"],
+                    "encodedPaths": ["enc-a"],
+                }
+            }
+        }
+        with patch("memory_utils.get_projects_index_file", return_value=index_file):
+            result = find_current_project(index, str(live_dir))
+        assert result is not None
+        assert result["name"] == "myproject"
+        assert result["originalPath"] == str(live_dir)
+
+    def test_basename_fallback_no_match_when_path_exists(self, tmp_path):
+        """Tier 2 does not fire when the indexed path exists on disk."""
+        live_dir = tmp_path / "myproject"
+        live_dir.mkdir()
+        index = {
+            "projects": {
+                str(live_dir).lower(): {
+                    "name": "myproject",
+                    "originalPath": str(live_dir),
+                    "workDays": ["2026-01-01"],
+                }
+            }
+        }
+        result = find_current_project(index, str(live_dir))
+        assert result is not None
+        assert result["name"] == "myproject"
+
+    def test_basename_fallback_ambiguous_skipped(self, tmp_path):
+        """Tier 2 returns None when multiple stale entries share the basename."""
+        live_dir = tmp_path / "myproject"
+        live_dir.mkdir()
+        index = {
+            "projects": {
+                "/home/user1/myproject": {
+                    "name": "myproject",
+                    "originalPath": "/home/user1/myproject",
+                },
+                "/home/user2/myproject": {
+                    "name": "myproject",
+                    "originalPath": "/home/user2/myproject",
+                },
+            }
+        }
+        result = find_current_project(index, str(live_dir))
+        assert result is None
+
+    def test_basename_fallback_ignores_live_entries(self, tmp_path):
+        """Tier 2 only considers stale entries (path doesn't exist on disk)."""
+        live_dir = tmp_path / "myproject"
+        live_dir.mkdir()
+        other_dir = tmp_path / "other"
+        other_dir.mkdir()
+        index = {
+            "projects": {
+                str(other_dir).lower(): {
+                    "name": "myproject",
+                    "originalPath": str(other_dir),
+                }
+            }
+        }
+        result = find_current_project(index, str(live_dir))
+        assert result is None
+
+    def test_basename_fallback_persists_correction(self, tmp_path):
+        """Tier 2 writes the corrected index to disk."""
+        live_dir = tmp_path / "myproject"
+        live_dir.mkdir()
+        index_file = tmp_path / "projects-index.json"
+
+        index = {
+            "projects": {
+                "/home/olduser/myproject": {
+                    "name": "myproject",
+                    "originalPath": "/home/olduser/myproject",
+                    "workDays": ["2026-01-01"],
+                    "encodedPaths": ["enc-a"],
+                }
+            }
+        }
+        with patch("memory_utils.get_projects_index_file", return_value=index_file):
+            find_current_project(index, str(live_dir))
+
+        assert index_file.exists()
+        import json
+        saved = json.loads(index_file.read_text())
+        keys = list(saved["projects"].keys())
+        assert len(keys) == 1
+        assert keys[0] == str(live_dir).lower()
+
 
 # =============================================================================
 # FileLock Tests


### PR DESCRIPTION
## Summary
- Adds stale project path detection when `sessions-index.json` records WSL paths but the system runs on macOS
- `find_current_project()` tier-2 basename fallback auto-corrects at session start and persists the fix
- `build-index --fix-paths` batch-corrects via 3-strategy fuzzy matching (JSONL cwd, home substitution, 3-level basename scan)
- `_extract_from_jsonl` now sorts by mtime descending so the newest session's cwd wins over stale paths

## Test plan
- 15 new tests across 4 test classes (749 total, all passing)
- `TestFindCurrentProject`: tier-2 basename fallback (correction, ambiguity skip, live entry ignore, persistence)
- `TestSuggestPathCorrection`: all 3 strategies, priority ordering, no-match isolation
- `TestExtractFromJsonlMtimeOrdering`: newest cwd wins over alphabetically-first
- `TestBuildProjectsIndexFixPaths`: end-to-end fix-paths flow, stale preservation without flag
- Verified end-to-end: `build-index --fix-paths` corrects all 11 stale WSL paths, `load_memory.py` loads project memory correctly after fix

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent path correction for stale project references using multiple resolution strategies (recent session history, home directory patterns, and directory name matching).
  * Introduced `--fix-paths` CLI flag to automatically apply corrections to the projects index.

* **Bug Fixes**
  * Enhanced project lookup with fallback logic that automatically restores and relocates previously moved projects based on directory names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->