### PR TITLE
feat(skills): require post-load summary in /load-project-memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ claude-memory-system/
 │   ├── project_manager.py      # Project lifecycle management library
 │   ├── devtools.py             # Dev diagnostics + mark-routed dedup migration
 │   └── synthesis_cron.py       # Deferred synthesis runner (systemd timer entry point)
-├── skills/                     # /remember, /synthesize, /recall, /settings, /projects
+├── skills/                     # /remember, /synthesize, /recall, /settings, /projects, /audit, /load-project-memory
 ├── systemd/                    # Systemd user units for deferred synthesis
 ├── tests/                      # Unit tests
 └── templates/                  # Memory file templates + default settings.json
@@ -98,6 +98,8 @@ python3 ~/.claude/scripts/decay.py --dry-run # Test decay
 **Loading** (`load_memory.py`): Reads LTM files + filters daily files by scope tags → assembles full memory to stdout for SessionStart hook injection. Output order: read instruction → timestamp → recall → global LTM → project LTM → project STM → global STM. When output exceeds ~10K chars, Claude Code saves it to a session-specific file and shows the path + 2KB preview; the read instruction in the first 2KB prompts Claude to read the full file.
 
 **Mode**: `mode: "full"` (default) emits all sections. `mode: "light"` emits only recall + global LTM, skipping project LTM/STM and global STM — for users who rely on Claude Code's native project-scoped memory and only want this system for cross-project memory plus last-session continuity.
+
+**On-demand project loading** (`emit_project_memory()` in `load_memory.py`, exposed via `--project-memory [name]` and the `/load-project-memory` skill): Emits project LTM + project STM for the cwd-detected project or an explicit name. Used to recover project context mid-session, primarily under `mode: "light"`. The skill instructs the agent to summarize counts/date ranges and surface relevant entries — not just dump them.
 
 **Recall** (`session_end_recall.py`): SessionEnd hook writes `pending-recall/{session_id}.md` for the next session. Each assistant message is per-message-truncated (head/tail split at `MAX_MESSAGE_LINES = 30`), then the budget is allocated 1/3 to oldest messages (head) and 2/3 to newest (tail). The latest message is force-included even if it alone overruns the tail allocation. When messages are skipped, a `... [N messages omitted] ...` marker is inserted between head and tail.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The installer detects your Python command and configures hooks with absolute pat
 | `/recall [query]` | Search through all historical daily memory files |
 | `/settings` | View/modify memory settings and check token usage |
 | `/projects` | Manage project data — list status, merge orphans, cleanup stale entries |
-| `/load-project-memory [name]` | Inject a project's LTM + STM into the current session (useful in light mode or when switching projects) |
+| `/load-project-memory [name]` | Inject a project's LTM + STM into the current session, then report counts, date ranges, relevant entries, and a verdict (useful in light mode or when switching projects) |
 
 ## How It Works
 

--- a/skills/load-project-memory/SKILL.md
+++ b/skills/load-project-memory/SKILL.md
@@ -36,7 +36,25 @@ Inject a project's long-term memory and recent short-term history into the curre
    - `## Project Long-Term Memory: <name>` (the project's LTM file)
    - `## Project Short-Term Memory: <name>` (recent daily entries scoped to the project)
 
-4. The output flows directly into context — no further action is needed. Acknowledge briefly to the user that the project's memory has been loaded.
+4. The output flows directly into context. After it loads, **do not stop at "memory loaded"** — read it and report back to the user with the following structure:
+
+   **a. Counts and date ranges.** Count the number of memory entries (lines starting with `- `, including those nested under section headers) in each block, and find the oldest and newest dates. LTM entries are dated inline as `(YYYY-MM-DD)`; STM entries are grouped under `### YYYY-MM-DD` headers. Open with one line in this format:
+
+   > 5 days of STM memory loaded (20 entries, 2026-04-26 to 2026-04-30). 20 days of LTM memory loaded (50 entries, 2025-09-15 to 2026-04-30).
+
+   If a section is missing (LTM-only or STM-only output), only report the section that loaded.
+
+   **b. Relevance scan.** Review what's been discussed in the current session and pick out 3–5 specific memory entries that look most relevant — gotchas about files you're touching, prior design decisions on the same subsystem, patterns that contradict or confirm the current approach, etc. Quote them verbatim. If nothing stands out as relevant, say so — don't pad.
+
+   > Here are some selected memories which may be relevant to what we're working on:
+   > - (2026-02-04) [pattern] PreToolUse hooks for subagent permissions — ...
+   > - ...
+
+   **c. Verdict.** Close with one of:
+   - **Actionable suggestions** if memory reveals a conflict, missed gotcha, or better approach: state what to change and why, citing the memory entry.
+   - **Confirmation** if memory aligns with the current direction: "The memory confirms what we're doing — looks good."
+
+   Do not skip the verdict. The whole point of the skill is to surface what the user can't see.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- `/load-project-memory` previously stopped at "memory loaded." This update requires the agent to summarize what came in: counts, date ranges, 3–5 relevant entries, and a verdict (actionable suggestions or confirmation).
- Adds the corresponding architecture note in CLAUDE.md and refines the README description.

## Test plan
- Documentation/skill-instruction change only; no code or test changes.
- Will be exercised live next time `/load-project-memory` is invoked.

Co-Authored-By: Claude <noreply@anthropic.com>