### PR TITLE
feat(recall): apply 1/3 head + 2/3 tail split to recall token budget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,8 @@ python3 ~/.claude/scripts/decay.py --dry-run # Test decay
 
 **Mode**: `mode: "full"` (default) emits all sections. `mode: "light"` emits only recall + global LTM, skipping project LTM/STM and global STM — for users who rely on Claude Code's native project-scoped memory and only want this system for cross-project memory plus last-session continuity.
 
+**Recall** (`session_end_recall.py`): SessionEnd hook writes `pending-recall/{session_id}.md` for the next session. Each assistant message is per-message-truncated (head/tail split at `MAX_MESSAGE_LINES = 30`), then the budget is allocated 1/3 to oldest messages (head) and 2/3 to newest (tail). The latest message is force-included even if it alone overruns the tail allocation. When messages are skipped, a `... [N messages omitted] ...` marker is inserted between head and tail.
+
 **Synthesis** (`synthesis.py` + `synthesis_cron.py`): Extract transcripts → inject scopes from CWD metadata → LLM summarizes → programmatic daily merge → LTM routing with keyword-overlap dedup (threshold 0.6) + route cap (5/file) → update `.synthesis-state.json` offsets.
 
 **Decay** (`decay.py`): Scan LTM files for `(YYYY-MM-DD)` dated entries → archive entries older than threshold → purge expired archives. `## Pinned` section protected.
@@ -146,5 +148,6 @@ Source of truth: `DEFAULT_SETTINGS` in `scripts/memory_utils.py`.
 | `decay.ageDays` | 30 |
 | `decay.projectWorkingDays` | 20 |
 | `decay.archiveRetentionDays` | 365 |
+| `previousSessionRecall.tokenLimit` | 500 |
 
 Short-term token limits: `workingDays × 750` (calculated in `_calculate_token_limits()`).

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Configure via `~/.claude/memory/settings.json` or `/settings set <path> <value>`
 | `decay.ageDays` | 30 | Archive global LTM entries older than N days |
 | `decay.projectWorkingDays` | 20 | Archive project LTM entries after N project work days |
 | `decay.archiveRetentionDays` | 365 | Purge archived items after N days |
+| `previousSessionRecall.tokenLimit` | 500 | Token budget for previous-session recall; 1/3 head + 2/3 tail allocation |
 
 **Calculated token limits** (short-term): `workingDays × 750 tokens/day`
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,3 @@
+{
+  "extraPaths": ["scripts", "tests"]
+}

--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -25,7 +25,7 @@ import json
 import os
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 # Add scripts directory to path for local imports
@@ -861,7 +861,8 @@ def main() -> None:
 
     # Include current local time for context
     now = datetime.now(timezone.utc).astimezone()
-    utc_offset_hours = now.utcoffset().total_seconds() / 3600
+    offset = now.utcoffset() or timedelta(0)
+    utc_offset_hours = offset.total_seconds() / 3600
     offset_sign = "+" if utc_offset_hours >= 0 else ""
     print(f"Current time: {now.strftime('%Y-%m-%d %H:%M')} (UTC{offset_sign}{utc_offset_hours:.0f})")
     print()

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -265,7 +265,7 @@ DEFAULT_SETTINGS = {
     },
     "previousSessionRecall": {
         "enabled": True,
-        "tokenLimit": 1500,
+        "tokenLimit": 500,
     },
     # totalTokenBudget calculated as sum of 4 components
 }

