### PR TITLE
chore(synthesis): set intervalHours default to 1h, derive launchd StartInterval from DEFAULT_SETTINGS

### DIFF
--- a/install.py
+++ b/install.py
@@ -28,6 +28,7 @@ from pathlib import Path
 # Import shared utilities from scripts/memory_utils.py (same repo, no symlink needed)
 sys.path.insert(0, str(Path(__file__).parent / "scripts"))
 from memory_utils import (  # noqa: E402
+    DEFAULT_SETTINGS,
     MIN_PYTHON,
     get_claude_dir,
     get_memory_dir,
@@ -299,7 +300,7 @@ def install_launchd_agent(python_cmd: str) -> None:
     plist = {
         "Label": LAUNCHD_LABEL,
         "ProgramArguments": [python_path, str(scripts_dir / "synthesis_cron.py")],
-        "StartInterval": 7200,  # Every 2 hours (matches systemd timer)
+        "StartInterval": int(DEFAULT_SETTINGS["synthesis"]["intervalHours"] * 3600),
         "StandardOutPath": str(log_dir / "synthesis.log"),
         "StandardErrorPath": str(log_dir / "synthesis.err"),
         "EnvironmentVariables": {

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -254,7 +254,7 @@ DEFAULT_SETTINGS = {
         "tokenLimit": 3000,
     },
     "synthesis": {
-        "intervalHours": 0.5,
+        "intervalHours": 2,
         "model": "sonnet",
         "minSessionMessages": 5,
     },

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -254,7 +254,7 @@ DEFAULT_SETTINGS = {
         "tokenLimit": 3000,
     },
     "synthesis": {
-        "intervalHours": 2,
+        "intervalHours": 1,
         "model": "sonnet",
         "minSessionMessages": 5,
     },

--- a/systemd/claude-memory-synthesis.timer
+++ b/systemd/claude-memory-synthesis.timer
@@ -2,7 +2,7 @@
 Description=Run Claude Memory Synthesis periodically
 
 [Timer]
-OnCalendar=*-*-* 0/2:00:00
+OnCalendar=*-*-* 0/1:00:00
 Persistent=true
 RandomizedDelaySec=300
 

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -20,7 +20,7 @@
     "_comment": "project-memory/{project}-long-term-memory.md - project-specific learnings"
   },
   "synthesis": {
-    "intervalHours": 2,
+    "intervalHours": 1,
     "model": "sonnet",
     "minSessionMessages": 5,
     "_comment": "Minimum hours between auto-synthesis runs. Model: sonnet (default)|haiku|opus. minSessionMessages: skip sessions with fewer messages during synthesis."
@@ -50,7 +50,7 @@
     "globalLongTerm.tokenLimit": 3000,
     "projectShortTerm.workingDays": 5,
     "projectLongTerm.tokenLimit": 3000,
-    "synthesis.intervalHours": 2,
+    "synthesis.intervalHours": 1,
     "synthesis.model": "sonnet",
     "synthesis.minSessionMessages": 5,
     "decay.ageDays": 30,

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -20,7 +20,7 @@
     "_comment": "project-memory/{project}-long-term-memory.md - project-specific learnings"
   },
   "synthesis": {
-    "intervalHours": 0.5,
+    "intervalHours": 2,
     "model": "sonnet",
     "minSessionMessages": 5,
     "_comment": "Minimum hours between auto-synthesis runs. Model: sonnet (default)|haiku|opus. minSessionMessages: skip sessions with fewer messages during synthesis."
@@ -50,7 +50,7 @@
     "globalLongTerm.tokenLimit": 3000,
     "projectShortTerm.workingDays": 5,
     "projectLongTerm.tokenLimit": 3000,
-    "synthesis.intervalHours": 0.5,
+    "synthesis.intervalHours": 2,
     "synthesis.model": "sonnet",
     "synthesis.minSessionMessages": 5,
     "decay.ageDays": 30,


### PR DESCRIPTION
## Summary
- Changes default `synthesis.intervalHours` from 0.5 to 1h (session recall makes 30-min interval unnecessary; launchd fires every hour which matches)
- `install.py` now derives launchd `StartInterval` from `DEFAULT_SETTINGS["synthesis"]["intervalHours"] * 3600` — single source of truth instead of hardcoded `7200`
- Systemd timer updated to `0/1:00:00` to match

## Test plan
- [ ] Verify `python3 install.py` produces launchd plist with `StartInterval: 3600`
- [ ] Verify `~/.claude/memory/settings.json` has `intervalHours: 1`
- [ ] Confirm synthesis stats show ~24 runs/day (vs 48 before) after next full day

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Memory synthesis scheduling interval updated to 1 hour across all systems
  * macOS installer scheduling now derives from centralized configuration settings instead of hardcoded values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->