### PR TITLE
feat(load_memory): move recall first and add read instruction for truncated output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ python3 ~/.claude/scripts/decay.py --dry-run # Test decay
 
 ### Key Pipelines
 
-**Loading** (`load_memory.py`): Reads LTM files + filters daily files by scope tags → assembles context string → outputs to stdout for SessionStart hook injection.
+**Loading** (`load_memory.py`): Reads LTM files + filters daily files by scope tags → assembles full memory to stdout for SessionStart hook injection. Output order: read instruction → timestamp → recall → global LTM → project LTM → project STM → global STM. When output exceeds ~10K chars, Claude Code saves it to a session-specific file and shows the path + 2KB preview; the read instruction in the first 2KB prompts Claude to read the full file.
 
 **Synthesis** (`synthesis.py` + `synthesis_cron.py`): Extract transcripts → inject scopes from CWD metadata → LLM summarizes → programmatic daily merge → LTM routing with keyword-overlap dedup (threshold 0.6) + route cap (5/file) → update `.synthesis-state.json` offsets.
 

--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -65,7 +65,9 @@ SYNTHESIS_PROMPT_DIR = "/tmp"
 # Key Interfaces
 # =============================================================================
 # Entry points:
-#   main()                                  SessionStart hook (stdout -> context)
+#   main()                  SessionStart hook — outputs all memory sections to
+#                           stdout; read instruction in first 2KB prompts Claude
+#                           to read the full output file when Claude Code truncates
 # Memory loading:
 #   load_global_memory() -> (str, int)
 #   load_project_memory(name) -> (str, int)
@@ -790,7 +792,21 @@ def write_synthesis_prompt(exclude_session_id: str | None = None) -> None:
 
 
 def main() -> None:
-    """Main entry point - outputs memory context to stdout."""
+    """Main entry point - outputs memory context to stdout.
+
+    Output order (most important first so the 2KB preview is maximally useful):
+    1. Read instruction (for when Claude Code truncates large output to a file)
+    2. Timestamp + synthesis errors
+    3. Previous session recall (highest-value context)
+    4. Global LTM
+    5. Project LTM
+    6. Project STM
+    7. Global STM
+
+    When output exceeds ~10K chars, Claude Code saves the full content to a
+    session-specific file and shows the path + first 2KB as a preview. The read
+    instruction in the first 2KB prompts Claude to read the full file.
+    """
     check_python_version()
 
     # Skip memory injection if explicitly disabled (e.g., ccblocks ping sessions)
@@ -806,6 +822,12 @@ def main() -> None:
     except (json.JSONDecodeError, IOError):
         pass  # Not called from hook, or invalid input — safe to continue
 
+    # Detect current project early (needed for recall matching and project memory)
+    pwd = resolve_session_path(os.getcwd())
+    projects_index = load_json_file(get_projects_index_file(), {})
+    current_project = find_current_project(projects_index, pwd)
+    project_name = current_project.get("name", "") if current_project else ""
+
     # Load settings
     settings = load_settings()
     short_term_days = settings["globalShortTerm"]["workingDays"]
@@ -815,8 +837,21 @@ def main() -> None:
     # Track total bytes for token estimation
     total_bytes = 0
 
+    # Load recall before starting output (placed early so it lands in the 2KB preview)
+    recall_section, recall_bytes = load_pending_recall(
+        current_session_id=current_session_id,
+        current_project_name=project_name,
+        resolved_cwd=pwd,
+    )
+    total_bytes += recall_bytes
+
     # Start output
     print("<memory>")
+
+    # Read instruction: when output is large, Claude Code saves it to a file and
+    # shows a path + 2KB preview. This instruction prompts Claude to read the full file.
+    print("If you see \"Full output saved to: ...\" above this text, read that file now for complete memory context.")
+    print()
 
     # Include current local time for context
     now = datetime.now(timezone.utc).astimezone()
@@ -831,6 +866,11 @@ def main() -> None:
         print(error_alert)
         print()
 
+    # Previous session recall (most valuable: what you were just working on)
+    if recall_section:
+        print(recall_section)
+        print()
+
     # Load global long-term memory
     global_content, global_bytes = load_global_memory()
     total_bytes += global_bytes
