### PR TITLE
feat(skills): add /load-project-memory for on-demand project memory loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The installer detects your Python command and configures hooks with absolute pat
 | `/recall [query]` | Search through all historical daily memory files |
 | `/settings` | View/modify memory settings and check token usage |
 | `/projects` | Manage project data — list status, merge orphans, cleanup stale entries |
+| `/load-project-memory [name]` | Inject a project's LTM + STM into the current session (useful in light mode or when switching projects) |
 
 ## How It Works
 

--- a/install.py
+++ b/install.py
@@ -198,7 +198,7 @@ def link_skills(script_dir: Path) -> None:
     """Symlink skill directories to ~/.claude/skills/."""
     skills_dir = get_claude_dir() / "skills"
 
-    skills = ["remember", "synthesize", "recall", "settings", "projects", "audit"]
+    skills = ["remember", "synthesize", "recall", "settings", "projects", "audit", "load-project-memory"]
 
     for skill in skills:
         src_dir = script_dir / "skills" / skill

--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -796,6 +796,73 @@ def write_synthesis_prompt(exclude_session_id: str | None = None) -> None:
         print(f"prompt_file={prompt_path}")
 
 
+def emit_project_memory(project_name_arg: str | None = None) -> int:
+    """Emit project LTM + project STM sections to stdout.
+
+    Used by the /load-project-memory skill to inject project-scoped memory
+    on demand mid-session (most useful in light mode, where these sections
+    are skipped at SessionStart).
+
+    Args:
+        project_name_arg: Explicit project name. If None, detect from cwd via
+            the projects index.
+
+    Returns:
+        Exit code (0 on success, 1 if requested project has no memory).
+    """
+    check_python_version()
+
+    settings = load_settings()
+    project_days = settings["projectShortTerm"]["workingDays"]
+
+    if project_name_arg:
+        project_name = project_name_arg
+        project = {"name": project_name}
+    else:
+        pwd = resolve_session_path(os.getcwd())
+        projects_index = load_json_file(get_projects_index_file(), {})
+        current_project = find_current_project(projects_index, pwd)
+        if not current_project:
+            print(
+                f"No project detected for cwd: {pwd}\n"
+                "Pass an explicit project name (e.g. /load-project-memory <name>).",
+                file=sys.stderr,
+            )
+            return 1
+        project = current_project
+        project_name = project.get("name", "")
+
+    project_content, _ = load_project_memory(project_name)
+    project_history, _ = load_project_history(project, project_days)
+
+    if not project_content and not project_history:
+        print(
+            f"No project memory found for: {project_name}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("<project-memory>")
+    print(f"Project: {project_name}")
+    print()
+
+    if project_content:
+        print(f"## Project Long-Term Memory: {project_name}")
+        print(project_content)
+        print()
+
+    if project_history:
+        print(f"## Project Short-Term Memory: {project_name}")
+        print()
+        for date, content in project_history:
+            print(f"### {date}")
+            print(content)
+            print()
+
+    print("</project-memory>")
+    return 0
+
+
 def main() -> None:
     """Main entry point - outputs memory context to stdout.
 
@@ -943,5 +1010,9 @@ if __name__ == "__main__":
         if len(sys.argv) > 3 and sys.argv[2] == "--exclude-session":
             exclude_id = sys.argv[3]
         write_synthesis_prompt(exclude_session_id=exclude_id)
+    elif len(sys.argv) > 1 and sys.argv[1] == "--project-memory":
+        # --project-memory [name]: emit project LTM + project STM (for /load-project-memory skill)
+        name_arg = sys.argv[2] if len(sys.argv) > 2 else None
+        sys.exit(emit_project_memory(name_arg))
     else:
         main()

--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -808,7 +808,8 @@ def emit_project_memory(project_name_arg: str | None = None) -> int:
             the projects index.
 
     Returns:
-        Exit code (0 on success, 1 if requested project has no memory).
+        Exit code (0 on success, 1 on failure — either no project detected
+        for the cwd or no memory found for the requested project).
     """
     check_python_version()
 

--- a/skills/load-project-memory/SKILL.md
+++ b/skills/load-project-memory/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: load-project-memory
+description: Use when user wants to load a project's long-term and short-term memory mid-session — typically when running in light mode and Claude lacks project-specific context
+user-invokable: true
+---
+
+# Load Project Memory
+
+Inject a project's long-term memory and recent short-term history into the current session. Useful when:
+
+- Memory system is in `light` mode (project sections are skipped at SessionStart)
+- You've switched focus to a different project mid-session
+- Claude doesn't seem to remember prior work on the project at hand
+
+## Usage
+
+- `/load-project-memory` — load memory for the project matching `$PWD`
+- `/load-project-memory <name>` — load memory for a named project (e.g. `/load-project-memory swyfft`)
+
+## Instructions
+
+1. Parse the optional project name argument from the user's invocation.
+2. Run the loader script via Bash:
+
+   ```bash
+   python3 $HOME/.claude/scripts/load_memory.py --project-memory [name]
+   ```
+
+   Omit `[name]` to use cwd-based detection.
+
+3. The script prints a `<project-memory>...</project-memory>` block containing:
+   - `## Project Long-Term Memory: <name>` (the project's LTM file)
+   - `## Project Short-Term Memory: <name>` (recent daily entries scoped to the project)
+
+4. The output flows directly into context — no further action is needed. Acknowledge briefly to the user that the project's memory has been loaded.
+
+## Notes
+
+- This is the on-demand equivalent of what `mode: full` loads automatically at SessionStart. It does **not** load global short-term memory; if you need that too, switch the system to full mode via `/settings set mode full` (next session) or invoke `load_memory.py` directly.
+- If the named project has no LTM file and no tagged daily entries, the script exits non-zero with a short stderr message.
+- Project name lookup uses the same names registered in `~/.claude/memory/projects-index.json`. Run `/projects` to list known names.

--- a/skills/load-project-memory/SKILL.md
+++ b/skills/load-project-memory/SKILL.md
@@ -20,13 +20,17 @@ Inject a project's long-term memory and recent short-term history into the curre
 ## Instructions
 
 1. Parse the optional project name argument from the user's invocation.
-2. Run the loader script via Bash:
+2. Run the loader script via Bash. Use **one of the two forms below** — do not pass the literal string `<name>` as argv. Always quote the project name to prevent shell metacharacter interpretation:
 
    ```bash
-   python3 $HOME/.claude/scripts/load_memory.py --project-memory [name]
+   # No argument — uses cwd-based project detection
+   python3 $HOME/.claude/scripts/load_memory.py --project-memory
    ```
 
-   Omit `[name]` to use cwd-based detection.
+   ```bash
+   # Explicit project name (substitute the user's argument; keep it quoted)
+   python3 $HOME/.claude/scripts/load_memory.py --project-memory "swyfft"
+   ```
 
 3. The script prints a `<project-memory>...</project-memory>` block containing:
    - `## Project Long-Term Memory: <name>` (the project's LTM file)

--- a/tests/test_load_memory.py
+++ b/tests/test_load_memory.py
@@ -1871,5 +1871,122 @@ class TestMainOutputOrder:
         assert "## Long-Term Memory" not in output
 
 
+# =============================================================================
+# emit_project_memory Tests
+# =============================================================================
+
+
+class TestEmitProjectMemory:
+    """Verify the on-demand project memory emitter (used by /load-project-memory)."""
+
+    def _run(self, monkeypatch, *, project_ltm="", project_stm=None,
+             current_project=None, project_name_arg=None):
+        import io
+
+        from load_memory import emit_project_memory
+
+        project_stm = project_stm or []
+
+        monkeypatch.setattr("load_memory.load_project_memory", lambda name: (project_ltm, len(project_ltm)))
+        monkeypatch.setattr(
+            "load_memory.load_project_history",
+            lambda proj, days: (project_stm, sum(len(c) for _, c in project_stm)),
+        )
+        monkeypatch.setattr("load_memory.resolve_session_path", lambda p: p)
+        monkeypatch.setattr("load_memory.load_json_file", lambda *a, **kw: {})
+        monkeypatch.setattr("load_memory.find_current_project", lambda idx, pwd: current_project)
+        monkeypatch.setattr("load_memory.load_settings", lambda: {
+            **DEFAULT_SETTINGS,
+            "projectShortTerm": {"workingDays": 5, "tokenLimit": 3750},
+        })
+
+        out = io.StringIO()
+        err = io.StringIO()
+        monkeypatch.setattr("sys.stdout", out)
+        monkeypatch.setattr("sys.stderr", err)
+        rc = emit_project_memory(project_name_arg)
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_explicit_name_emits_ltm_and_stm(self, monkeypatch):
+        rc, stdout, _ = self._run(
+            monkeypatch,
+            project_ltm="- (2026-01-01) [pattern] ltm-line",
+            project_stm=[("2026-04-21", "- [swyfft/implement] stm-line")],
+            project_name_arg="swyfft",
+        )
+        assert rc == 0
+        assert "<project-memory>" in stdout
+        assert stdout.rstrip().endswith("</project-memory>")
+        assert "Project: swyfft" in stdout
+        assert "## Project Long-Term Memory: swyfft" in stdout
+        assert "ltm-line" in stdout
+        assert "## Project Short-Term Memory: swyfft" in stdout
+        assert "2026-04-21" in stdout
+        assert "stm-line" in stdout
+
+    def test_uses_cwd_when_no_arg(self, monkeypatch):
+        rc, stdout, _ = self._run(
+            monkeypatch,
+            project_ltm="- (2026-01-01) [pattern] cwd-ltm",
+            current_project={"name": "cwdproject"},
+        )
+        assert rc == 0
+        assert "Project: cwdproject" in stdout
+        assert "cwd-ltm" in stdout
+
+    def test_no_project_detected_returns_error(self, monkeypatch):
+        rc, stdout, stderr = self._run(
+            monkeypatch,
+            current_project=None,
+        )
+        assert rc == 1
+        assert stdout == ""
+        assert "No project detected" in stderr
+
+    def test_empty_project_returns_error(self, monkeypatch):
+        rc, stdout, stderr = self._run(
+            monkeypatch,
+            project_name_arg="ghost",
+        )
+        assert rc == 1
+        assert stdout == ""
+        assert "No project memory found" in stderr
+        assert "ghost" in stderr
+
+    def test_emits_ltm_only(self, monkeypatch):
+        rc, stdout, _ = self._run(
+            monkeypatch,
+            project_ltm="- (2026-01-01) [pattern] only-ltm",
+            project_name_arg="proj",
+        )
+        assert rc == 0
+        assert "## Project Long-Term Memory: proj" in stdout
+        assert "only-ltm" in stdout
+        assert "## Project Short-Term Memory" not in stdout
+
+    def test_emits_stm_only(self, monkeypatch):
+        rc, stdout, _ = self._run(
+            monkeypatch,
+            project_stm=[("2026-04-21", "- [proj/implement] only-stm")],
+            project_name_arg="proj",
+        )
+        assert rc == 0
+        assert "## Project Short-Term Memory: proj" in stdout
+        assert "only-stm" in stdout
+        assert "## Project Long-Term Memory" not in stdout
+
+    def test_explicit_arg_overrides_cwd_project(self, monkeypatch):
+        """Passing a name should bypass cwd detection entirely."""
+        rc, stdout, _ = self._run(
+            monkeypatch,
+            project_ltm="- (2026-01-01) [pattern] arg-ltm",
+            project_name_arg="explicit",
+            current_project={"name": "shouldnotmatter"},
+        )
+        assert rc == 0
+        assert "Project: explicit" in stdout
+        assert "Project: shouldnotmatter" not in stdout
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_load_memory.py
+++ b/tests/test_load_memory.py
@@ -1895,10 +1895,7 @@ class TestEmitProjectMemory:
         monkeypatch.setattr("load_memory.resolve_session_path", lambda p: p)
         monkeypatch.setattr("load_memory.load_json_file", lambda *a, **kw: {})
         monkeypatch.setattr("load_memory.find_current_project", lambda idx, pwd: current_project)
-        monkeypatch.setattr("load_memory.load_settings", lambda: {
-            **DEFAULT_SETTINGS,
-            "projectShortTerm": {"workingDays": 5, "tokenLimit": 3750},
-        })
+        monkeypatch.setattr("load_memory.load_settings", lambda: dict(DEFAULT_SETTINGS))
 
         out = io.StringIO()
         err = io.StringIO()

--- a/uninstall.py
+++ b/uninstall.py
@@ -209,6 +209,7 @@ def purge_memory_data() -> None:
         claude_dir / "skills" / "settings",
         claude_dir / "skills" / "projects",
         claude_dir / "skills" / "audit",
+        claude_dir / "skills" / "load-project-memory",
         # Hook scripts
         claude_dir / "hooks" / "pretooluse-allow-memory.sh",
         # Scripts (current)
@@ -266,7 +267,7 @@ def print_cleanup_instructions() -> None:
     print("Or manually:")
     print()
     print("  rm -rf ~/.claude/memory")
-    print("  rm -rf ~/.claude/skills/{remember,synthesize,recall,settings,projects,audit}")
+    print("  rm -rf ~/.claude/skills/{remember,synthesize,recall,settings,projects,audit,load-project-memory}")
     print("  rm -rf ~/.claude/hooks  # if empty after removing memory hook")
     print("  rm ~/.claude/scripts/{memory_utils,load_memory,indexing,transcript_ops,decay,token_usage,project_manager,synthesis_cron,synthesis,devtools}.py")
     if sys.platform == "darwin":

--- a/uninstall.py
+++ b/uninstall.py
@@ -233,7 +233,13 @@ def purge_memory_data() -> None:
 
     removed = []
     for item in items_to_remove:
-        if item.exists():
+        # is_symlink() must be checked before is_dir(): is_dir() follows symlinks
+        # and rmtree() refuses to remove a symlink-to-directory. Skills and scripts
+        # are installed as symlinks by install.py.
+        if item.is_symlink():
+            item.unlink()
+            removed.append(str(item.relative_to(Path.home())))
+        elif item.exists():
             if item.is_dir():
                 shutil.rmtree(item)
             else:


### PR DESCRIPTION
## Summary
- New `/load-project-memory [name]` skill injects a project's LTM + recent STM into the current session — fixes the gap in `light` mode where project context isn't loaded at SessionStart, and helps when switching focus mid-session.
- Adds `--project-memory [name]` CLI flag to `scripts/load_memory.py` that reuses existing `load_project_memory()` / `load_project_history()`. Accepts an explicit project name or falls back to cwd-based detection via the projects index.
- README updated; `install.py` / `uninstall.py` wired up.

## Test plan
- 7 new tests in `tests/test_load_memory.py::TestEmitProjectMemory` cover: explicit name, cwd detection, no-project-detected error, missing-memory error, LTM-only, STM-only, and arg-overrides-cwd. All pass.
- Full suite: 826 passed, 1 pre-existing failure (`TestInstallLaunchdAgent::test_creates_plist_file`) unrelated to this change — verified via `git stash` it fails on `main` too (stale expectation from PR #139's intervalHours default change).
- Smoke-tested CLI directly: `python3 scripts/load_memory.py --project-memory claude-memory-system` emits the expected `<project-memory>` block; `--project-memory nonexistent` exits 1 with stderr message.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `/load-project-memory [name]` command to inject project-scoped long-term and short-term memory into your current session, with automatic project detection from working directory when no project name is specified.

* **Documentation**
  * Added command reference to README.

* **Chores**
  * Updated installation and uninstall processes to support the new skill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->