--- a/scripts/project_manager.py
+++ b/scripts/project_manager.py
@@ -1090,13 +1090,11 @@ def execute_move(
 
     # Use lock for thread safety
     lock_path = get_memory_dir() / ".project_manager.lock"
+    backup_path: Path | None = None
     try:
         with FileLock(lock_path, timeout=30):
             # Create backup
             backup_path = backup_files([Path(f) for f in plan.backups])
-
-            old_encoded = encode_path(str(old_path))
-            new_encoded = encode_path(str(new_path))
 
             # Execute merges
             for source, dest in plan.merges:
@@ -1175,7 +1173,7 @@ def execute_move(
         return {
             "success": False,
             "message": f"Error during move: {e}",
-            "backup_path": str(backup_path) if "backup_path" in locals() else None,
+            "backup_path": str(backup_path) if backup_path else None,
         }
 
 
@@ -1216,6 +1214,7 @@ def execute_merge_orphan(
 
     lock_path = get_memory_dir() / ".project_manager.lock"
     renamed_folders = []
+    backup_path: Path | None = None
 
     try:
         with FileLock(lock_path, timeout=30):
@@ -1365,7 +1364,7 @@ def execute_merge_orphan(
         return {
             "success": False,
             "message": f"Error during merge: {e}",
-            "backup_path": str(backup_path) if "backup_path" in locals() else None,
+            "backup_path": str(backup_path) if backup_path else None,
             "renamed_folders": renamed_folders,
         }
 
@@ -1396,6 +1395,7 @@ def execute_cleanup(confirmed: bool = False) -> dict:
         }
 
     lock_path = get_memory_dir() / ".project_manager.lock"
+    backup_path: Path | None = None
 
     try:
         with FileLock(lock_path, timeout=30):
@@ -1434,7 +1434,7 @@ def execute_cleanup(confirmed: bool = False) -> dict:
             "success": False,
             "message": f"Error during cleanup: {e}",
             "removed_entries": [],
-            "backup_path": str(backup_path) if "backup_path" in locals() else None,
+            "backup_path": str(backup_path) if backup_path else None,
         }
 
 

--- a/scripts/session_end_recall.py
+++ b/scripts/session_end_recall.py
@@ -6,8 +6,9 @@ Reads {session_id, transcript_path, cwd} from stdin JSON (delivered by Claude Co
 Writes ~/.claude/memory/pending-recall/{session_id}.md with:
 - YAML-like frontmatter (session_id, project, timestamp, cwd)
 - First user prompt as blockquote
-- Assistant messages in chronological order (newest-first token budgeting,
-  oldest-first output)
+- Assistant messages with head/tail budget split: oldest-first (1/3 of remaining
+  budget) + newest-last (2/3), with "[N messages omitted]" marker for the
+  skipped middle. Always emits chronological order.
 
 No LLM involved. Targets <5s execution time.
 
@@ -24,6 +25,7 @@ if str(script_dir) not in sys.path:
     sys.path.insert(0, str(script_dir))
 
 from memory_utils import (
+    DEFAULT_SETTINGS,
     find_current_project,
     get_pending_recall_dir,
     get_projects_index_file,
@@ -33,7 +35,7 @@ from memory_utils import (
 )
 from transcript_ops import extract_first_user_prompt, parse_jsonl_file
 
-MAX_MESSAGE_LINES = 50
+MAX_MESSAGE_LINES = 30
 
 
 def _truncate_message(text: str) -> str:
@@ -49,6 +51,54 @@ def _truncate_message(text: str) -> str:
         + [f"\n... [{truncated} lines truncated] ...\n"]
         + lines[-tail:]
     )
+
+
+def _select_messages(
+    messages: list[dict], remaining_budget: int
+) -> tuple[list[str], list[str], int]:
+    """Select head + tail assistant messages within remaining_budget tokens.
+
+    Per-message truncation is applied to all candidates first. The tail (newest)
+    is always primary; if everything fits, it all goes in tail_texts and
+    head_texts is empty. When the budget is tight, allocates 2/3 to tail
+    (newest) and 1/3 to head (oldest); head and tail are disjoint contiguous
+    slices and omitted_count is the gap between them.
+
+    The latest message is always force-included even if it alone exceeds the
+    tail allocation — empty recall is worse than a small overshoot.
+    """
+    truncated = [_truncate_message(m["content"]) for m in messages]
+    n = len(truncated)
+    if n == 0:
+        return [], [], 0
+
+    total_tokens = sum(len(t) // 4 for t in truncated)
+    if total_tokens <= remaining_budget:
+        return [], truncated, 0
+
+    tail_budget = (remaining_budget * 2) // 3
+    head_budget = remaining_budget - tail_budget
+
+    tail_start = n
+    used = 0
+    for i in range(n - 1, -1, -1):
+        msg_tokens = len(truncated[i]) // 4
+        if tail_start < n and used + msg_tokens > tail_budget:
+            break
+        tail_start = i
+        used += msg_tokens
+
+    head_end = 0
+    used = 0
+    for i in range(tail_start):
+        msg_tokens = len(truncated[i]) // 4
+        if used + msg_tokens > head_budget:
+            break
+        head_end = i + 1
+        used += msg_tokens
+
+    omitted = tail_start - head_end
+    return truncated[:head_end], truncated[tail_start:], omitted
 
 
 def write_recall_file(
@@ -71,30 +121,21 @@ def write_recall_file(
         recall_dir = get_pending_recall_dir()
     if token_limit is None:
         settings = load_settings()
-        token_limit = settings.get("previousSessionRecall", {}).get("tokenLimit", 1500)
+        default_limit = DEFAULT_SETTINGS["previousSessionRecall"]["tokenLimit"]
+        token_limit = int(
+            settings.get("previousSessionRecall", {}).get("tokenLimit", default_limit)
+            or default_limit
+        )
 
     first_prompt = extract_first_user_prompt(transcript_path)
-
     messages = parse_jsonl_file(transcript_path)
 
-    collected = []
-    running_tokens = 0
+    prompt_tokens = len(first_prompt) // 4 + 5 if first_prompt else 0
+    remaining_budget = max(0, token_limit - prompt_tokens)
+    head_texts, tail_texts, omitted_count = _select_messages(messages, remaining_budget)
 
-    if first_prompt:
-        running_tokens += len(first_prompt) // 4 + 5
-
-    for msg in reversed(messages):
-        text = _truncate_message(msg["content"])
-        msg_tokens = len(text) // 4
-        if running_tokens + msg_tokens > token_limit:
-            break
-        collected.append(text)
-        running_tokens += msg_tokens
-
-    if not collected and not first_prompt:
+    if not head_texts and not tail_texts and not first_prompt:
         return
-
-    collected.reverse()
 
     resolved_cwd = resolve_session_path(cwd)
     projects_index = load_json_file(get_projects_index_file(), {})
@@ -114,7 +155,15 @@ def write_recall_file(
         parts.extend(f"> {line}" for line in first_prompt.splitlines())
         parts.append("")
 
-    parts.extend("\n\n".join(collected).split("\n"))
+    sections = []
+    if head_texts:
+        sections.append("\n\n".join(head_texts))
+    if omitted_count > 0:
+        sections.append(f"... [{omitted_count} messages omitted] ...")
+    if tail_texts:
+        sections.append("\n\n".join(tail_texts))
+    if sections:
+        parts.extend("\n\n".join(sections).split("\n"))
     parts.append("")
 
     recall_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/session_end_recall.py
+++ b/scripts/session_end_recall.py
@@ -122,10 +122,8 @@ def write_recall_file(
     if token_limit is None:
         settings = load_settings()
         default_limit = DEFAULT_SETTINGS["previousSessionRecall"]["tokenLimit"]
-        token_limit = int(
-            settings.get("previousSessionRecall", {}).get("tokenLimit", default_limit)
-            or default_limit
-        )
+        configured = settings.get("previousSessionRecall", {}).get("tokenLimit")
+        token_limit = configured if isinstance(configured, int) else default_limit
 
     first_prompt = extract_first_user_prompt(transcript_path)
     messages = parse_jsonl_file(transcript_path)

--- a/scripts/synthesis.py
+++ b/scripts/synthesis.py
@@ -20,6 +20,7 @@ import io
 import json
 import re
 import sys
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -457,7 +458,7 @@ _SCOPED_ENTRY = re.compile(r"^\s*-\s*(?:\[routed\])?\s*\[[a-z0-9-]+(?:\|[a-z0-9-
 
 def inject_scopes(
     dailies: list[DailyFile],
-    session_projects: dict[str, str | None],
+    session_projects: Mapping[str, str | None],
 ) -> list[DailyFile]:
     """Inject project scope tags into daily entries based on session metadata.
 

--- a/tests/test_devtools.py
+++ b/tests/test_devtools.py
@@ -292,7 +292,7 @@ class TestStatsCommand:
             result = cmd_stats(argparse.Namespace())
         assert result == 0
         output = capsys.readouterr().out
-        runs_line = next(l for l in output.strip().splitlines() if l.strip().startswith("Runs:"))
+        runs_line = next(line for line in output.strip().splitlines() if line.strip().startswith("Runs:"))
         parts = runs_line.split()
         assert parts[1] == "1"
         assert parts[2] == "2"
@@ -309,7 +309,7 @@ class TestStatsCommand:
             result = cmd_stats(argparse.Namespace())
         assert result == 0
         output = capsys.readouterr().out
-        errors_line = next(l for l in output.strip().splitlines() if l.strip().startswith("Errors:"))
+        errors_line = next(line for line in output.strip().splitlines() if line.strip().startswith("Errors:"))
         parts = errors_line.split()
         assert parts[1] == "2"
         assert parts[2] == "2"
@@ -325,7 +325,7 @@ class TestStatsCommand:
             result = cmd_stats(argparse.Namespace())
         assert result == 0
         output = capsys.readouterr().out
-        runs_line = next(l for l in output.strip().splitlines() if l.strip().startswith("Runs:"))
+        runs_line = next(line for line in output.strip().splitlines() if line.strip().startswith("Runs:"))
         parts = runs_line.split()
         assert parts[1] == "1"
         assert parts[2] == "1"

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -863,7 +863,7 @@ class TestSuggestPathCorrection:
                 "/some/other/path/myproject", project_data, {},
             )
         assert suggested == str(live_dir)
-        assert "basename match" in strategy
+        assert strategy is not None and "basename match" in strategy
 
     def test_basename_scan_strategy_grandchild(self, tmp_path):
         """Strategy 3: basename found as grandchild of $HOME."""
@@ -878,7 +878,7 @@ class TestSuggestPathCorrection:
                 "/some/other/path/myproject", project_data, {},
             )
         assert suggested == str(live_dir)
-        assert "basename match" in strategy
+        assert strategy is not None and "basename match" in strategy
 
     def test_no_match_returns_none(self, tmp_path):
         """No strategies match -> (None, None)."""

--- a/tests/test_integration_git_subdir.py
+++ b/tests/test_integration_git_subdir.py
@@ -18,23 +18,25 @@ Run with: python -m pytest tests/test_integration_git_subdir.py -v
 
 import copy
 import json
-import os
-import sys
-from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch
 
 import pytest
+
 
 # ---------------------------------------------------------------------------
 # Attempt to import not-yet-existing functions.
 # Tests that need them are marked xfail so the file itself doesn't crash.
 # ---------------------------------------------------------------------------
+def _missing_resolver(*_args, **_kwargs):
+    raise NotImplementedError("resolve_session_path not yet implemented")
+
+
 try:
     from memory_utils import resolve_git_subdir_to_root, resolve_session_path
     _RESOLVE_SESSION_PATH_EXISTS = True
 except ImportError:
-    resolve_git_subdir_to_root = None  # type: ignore[assignment]
-    resolve_session_path = None        # type: ignore[assignment]
+    resolve_git_subdir_to_root = _missing_resolver  # type: ignore[assignment]
+    resolve_session_path = _missing_resolver        # type: ignore[assignment]
     _RESOLVE_SESSION_PATH_EXISTS = False
 
 # These exist today and must always import cleanly.
@@ -42,7 +44,6 @@ from memory_utils import (  # noqa: E402
     DEFAULT_SETTINGS,
     _calculate_token_limits,
     find_current_project,
-    resolve_worktree_to_main_repo,
 )
 
 # =============================================================================
@@ -57,6 +58,7 @@ needs_resolve_session_path = pytest.mark.xfail(
 
 # find_current_project must accept exactly 2 args
 import inspect as _inspect
+
 _FCP_TWO_ARGS = len(_inspect.signature(find_current_project).parameters) == 2
 
 # Wiring checks: callers must import resolve_session_path (not just that it exists)

--- a/tests/test_load_memory.py
+++ b/tests/test_load_memory.py
@@ -1450,6 +1450,7 @@ class TestCheckSynthesisErrors:
         with mock.patch("load_memory.SYNTHESIS_ERROR_LOG", error_log):
             result = check_synthesis_errors()
         # Should contain errors 5-9 (last 5), not 0-4
+        assert result is not None
         assert "error 5" in result
         assert "error 9" in result
         assert "error 0" not in result

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -1452,7 +1452,8 @@ class TestPreviousSessionRecallSetting:
     def test_default_settings_has_previous_session_recall(self):
         recall_settings = DEFAULT_SETTINGS["previousSessionRecall"]
         assert recall_settings["enabled"] is True
-        assert recall_settings["tokenLimit"] == 1500
+        assert isinstance(recall_settings["tokenLimit"], int)
+        assert recall_settings["tokenLimit"] > 0
 
     def test_load_settings_merges_recall_override(self, tmp_path):
         settings_file = tmp_path / "settings.json"

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from project_manager import (  # noqa: I001
     backup_files,
     decode_path_best_effort,

--- a/tests/test_session_end_recall.py
+++ b/tests/test_session_end_recall.py
@@ -182,6 +182,35 @@ class TestWriteRecallFile:
         content = (recall_dir / "force-test.md").read_text()
         assert "BIGMSG" in content
 
+    def test_zero_token_limit_respected_not_silent_fallback(self, tmp_path):
+        """tokenLimit: 0 is respected literally (no silent fallback to default)."""
+        transcript = tmp_path / "session.jsonl"
+        transcript.write_text(make_jsonl_content([
+            ("user", "start"),
+            ("assistant", "should-not-appear-1"),
+            ("assistant", "should-not-appear-2"),
+            ("assistant", "FORCE_INCLUDED"),
+        ]))
+        recall_dir = tmp_path / "pending-recall"
+
+        zero_settings = {**DEFAULT_SETTINGS, "previousSessionRecall": {"enabled": True, "tokenLimit": 0}}
+        from session_end_recall import write_recall_file
+        with patch("session_end_recall.load_settings", return_value=zero_settings):
+            write_recall_file(
+                session_id="zero-test",
+                transcript_path=transcript,
+                cwd="/test",
+                recall_dir=recall_dir,
+            )
+
+        content = (recall_dir / "zero-test.md").read_text()
+        # First user prompt always emitted; force-include guarantees latest assistant
+        assert "> start" in content
+        assert "FORCE_INCLUDED" in content
+        # Earlier messages must be omitted under zero budget
+        assert "should-not-appear-1" not in content
+        assert "should-not-appear-2" not in content
+
     def test_no_marker_when_head_meets_tail(self, tmp_path):
         """When head and tail together cover all messages with no gap, no marker."""
         msgs = [("user", "start")]

--- a/tests/test_session_end_recall.py
+++ b/tests/test_session_end_recall.py
@@ -1,7 +1,4 @@
 import json
-import textwrap
-from datetime import datetime, timezone
-from pathlib import Path
 from unittest.mock import patch
 
 from helpers import make_jsonl_content
@@ -75,8 +72,10 @@ class TestWriteRecallFile:
         assert body_tokens <= token_limit + 100
 
     def test_per_message_truncation(self, tmp_path):
-        """Messages over 50 lines get head/tail truncated."""
-        long_msg = "\n".join(f"line {i}" for i in range(100))
+        """Messages over MAX_MESSAGE_LINES get head/tail truncated."""
+        from session_end_recall import MAX_MESSAGE_LINES, write_recall_file
+
+        long_msg = "\n".join(f"line {i}" for i in range(MAX_MESSAGE_LINES * 2))
         transcript = tmp_path / "session.jsonl"
         transcript.write_text(make_jsonl_content([
             ("user", "start"),
@@ -84,7 +83,6 @@ class TestWriteRecallFile:
         ]))
         recall_dir = tmp_path / "pending-recall"
 
-        from session_end_recall import write_recall_file
         write_recall_file(
             session_id="truncate-test",
             transcript_path=transcript,
@@ -93,7 +91,7 @@ class TestWriteRecallFile:
         )
 
         content = (recall_dir / "truncate-test.md").read_text()
-        assert "[" in content and "truncated" in content.lower() or "..." in content
+        assert "lines truncated" in content
 
     def test_empty_transcript(self, tmp_path):
         """Empty transcript produces no recall file."""
@@ -110,6 +108,99 @@ class TestWriteRecallFile:
         )
 
         assert not (recall_dir / "empty-test.md").exists()
+
+    def test_head_tail_split_with_omitted_marker(self, tmp_path):
+        """Tight budget keeps oldest + newest messages and inserts omission marker."""
+        msgs = [("user", "start")]
+        msgs.extend(("assistant", f"MSG{i}: " + "x" * 200) for i in range(10))
+        transcript = tmp_path / "session.jsonl"
+        transcript.write_text(make_jsonl_content(msgs))
+        recall_dir = tmp_path / "pending-recall"
+
+        from session_end_recall import write_recall_file
+        write_recall_file(
+            session_id="split-test",
+            transcript_path=transcript,
+            cwd="/test",
+            recall_dir=recall_dir,
+            token_limit=200,
+        )
+
+        content = (recall_dir / "split-test.md").read_text()
+        assert "messages omitted" in content
+        assert "MSG0" in content
+        assert "MSG9" in content
+        marker_pos = content.index("messages omitted")
+        msg0_pos = content.index("MSG0")
+        msg9_pos = content.index("MSG9")
+        assert msg0_pos < marker_pos < msg9_pos
+
+    def test_no_marker_when_everything_fits(self, tmp_path):
+        """Generous budget includes all messages with no omission marker."""
+        transcript = tmp_path / "session.jsonl"
+        transcript.write_text(make_jsonl_content([
+            ("user", "start"),
+            ("assistant", "first"),
+            ("assistant", "second"),
+            ("assistant", "third"),
+        ]))
+        recall_dir = tmp_path / "pending-recall"
+
+        from session_end_recall import write_recall_file
+        write_recall_file(
+            session_id="fits-test",
+            transcript_path=transcript,
+            cwd="/test",
+            recall_dir=recall_dir,
+            token_limit=500,
+        )
+
+        content = (recall_dir / "fits-test.md").read_text()
+        assert "messages omitted" not in content
+        assert all(s in content for s in ("first", "second", "third"))
+
+    def test_latest_message_force_included(self, tmp_path):
+        """Single message exceeding tail budget is still included."""
+        big_msg = "BIGMSG: " + "y" * 4000
+        transcript = tmp_path / "session.jsonl"
+        transcript.write_text(make_jsonl_content([
+            ("user", "start"),
+            ("assistant", "earlier"),
+            ("assistant", big_msg),
+        ]))
+        recall_dir = tmp_path / "pending-recall"
+
+        from session_end_recall import write_recall_file
+        write_recall_file(
+            session_id="force-test",
+            transcript_path=transcript,
+            cwd="/test",
+            recall_dir=recall_dir,
+            token_limit=100,
+        )
+
+        content = (recall_dir / "force-test.md").read_text()
+        assert "BIGMSG" in content
+
+    def test_no_marker_when_head_meets_tail(self, tmp_path):
+        """When head and tail together cover all messages with no gap, no marker."""
+        msgs = [("user", "start")]
+        msgs.extend(("assistant", f"M{i}") for i in range(4))
+        transcript = tmp_path / "session.jsonl"
+        transcript.write_text(make_jsonl_content(msgs))
+        recall_dir = tmp_path / "pending-recall"
+
+        from session_end_recall import write_recall_file
+        write_recall_file(
+            session_id="nogap-test",
+            transcript_path=transcript,
+            cwd="/test",
+            recall_dir=recall_dir,
+            token_limit=50,
+        )
+
+        content = (recall_dir / "nogap-test.md").read_text()
+        assert "messages omitted" not in content
 
     def test_chronological_output_order(self, tmp_path):
         """Assistant messages appear oldest-to-newest in output."""
@@ -208,6 +299,7 @@ class TestMainEntryPoint:
         })
 
         import io
+
         from session_end_recall import main as recall_main
         with patch("sys.stdin", io.StringIO(stdin_data)), \
              patch("session_end_recall.get_pending_recall_dir", return_value=recall_dir), \


### PR DESCRIPTION
## Summary
- Replaces newest-first-only message selection in `session_end_recall.py` with a 1/3-head + 2/3-tail split, with `... [N messages omitted] ...` marker between them. The latest message is force-included even if it alone exceeds the tail allocation, so recall is never empty.
- Lowers `MAX_MESSAGE_LINES` 50 → 30 and default `previousSessionRecall.tokenLimit` 1500 → 500. Empirically only long-debugging sessions hit either threshold.
- Adds `pyrightconfig.json` with `extraPaths: ["scripts", "tests"]` so static analysis resolves the runtime sys.path additions, and fixes the 25 pre-existing real type errors that surfaced once paths resolved (load_memory `utcoffset` None, project_manager `backup_path` possibly unbound, synthesis `inject_scopes` dict variance, several test-file optional-call/in-on-Optional patterns).

## Test plan
- `pytest tests/ -q` — 817 passed (5 new tests for head/tail split, no-marker fits-all, force-include latest, no-marker-when-no-gap, plus per-message line cap test)
- `pyright .` — 0 errors, 0 warnings, 0 informations
- `ruff check .` — All checks passed

## Behavior change
Default recall in next session: ~500-token budget (down from ~1500). Long sessions now show the first user prompt, ~1-2 oldest assistant messages, the omission marker, and the latest 2-4 messages — instead of just the tail end of the conversation.

Co-Authored-By: Claude <noreply@anthropic.com>