@@ -840,21 +880,28 @@ def main() -> None:
         print(global_content)
         print()
 
-    # Detect current project (resolve worktree/subdir to repo root for matching)
-    pwd = resolve_session_path(os.getcwd())
-    projects_index = load_json_file(get_projects_index_file(), {})
-    current_project = find_current_project(projects_index, pwd)
-
     # Load project-specific long-term memory
-    if current_project:
-        project_name = current_project.get("name", "")
-        if project_name:
-            project_content, project_bytes = load_project_memory(project_name)
-            total_bytes += project_bytes
+    if project_name:
+        project_content, project_bytes = load_project_memory(project_name)
+        total_bytes += project_bytes
 
-            if project_content:
-                print(f"## Project Long-Term Memory: {project_name}")
-                print(project_content)
+        if project_content:
+            print(f"## Project Long-Term Memory: {project_name}")
+            print(project_content)
+            print()
+
+    # Load project short-term memory (project history, filtered to [project/*] tags)
+    if current_project:
+        pn = current_project.get("name", "unknown")
+        project_history, history_bytes = load_project_history(current_project, project_days)
+        total_bytes += history_bytes
+
+        if project_history:
+            print(f"## Project Short-Term Memory: {pn}")
+            print()
+            for date, content in project_history:
+                print(f"### {date}")
+                print(content)
                 print()
 
     # Load global short-term memory (recent daily summaries, filtered to [global/*] tags)
@@ -867,32 +914,6 @@ def main() -> None:
             print(f"### {date}")
             print(content)
             print()
-
-    # Load project short-term memory (project history, filtered to [project/*] tags)
-    if current_project:
-        project_name = current_project.get("name", "unknown")
-        project_history, history_bytes = load_project_history(current_project, project_days)
-        total_bytes += history_bytes
-
-        if project_history:
-            print(f"## Project Short-Term Memory: {project_name}")
-            print()
-            for date, content in project_history:
-                print(f"### {date}")
-                print(content)
-                print()
-
-    # Load pending recall for current project
-    project_name = current_project.get("name", "") if current_project else ""
-    recall_section, recall_bytes = load_pending_recall(
-        current_session_id=current_session_id,
-        current_project_name=project_name,
-        resolved_cwd=pwd,
-    )
-    total_bytes += recall_bytes
-    if recall_section:
-        print(recall_section)
-        print()
 
     print("</memory>")
 

--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -892,12 +892,11 @@ def main() -> None:
 
     # Load project short-term memory (project history, filtered to [project/*] tags)
     if current_project:
-        pn = current_project.get("name", "unknown")
         project_history, history_bytes = load_project_history(current_project, project_days)
         total_bytes += history_bytes
 
         if project_history:
-            print(f"## Project Short-Term Memory: {pn}")
+            print(f"## Project Short-Term Memory: {project_name}")
             print()
             for date, content in project_history:
                 print(f"### {date}")

--- a/tests/test_load_memory.py
+++ b/tests/test_load_memory.py
@@ -1621,12 +1621,19 @@ class TestLoadPendingRecall:
 # =============================================================================
 
 
+_DEFAULT_PROJECT = object()  # sentinel: use {"name": "testproject"} as the default mock
+
+
 class TestMainOutputOrder:
     """Verify main() outputs sections in the correct order with read instruction first."""
 
-    def _run_main(self, monkeypatch, tmp_path, *, global_ltm="", project_ltm="",
-                  global_stm=None, project_stm=None, recall=""):
-        """Run main() with mocked memory sources, return captured stdout."""
+    def _run_main(self, monkeypatch, *, global_ltm="", project_ltm="",
+                  global_stm=None, project_stm=None, recall="", current_project=_DEFAULT_PROJECT):
+        """Run main() with mocked memory sources, return captured stdout.
+
+        Pass current_project=None to simulate no project found (find_current_project returns None).
+        Omit current_project to use the default {"name": "testproject"} mock.
+        """
         import io
         from load_memory import main
 
@@ -1646,7 +1653,8 @@ class TestMainOutputOrder:
         monkeypatch.setattr("load_memory.check_synthesis_errors", lambda: None)
         monkeypatch.setattr("load_memory.resolve_session_path", lambda p: p)
         monkeypatch.setattr("load_memory.load_json_file", lambda *a, **kw: {})
