### PR TITLE
docs(install): mention /load-project-memory in success message

### DIFF
--- a/install.py
+++ b/install.py
@@ -596,6 +596,7 @@ def print_success_message() -> None:
     print("  /settings   - View/modify memory settings & token usage")
     print("  /projects   - Manage projects (move, merge orphans, cleanup)")
     print("  /audit      - Audit long-term memory for stale or incorrect entries")
+    print("  /load-project-memory [name] - Load a project's LTM + STM on demand (useful in light mode)")
     print()
     print("Memory location: ~/.claude/memory/")
     print("  - global-long-term-memory.md  (loaded every session)")


### PR DESCRIPTION
## Summary
The install.py success banner listed six commands but didn't mention the new `/load-project-memory` skill installed alongside them. One-line addition to the printed list.

## Test plan
- Trivial print-statement change; no test changes needed.

Co-Authored-By: Claude <noreply@anthropic.com>