-        monkeypatch.setattr("load_memory.find_current_project", lambda idx, pwd: {"name": "testproject"})
+        effective_project = {"name": "testproject"} if current_project is _DEFAULT_PROJECT else current_project
+        monkeypatch.setattr("load_memory.find_current_project", lambda idx, pwd: effective_project)
         monkeypatch.setattr("load_memory.load_settings", lambda: {
             **DEFAULT_SETTINGS,
             "globalShortTerm": {"workingDays": 2, "tokenLimit": 1500},
@@ -1659,22 +1667,22 @@ class TestMainOutputOrder:
         main()
         return captured.getvalue()
 
-    def test_read_instruction_present(self, monkeypatch, tmp_path):
+    def test_read_instruction_present(self, monkeypatch):
         """Read instruction appears in output so Claude can find the full file when truncated."""
-        output = self._run_main(monkeypatch, tmp_path, global_ltm="## Long-Term Memory\n- item")
+        output = self._run_main(monkeypatch, global_ltm="## Long-Term Memory\n- item")
         assert "Full output saved to" in output
 
-    def test_read_instruction_before_ltm(self, monkeypatch, tmp_path):
+    def test_read_instruction_before_ltm(self, monkeypatch):
         """Read instruction appears before long-term memory content."""
-        output = self._run_main(monkeypatch, tmp_path, global_ltm="## Long-Term Memory\n- ltm item")
+        output = self._run_main(monkeypatch, global_ltm="## Long-Term Memory\n- ltm item")
         instr_pos = output.find("Full output saved to")
         ltm_pos = output.find("ltm item")
         assert instr_pos < ltm_pos
 
-    def test_recall_before_ltm(self, monkeypatch, tmp_path):
+    def test_recall_before_ltm(self, monkeypatch):
         """Previous session recall appears before long-term memory."""
         output = self._run_main(
-            monkeypatch, tmp_path,
+            monkeypatch,
             global_ltm="## Long-Term Memory\n- ltm item",
             recall="I was working on feature X",
         )
@@ -1683,10 +1691,10 @@ class TestMainOutputOrder:
         assert recall_pos != -1, "Recall section missing"
         assert recall_pos < ltm_pos
 
-    def test_project_stm_before_global_stm(self, monkeypatch, tmp_path):
+    def test_project_stm_before_global_stm(self, monkeypatch):
         """Project STM appears before global STM."""
         output = self._run_main(
-            monkeypatch, tmp_path,
+            monkeypatch,
             global_stm=[("2026-04-20", "- [global/implement] global work")],
             project_stm=[("2026-04-21", "- [testproject/implement] project work")],
         )
@@ -1696,10 +1704,10 @@ class TestMainOutputOrder:
         assert global_stm_pos != -1, "Global STM missing"
         assert proj_stm_pos < global_stm_pos
 
-    def test_project_ltm_before_project_stm(self, monkeypatch, tmp_path):
+    def test_project_ltm_before_project_stm(self, monkeypatch):
         """Project LTM appears before project STM."""
         output = self._run_main(
-            monkeypatch, tmp_path,
+            monkeypatch,
             project_ltm="- (2026-01-01) [pattern] ltm pattern",
             project_stm=[("2026-04-21", "- [testproject/implement] recent work")],
         )
@@ -1707,10 +1715,10 @@ class TestMainOutputOrder:
         stm_pos = output.find("recent work")
         assert ltm_pos < stm_pos
 
-    def test_section_order_full(self, monkeypatch, tmp_path):
+    def test_section_order_full(self, monkeypatch):
         """Full section order: read instruction → recall → global LTM → project LTM → project STM → global STM."""
         output = self._run_main(
-            monkeypatch, tmp_path,
+            monkeypatch,
             global_ltm="- global ltm content",
             project_ltm="- project ltm content",
             global_stm=[("2026-04-20", "- [global/implement] global stm content")],
@@ -1734,11 +1742,23 @@ class TestMainOutputOrder:
         assert order_keys.index("project_ltm") < order_keys.index("project_stm")
         assert order_keys.index("project_stm") < order_keys.index("global_stm")
 
-    def test_no_recall_still_has_instruction(self, monkeypatch, tmp_path):
+    def test_no_recall_still_has_instruction(self, monkeypatch):
         """Read instruction appears even when there's no recall."""
-        output = self._run_main(monkeypatch, tmp_path, global_ltm="- some ltm")
+        output = self._run_main(monkeypatch, global_ltm="- some ltm")
         assert "Full output saved to" in output
         assert "Previous Session Recall" not in output
+
+    def test_no_current_project_falls_back(self, monkeypatch):
+        """When find_current_project returns None, main() produces global-only output (no project sections)."""
+        output = self._run_main(
+            monkeypatch,
+            global_ltm="- global ltm only",
+            project_ltm="- should not appear",
+            current_project=None,
+        )
+        assert "global ltm only" in output
+        assert "Project Long-Term Memory" not in output
+        assert "Project Short-Term Memory" not in output
 
 
 if __name__ == "__main__":

--- a/tests/test_load_memory.py
+++ b/tests/test_load_memory.py
@@ -1616,5 +1616,130 @@ class TestLoadPendingRecall:
         assert section == ""
 
 
+# =============================================================================
+# main() Output Order Tests
+# =============================================================================
+
+
+class TestMainOutputOrder:
+    """Verify main() outputs sections in the correct order with read instruction first."""
+
+    def _run_main(self, monkeypatch, tmp_path, *, global_ltm="", project_ltm="",
+                  global_stm=None, project_stm=None, recall=""):
+        """Run main() with mocked memory sources, return captured stdout."""
+        import io
+        from load_memory import main
+
+        monkeypatch.delenv("CLAUDE_SKIP_MEMORY", raising=False)
+        monkeypatch.setattr("sys.stdin", io.StringIO("{}"))
+
+        monkeypatch.setattr("load_memory.load_global_memory", lambda: (global_ltm, len(global_ltm)))
+        monkeypatch.setattr("load_memory.load_project_memory", lambda name: (project_ltm, len(project_ltm)))
+
+        global_stm = global_stm or []
+        project_stm = project_stm or []
+        monkeypatch.setattr("load_memory.load_daily_summaries", lambda days, scope="global": (global_stm, sum(len(c) for _, c in global_stm)))
+        monkeypatch.setattr("load_memory.load_project_history", lambda proj, days: (project_stm, sum(len(c) for _, c in project_stm)))
+
+        recall_section = f"## Previous Session Recall\n{recall}" if recall else ""
+        monkeypatch.setattr("load_memory.load_pending_recall", lambda **kw: (recall_section, len(recall_section)))
+        monkeypatch.setattr("load_memory.check_synthesis_errors", lambda: None)
+        monkeypatch.setattr("load_memory.resolve_session_path", lambda p: p)
+        monkeypatch.setattr("load_memory.load_json_file", lambda *a, **kw: {})
+        monkeypatch.setattr("load_memory.find_current_project", lambda idx, pwd: {"name": "testproject"})
+        monkeypatch.setattr("load_memory.load_settings", lambda: {
+            **DEFAULT_SETTINGS,
+            "globalShortTerm": {"workingDays": 2, "tokenLimit": 1500},
+            "projectShortTerm": {"workingDays": 5, "tokenLimit": 3750},
+            "totalTokenBudget": 6000,
+        })
+
+        captured = io.StringIO()
+        monkeypatch.setattr("sys.stdout", captured)
+        main()
+        return captured.getvalue()
+
+    def test_read_instruction_present(self, monkeypatch, tmp_path):
+        """Read instruction appears in output so Claude can find the full file when truncated."""
+        output = self._run_main(monkeypatch, tmp_path, global_ltm="## Long-Term Memory\n- item")
+        assert "Full output saved to" in output
+
+    def test_read_instruction_before_ltm(self, monkeypatch, tmp_path):
+        """Read instruction appears before long-term memory content."""
+        output = self._run_main(monkeypatch, tmp_path, global_ltm="## Long-Term Memory\n- ltm item")
+        instr_pos = output.find("Full output saved to")
+        ltm_pos = output.find("ltm item")
+        assert instr_pos < ltm_pos
+
+    def test_recall_before_ltm(self, monkeypatch, tmp_path):
+        """Previous session recall appears before long-term memory."""
+        output = self._run_main(
+            monkeypatch, tmp_path,
+            global_ltm="## Long-Term Memory\n- ltm item",
+            recall="I was working on feature X",
+        )
+        recall_pos = output.find("Previous Session Recall")
+        ltm_pos = output.find("ltm item")
+        assert recall_pos != -1, "Recall section missing"
+        assert recall_pos < ltm_pos
+
+    def test_project_stm_before_global_stm(self, monkeypatch, tmp_path):
+        """Project STM appears before global STM."""
+        output = self._run_main(
+            monkeypatch, tmp_path,
+            global_stm=[("2026-04-20", "- [global/implement] global work")],
+            project_stm=[("2026-04-21", "- [testproject/implement] project work")],
+        )
+        proj_stm_pos = output.find("project work")
+        global_stm_pos = output.find("global work")
+        assert proj_stm_pos != -1, "Project STM missing"
+        assert global_stm_pos != -1, "Global STM missing"
+        assert proj_stm_pos < global_stm_pos
+
+    def test_project_ltm_before_project_stm(self, monkeypatch, tmp_path):
+        """Project LTM appears before project STM."""
+        output = self._run_main(
+            monkeypatch, tmp_path,
+            project_ltm="- (2026-01-01) [pattern] ltm pattern",
+            project_stm=[("2026-04-21", "- [testproject/implement] recent work")],
+        )
+        ltm_pos = output.find("ltm pattern")
+        stm_pos = output.find("recent work")
+        assert ltm_pos < stm_pos
+
+    def test_section_order_full(self, monkeypatch, tmp_path):
+        """Full section order: read instruction → recall → global LTM → project LTM → project STM → global STM."""
+        output = self._run_main(
+            monkeypatch, tmp_path,
+            global_ltm="- global ltm content",
+            project_ltm="- project ltm content",
+            global_stm=[("2026-04-20", "- [global/implement] global stm content")],
+            project_stm=[("2026-04-21", "- [testproject/implement] project stm content")],
+            recall="recall content here",
+        )
+        positions = {
+            "read_instr": output.find("Full output saved to"),
+            "recall": output.find("recall content here"),
+            "global_ltm": output.find("global ltm content"),
+            "project_ltm": output.find("project ltm content"),
+            "project_stm": output.find("project stm content"),
+            "global_stm": output.find("global stm content"),
+        }
+        assert all(v != -1 for v in positions.values()), f"Missing section: {[k for k,v in positions.items() if v == -1]}"
+        order = sorted(positions.items(), key=lambda x: x[1])
+        order_keys = [k for k, _ in order]
+        assert order_keys.index("read_instr") < order_keys.index("recall")
+        assert order_keys.index("recall") < order_keys.index("global_ltm")
+        assert order_keys.index("global_ltm") < order_keys.index("project_ltm")
+        assert order_keys.index("project_ltm") < order_keys.index("project_stm")
+        assert order_keys.index("project_stm") < order_keys.index("global_stm")
+
+    def test_no_recall_still_has_instruction(self, monkeypatch, tmp_path):
+        """Read instruction appears even when there's no recall."""
+        output = self._run_main(monkeypatch, tmp_path, global_ltm="- some ltm")
+        assert "Full output saved to" in output
+        assert "Previous Session Recall" not in output
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Adds a read instruction at the top of `<memory>` output so Claude reads the full output file when Claude Code truncates large hook output (saves to session-specific file, shows path + 2KB preview)
- Moves previous session recall to appear **before** LTM sections, so the most relevant context lands in the 2KB preview rather than past the truncation point
- Reorders STM: project STM before global STM (closer relevance first)

## Test plan

- 7 new tests in `TestMainOutputOrder` covering: read instruction presence, instruction before LTM, recall before LTM, project STM before global STM, project LTM before project STM, full section order, and no-recall case
- 756 tests passing total

Closes #132

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory context now automatically saves large outputs (>10K characters) to a file with a preview and read instruction displayed.

* **Documentation**
  * Updated memory loading pipeline documentation to reflect new output ordering and handling of oversized memory payloads.

* **Tests**
  * Added comprehensive test suite verifying memory output section ordering and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->