### PR TITLE
Migrate to uv-managed Python

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,12 +47,12 @@ claude-memory-system/
 Tests live in `tests/test_<module>.py` matching the script they test.
 
 ```bash
-python3 -m pytest tests/ -q                  # Run all (do this first)
-python3 -m pytest tests/ -v                  # Verbose for debugging
-python3 install.py                           # Apply changes
-python3 ~/.claude/scripts/load_memory.py     # Test memory loading
-python3 ~/.claude/scripts/indexing.py list-recent  # Test session listing
-python3 ~/.claude/scripts/decay.py --dry-run # Test decay
+uv run -m pytest tests/ -q                  # Run all (do this first)
+uv run -m pytest tests/ -v                  # Verbose for debugging
+uv run install.py                           # Apply changes
+uv run ~/.claude/scripts/load_memory.py     # Test memory loading
+uv run ~/.claude/scripts/indexing.py list-recent  # Test session listing
+uv run ~/.claude/scripts/decay.py --dry-run # Test decay
 ```
 
 **Conventions:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ Source of truth: `DEFAULT_SETTINGS` in `scripts/memory_utils.py`.
 | `globalLongTerm.tokenLimit` | 3,000 |
 | `projectShortTerm.workingDays` | 5 |
 | `projectLongTerm.tokenLimit` | 3,000 |
-| `synthesis.intervalHours` | 0.5 |
+| `synthesis.intervalHours` | 2 |
 | `synthesis.model` | sonnet |
 | `synthesis.minSessionMessages` | 5 |
 | `decay.ageDays` | 30 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,13 +47,15 @@ claude-memory-system/
 Tests live in `tests/test_<module>.py` matching the script they test.
 
 ```bash
-uv run -m pytest tests/ -q                  # Run all (do this first)
-uv run -m pytest tests/ -v                  # Verbose for debugging
-uv run install.py                           # Apply changes
-uv run ~/.claude/scripts/load_memory.py     # Test memory loading
-uv run ~/.claude/scripts/indexing.py list-recent  # Test session listing
-uv run ~/.claude/scripts/decay.py --dry-run # Test decay
+uv run --with pytest -m pytest tests/ -q                          # Run all (do this first)
+uv run --with pytest -m pytest tests/ -v                          # Verbose for debugging
+uv run install.py                                                  # Apply changes
+uv run --no-project ~/.claude/scripts/load_memory.py               # Test memory loading
+uv run --no-project ~/.claude/scripts/indexing.py list-recent      # Test session listing
+uv run --no-project ~/.claude/scripts/decay.py --dry-run           # Test decay
 ```
+
+**`--no-project`** is required for any `uv run` that targets a script outside the repo (the installed scripts under `~/.claude/scripts/`). Without it, uv discovers a pyproject.toml from the current working directory and creates a `.venv` there as a side effect. The hooks, launchd ProgramArguments, and systemd ExecStart all use `--no-project` for the same reason.
 
 **Conventions:**
 - Class per function/feature: `class TestFunctionName`

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Configure via `~/.claude/memory/settings.json` or `/settings set <path> <value>`
   "projectShortTerm": { "workingDays": 5 },
   "projectLongTerm": { "tokenLimit": 3000 },
   "synthesis": {
-    "intervalHours": 0.5,
+    "intervalHours": 2,
     "model": "sonnet",
     "minSessionMessages": 5
   },
@@ -162,7 +162,7 @@ Configure via `~/.claude/memory/settings.json` or `/settings set <path> <value>`
 | `globalLongTerm.tokenLimit` | 3,000 | Token limit for global long-term memory |
 | `projectShortTerm.workingDays` | 5 | Project-specific days to load |
 | `projectLongTerm.tokenLimit` | 3,000 | Token limit for project long-term memory |
-| `synthesis.intervalHours` | 0.5 | Hours between auto-synthesis checks |
+| `synthesis.intervalHours` | 2 | Hours between auto-synthesis checks |
 | `synthesis.model` | sonnet | Model for synthesis LLM calls |
 | `synthesis.minSessionMessages` | 5 | Skip sessions with fewer messages |
 | `decay.ageDays` | 30 | Archive global LTM entries older than N days |

--- a/README.md
+++ b/README.md
@@ -14,30 +14,30 @@ A markdown-based memory system for Claude Code that persists context across sess
 - **Error surfacing**: Synthesis failures logged and surfaced as alerts on next session start
 - **Configurable**: Token budgets, working days, synthesis scheduling, and decay via settings.json
 - **Manual tools**: `/remember` for notes, `/recall` for historical search, `/synthesize` for on-demand processing
-- **Cross-platform**: Works on Windows, macOS, and Linux (Python 3.9+)
+- **Cross-platform**: Works on Windows, macOS, and Linux (uv-managed Python)
 
 ## Installation
 
 ```bash
 git clone https://github.com/nikhilsitaram/claude-memory-system.git
 cd claude-memory-system
-python3 install.py    # or: python install.py
+uv run install.py
 ```
 
 Start a new Claude Code session to activate the memory system.
 
 ## Requirements
 
-- **Python 3.9+**
+- **uv** — install from https://docs.astral.sh/uv/getting-started/installation/ (manages the Python interpreter for all hooks and scripts)
 - **Claude Code CLI** — must be installed and run at least once (`~/.claude` must exist)
 
 | Platform | Notes |
 |----------|-------|
-| **Linux** | Fully supported. Use `python3 install.py`. |
-| **macOS** | Fully supported. Use `python3 install.py`. |
-| **Windows** | Best-effort. Use `python install.py`. Recommended: WSL for full compatibility. |
+| **Linux** | Fully supported. Use `uv run install.py`. |
+| **macOS** | Fully supported. Use `uv run install.py`. |
+| **Windows** | Best-effort. Use `uv run install.py`. Recommended: WSL for full compatibility. |
 
-The installer detects your Python command and configures hooks with absolute paths.
+The installer locates `uv` and bakes its absolute path into hooks, the launchd agent, and the systemd service file.
 
 ## Commands
 
@@ -221,8 +221,8 @@ The memory system uses a **PreToolUse hook** to auto-approve memory operations w
 
 ```bash
 cd claude-memory-system
-python3 uninstall.py           # Remove hooks/permissions, keep memory data
-python3 uninstall.py --purge   # Remove everything including memory data
+uv run uninstall.py           # Remove hooks/permissions, keep memory data
+uv run uninstall.py --purge   # Remove everything including memory data
 ```
 
 ## Updates
@@ -230,7 +230,7 @@ python3 uninstall.py --purge   # Remove everything including memory data
 ```bash
 cd claude-memory-system
 git pull
-python3 install.py
+uv run install.py
 ```
 
 The installer is idempotent and preserves existing memory data.

--- a/install.py
+++ b/install.py
@@ -384,14 +384,14 @@ def remove_obsolete_hooks(settings: dict) -> dict:
     return settings
 
 
-def merge_hooks(settings: dict, uv_cmd: str) -> dict:
+def merge_hooks(settings: dict, uv_path: str) -> dict:
     """Merge memory system hooks into settings."""
     home = str(Path.home())
     scripts_dir = f"{home}/.claude/scripts"
     hooks_dir = f"{home}/.claude/hooks"
 
-    load_cmd = f"{uv_cmd} run {scripts_dir}/load_memory.py"
-    recall_cmd = f"{uv_cmd} run {scripts_dir}/session_end_recall.py"
+    load_cmd = f"{uv_path} run {scripts_dir}/load_memory.py"
+    recall_cmd = f"{uv_path} run {scripts_dir}/session_end_recall.py"
 
     hooks_to_add = {
         # PreToolUse hook auto-allows memory operations for subagents
@@ -546,7 +546,7 @@ def merge_permissions(settings: dict) -> dict:
     return settings
 
 
-def build_project_index(uv_cmd: str) -> None:
+def build_project_index(uv_path: str) -> None:
     """Build initial project index."""
     scripts_dir = get_claude_dir() / "scripts"
     indexing_script = scripts_dir / "indexing.py"
@@ -557,7 +557,7 @@ def build_project_index(uv_cmd: str) -> None:
 
     try:
         result = subprocess.run(
-            [uv_cmd, "run", str(indexing_script), "build-index"],
+            [uv_path, "run", str(indexing_script), "build-index"],
             capture_output=True,
             text=True,
             timeout=30,
@@ -613,8 +613,8 @@ def main() -> int:
         return 1
 
     # Detect uv (required) for hooks and scheduled units
-    uv_cmd = detect_uv_command()
-    print(f"Using uv: {uv_cmd}")
+    uv_path = detect_uv_command()
+    print(f"Using uv: {uv_path}")
 
     # Get script directory
     script_dir = get_script_dir()
@@ -625,9 +625,9 @@ def main() -> int:
     # Link scripts, hooks, and skills (symlinks for auto-apply on repo changes)
     link_scripts(script_dir)
     if sys.platform == "darwin":
-        install_launchd_agent(uv_cmd)
+        install_launchd_agent(uv_path)
     else:
-        install_systemd_units(script_dir, uv_cmd)
+        install_systemd_units(script_dir, uv_path)
     link_hooks(script_dir)
     link_skills(script_dir)
     copy_templates(script_dir)
@@ -643,7 +643,7 @@ def main() -> int:
     settings = remove_obsolete_hooks(settings)
 
     # Add hooks
-    settings = merge_hooks(settings, uv_cmd)
+    settings = merge_hooks(settings, uv_path)
 
     # Add permissions
     settings = merge_permissions(settings)
@@ -655,7 +655,7 @@ def main() -> int:
     # Build project index
     print()
     print("Building project index...")
-    build_project_index(uv_cmd)
+    build_project_index(uv_path)
 
     # Success message
     print_success_message()

--- a/install.py
+++ b/install.py
@@ -3,20 +3,19 @@
 Cross-platform installer for Claude Code Memory System.
 
 This script:
-1. Checks Python version (requires 3.9+)
-2. Detects available Python command (python3 vs python)
+1. Checks Python version (requires 3.9+) for the installer itself
+2. Detects `uv` (required — used to run all hook/script commands)
 3. Backs up existing settings.json
 4. Creates directory structure
 5. Symlinks scripts, hooks, and skills (auto-applies repo changes)
-6. Merges hooks into settings.json (with absolute paths)
+6. Merges hooks into settings.json with `uv run` invocations
 7. Adds permissions
 8. Builds project index
 
 Usage:
-    python3 install.py
-    python install.py
+    uv run install.py
 
-Requirements: Python 3.9+
+Requirements: Python 3.9+ (installer), uv (https://docs.astral.sh/uv/)
 """
 
 import os
@@ -52,33 +51,25 @@ def check_python_version() -> None:
         sys.exit(1)
 
 
-def detect_python_command() -> str:
+def detect_uv_command() -> str:
     """
-    Detect which Python command to use in hooks.
+    Locate the `uv` executable. Exits with an install hint if missing.
 
-    Checks python3 first (preferred on Unix), then python.
-    Returns the command that points to Python 3.9+.
+    Returns the absolute path to `uv` so hooks and launchd/systemd units
+    don't depend on PATH at trigger time.
     """
-    for cmd in ["python3", "python"]:
-        try:
-            result = subprocess.run(
-                [cmd, "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if result.returncode == 0:
-                version_str = result.stdout.strip()
-                parts = version_str.split(".")
-                if len(parts) >= 2:
-                    major, minor = int(parts[0]), int(parts[1])
-                    if major >= 3 and minor >= 9:
-                        return cmd
-        except (subprocess.TimeoutExpired, FileNotFoundError, ValueError):
-            continue
+    uv_path = shutil.which("uv")
+    if uv_path:
+        return uv_path
 
-    # Fall back to current executable
-    return sys.executable
+    print("Error: `uv` not found on PATH.")
+    print()
+    print("This installer uses uv to manage Python for all hooks and scripts.")
+    print("Install uv: https://docs.astral.sh/uv/getting-started/installation/")
+    print()
+    print("Quick install:")
+    print("  curl -LsSf https://astral.sh/uv/install.sh | sh")
+    sys.exit(1)
 
 
 def get_script_dir() -> Path:
@@ -250,7 +241,7 @@ def copy_templates(script_dir: Path) -> None:
 
 
 
-def install_systemd_units(script_dir: Path) -> None:
+def install_systemd_units(script_dir: Path, uv_cmd: str) -> None:
     """Install systemd user units for deferred synthesis."""
     systemd_user_dir = Path.home() / ".config" / "systemd" / "user"
 
@@ -264,12 +255,15 @@ def install_systemd_units(script_dir: Path) -> None:
 
     systemd_user_dir.mkdir(parents=True, exist_ok=True)
 
+    uv_path = shutil.which(uv_cmd) or uv_cmd
+
     units = ["claude-memory-synthesis.service", "claude-memory-synthesis.timer"]
     for unit in units:
         src = script_dir / "systemd" / unit
         if src.exists():
             dest = systemd_user_dir / unit
-            shutil.copy2(src, dest)
+            content = src.read_text(encoding="utf-8").replace("__UV_PATH__", uv_path)
+            dest.write_text(content, encoding="utf-8")
 
     # Reload and enable timer
     subprocess.run(["systemctl", "--user", "daemon-reload"],
@@ -281,7 +275,7 @@ def install_systemd_units(script_dir: Path) -> None:
     print("Installed systemd units (timer enabled)")
 
 
-def install_launchd_agent(python_cmd: str) -> None:
+def install_launchd_agent(uv_cmd: str) -> None:
     """Install a launchd user agent for periodic synthesis on macOS."""
     import plistlib
 
@@ -295,11 +289,11 @@ def install_launchd_agent(python_cmd: str) -> None:
     home = str(Path.home())
 
     # Resolve full path (launchd has minimal default PATH)
-    python_path = shutil.which(python_cmd) or python_cmd
+    uv_path = shutil.which(uv_cmd) or uv_cmd
 
     plist = {
         "Label": LAUNCHD_LABEL,
-        "ProgramArguments": [python_path, str(scripts_dir / "synthesis_cron.py")],
+        "ProgramArguments": [uv_path, "run", str(scripts_dir / "synthesis_cron.py")],
         "StartInterval": int(DEFAULT_SETTINGS["synthesis"]["intervalHours"] * 3600),
         "StandardOutPath": str(log_dir / "synthesis.log"),
         "StandardErrorPath": str(log_dir / "synthesis.err"),
@@ -387,11 +381,14 @@ def remove_obsolete_hooks(settings: dict) -> dict:
     return settings
 
 
-def merge_hooks(settings: dict, python_cmd: str) -> dict:
+def merge_hooks(settings: dict, uv_cmd: str) -> dict:
     """Merge memory system hooks into settings."""
     home = str(Path.home())
     scripts_dir = f"{home}/.claude/scripts"
     hooks_dir = f"{home}/.claude/hooks"
+
+    load_cmd = f"{uv_cmd} run {scripts_dir}/load_memory.py"
+    recall_cmd = f"{uv_cmd} run {scripts_dir}/session_end_recall.py"
 
     hooks_to_add = {
         # PreToolUse hook auto-allows memory operations for subagents
@@ -410,45 +407,16 @@ def merge_hooks(settings: dict, python_cmd: str) -> dict:
         ],
         "SessionStart": [
             {
-                "matcher": "startup",
+                "matcher": matcher,
                 "hooks": [
                     {
                         "type": "command",
-                        "command": f"{python_cmd} {scripts_dir}/load_memory.py",
+                        "command": load_cmd,
                         "timeout": 30,
                     }
                 ],
-            },
-            {
-                "matcher": "resume",
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": f"{python_cmd} {scripts_dir}/load_memory.py",
-                        "timeout": 30,
-                    }
-                ],
-            },
-            {
-                "matcher": "clear",
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": f"{python_cmd} {scripts_dir}/load_memory.py",
-                        "timeout": 30,
-                    }
-                ],
-            },
-            {
-                "matcher": "compact",
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": f"{python_cmd} {scripts_dir}/load_memory.py",
-                        "timeout": 30,
-                    }
-                ],
-            },
+            }
+            for matcher in ("startup", "resume", "clear", "compact")
         ],
         # SessionEnd: recall writer first, then deferred synthesis trigger
         "SessionEnd": [
@@ -457,7 +425,7 @@ def merge_hooks(settings: dict, python_cmd: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": f"{python_cmd} {scripts_dir}/session_end_recall.py",
+                        "command": recall_cmd,
                         "timeout": 10,
                     },
                     {
@@ -475,7 +443,7 @@ def merge_hooks(settings: dict, python_cmd: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": f"{python_cmd} {scripts_dir}/session_end_recall.py",
+                        "command": recall_cmd,
                         "timeout": 10,
                     },
                     {
@@ -490,6 +458,24 @@ def merge_hooks(settings: dict, python_cmd: str) -> dict:
 
     if "hooks" not in settings:
         settings["hooks"] = {}
+
+    # Migration: drop every existing hook entry that references our memory
+    # scripts so we can re-add canonical entries below. This is what keeps
+    # repeat installs idempotent — without it, prior `python3 …` invocations
+    # or differently-flagged `uv run …` invocations accumulate as duplicates.
+    memory_scripts = ("load_memory.py", "session_end_recall.py")
+    for event in ("SessionStart", "SessionEnd", "PreCompact"):
+        if event not in settings.get("hooks", {}):
+            continue
+        settings["hooks"][event] = [
+            entry for entry in settings["hooks"][event]
+            if not any(
+                any(s in h.get("command", "") for s in memory_scripts)
+                for h in entry.get("hooks", [])
+            )
+        ]
+        if not settings["hooks"][event]:
+            del settings["hooks"][event]
 
     # Remove existing synthesis SessionEnd/PreCompact hooks (handles platform migration)
     # Match both systemd ("claude-memory-synthesis") and launchd ("com.claude.memory-synthesis")
@@ -557,7 +543,7 @@ def merge_permissions(settings: dict) -> dict:
     return settings
 
 
-def build_project_index(python_cmd: str) -> None:
+def build_project_index(uv_cmd: str) -> None:
     """Build initial project index."""
     scripts_dir = get_claude_dir() / "scripts"
     indexing_script = scripts_dir / "indexing.py"
@@ -568,7 +554,7 @@ def build_project_index(python_cmd: str) -> None:
 
     try:
         result = subprocess.run(
-            [python_cmd, str(indexing_script), "build-index"],
+            [uv_cmd, "run", str(indexing_script), "build-index"],
             capture_output=True,
             text=True,
             timeout=30,
@@ -623,9 +609,9 @@ def main() -> int:
         print("Run Claude Code at least once before installing the memory system.")
         return 1
 
-    # Detect Python command for hooks
-    python_cmd = detect_python_command()
-    print(f"Using Python command: {python_cmd}")
+    # Detect uv (required) for hooks and scheduled units
+    uv_cmd = detect_uv_command()
+    print(f"Using uv: {uv_cmd}")
 
     # Get script directory
     script_dir = get_script_dir()
@@ -636,9 +622,9 @@ def main() -> int:
     # Link scripts, hooks, and skills (symlinks for auto-apply on repo changes)
     link_scripts(script_dir)
     if sys.platform == "darwin":
-        install_launchd_agent(python_cmd)
+        install_launchd_agent(uv_cmd)
     else:
-        install_systemd_units(script_dir)
+        install_systemd_units(script_dir, uv_cmd)
     link_hooks(script_dir)
     link_skills(script_dir)
     copy_templates(script_dir)
@@ -654,7 +640,7 @@ def main() -> int:
     settings = remove_obsolete_hooks(settings)
 
     # Add hooks
-    settings = merge_hooks(settings, python_cmd)
+    settings = merge_hooks(settings, uv_cmd)
 
     # Add permissions
     settings = merge_permissions(settings)
@@ -666,7 +652,7 @@ def main() -> int:
     # Build project index
     print()
     print("Building project index...")
-    build_project_index(python_cmd)
+    build_project_index(uv_cmd)
 
     # Success message
     print_success_message()

--- a/install.py
+++ b/install.py
@@ -241,8 +241,12 @@ def copy_templates(script_dir: Path) -> None:
 
 
 
-def install_systemd_units(script_dir: Path, uv_cmd: str) -> None:
-    """Install systemd user units for deferred synthesis."""
+def install_systemd_units(script_dir: Path, uv_path: str) -> None:
+    """Install systemd user units for deferred synthesis.
+
+    `uv_path` must be an absolute path (as returned by `detect_uv_command`)
+    so the templated .service file gets a self-contained ExecStart.
+    """
     systemd_user_dir = Path.home() / ".config" / "systemd" / "user"
 
     # Check if systemctl is available
@@ -254,8 +258,6 @@ def install_systemd_units(script_dir: Path, uv_cmd: str) -> None:
         return
 
     systemd_user_dir.mkdir(parents=True, exist_ok=True)
-
-    uv_path = shutil.which(uv_cmd) or uv_cmd
 
     units = ["claude-memory-synthesis.service", "claude-memory-synthesis.timer"]
     for unit in units:
@@ -275,8 +277,12 @@ def install_systemd_units(script_dir: Path, uv_cmd: str) -> None:
     print("Installed systemd units (timer enabled)")
 
 
-def install_launchd_agent(uv_cmd: str) -> None:
-    """Install a launchd user agent for periodic synthesis on macOS."""
+def install_launchd_agent(uv_path: str) -> None:
+    """Install a launchd user agent for periodic synthesis on macOS.
+
+    `uv_path` must be an absolute path (as returned by `detect_uv_command`)
+    since launchd has minimal default PATH and won't find `uv` by name.
+    """
     import plistlib
 
     launch_agents_dir = Path.home() / "Library" / "LaunchAgents"
@@ -287,9 +293,6 @@ def install_launchd_agent(uv_cmd: str) -> None:
     log_dir = Path.home() / "Library" / "Logs" / "claude-memory"
     log_dir.mkdir(parents=True, exist_ok=True)
     home = str(Path.home())
-
-    # Resolve full path (launchd has minimal default PATH)
-    uv_path = shutil.which(uv_cmd) or uv_cmd
 
     plist = {
         "Label": LAUNCHD_LABEL,

--- a/install.py
+++ b/install.py
@@ -296,7 +296,8 @@ def install_launchd_agent(uv_path: str) -> None:
 
     plist = {
         "Label": LAUNCHD_LABEL,
-        "ProgramArguments": [uv_path, "run", str(scripts_dir / "synthesis_cron.py")],
+        # See merge_hooks for why `--no-project` matters.
+        "ProgramArguments": [uv_path, "run", "--no-project", str(scripts_dir / "synthesis_cron.py")],
         "StartInterval": int(DEFAULT_SETTINGS["synthesis"]["intervalHours"] * 3600),
         "StandardOutPath": str(log_dir / "synthesis.log"),
         "StandardErrorPath": str(log_dir / "synthesis.err"),
@@ -390,8 +391,13 @@ def merge_hooks(settings: dict, uv_path: str) -> dict:
     scripts_dir = f"{home}/.claude/scripts"
     hooks_dir = f"{home}/.claude/hooks"
 
-    load_cmd = f"{uv_path} run {scripts_dir}/load_memory.py"
-    recall_cmd = f"{uv_path} run {scripts_dir}/session_end_recall.py"
+    # `--no-project` is critical: without it, `uv run` walks up from the
+    # current working directory looking for a pyproject.toml. When a hook
+    # fires while Claude Code is open in a Python project, uv would
+    # create a `.venv` and sync that project's dependencies as a side
+    # effect of every memory hook. The flag pins uv to an ephemeral env.
+    load_cmd = f"{uv_path} run --no-project {scripts_dir}/load_memory.py"
+    recall_cmd = f"{uv_path} run --no-project {scripts_dir}/session_end_recall.py"
 
     hooks_to_add = {
         # PreToolUse hook auto-allows memory operations for subagents
@@ -462,37 +468,27 @@ def merge_hooks(settings: dict, uv_path: str) -> dict:
     if "hooks" not in settings:
         settings["hooks"] = {}
 
-    # Migration: drop every existing hook entry that references our memory
-    # scripts so we can re-add canonical entries below. This is what keeps
-    # repeat installs idempotent — without it, prior `python3 …` invocations
-    # or differently-flagged `uv run …` invocations accumulate as duplicates.
-    memory_scripts = ("load_memory.py", "session_end_recall.py")
+    # Migration: strip every existing inner hook that references our memory
+    # scripts or the synthesis scheduler before re-adding canonical entries.
+    # Filter at the inner-hook level (not the entry level) so a user-added
+    # hook that happens to share a matcher with one of ours survives.
+    # `memory-synthesis` matches both systemd and launchd commands and
+    # subsumes the prior platform-migration pass.
+    memory_substrings = ("load_memory.py", "session_end_recall.py", "memory-synthesis")
     for event in ("SessionStart", "SessionEnd", "PreCompact"):
         if event not in settings.get("hooks", {}):
             continue
+        for entry in settings["hooks"][event]:
+            entry["hooks"] = [
+                h for h in entry.get("hooks", [])
+                if not any(s in h.get("command", "") for s in memory_substrings)
+            ]
+        # Drop entries left empty after stripping
         settings["hooks"][event] = [
-            entry for entry in settings["hooks"][event]
-            if not any(
-                any(s in h.get("command", "") for s in memory_scripts)
-                for h in entry.get("hooks", [])
-            )
+            entry for entry in settings["hooks"][event] if entry.get("hooks")
         ]
         if not settings["hooks"][event]:
             del settings["hooks"][event]
-
-    # Remove existing synthesis SessionEnd/PreCompact hooks (handles platform migration)
-    # Match both systemd ("claude-memory-synthesis") and launchd ("com.claude.memory-synthesis")
-    for event in ("SessionEnd", "PreCompact"):
-        if event in settings.get("hooks", {}):
-            settings["hooks"][event] = [
-                entry for entry in settings["hooks"][event]
-                if not any(
-                    "memory-synthesis" in h.get("command", "")
-                    for h in entry.get("hooks", [])
-                )
-            ]
-            if not settings["hooks"][event]:
-                del settings["hooks"][event]
 
     for event, new_entries in hooks_to_add.items():
         if event not in settings["hooks"]:
@@ -557,7 +553,7 @@ def build_project_index(uv_path: str) -> None:
 
     try:
         result = subprocess.run(
-            [uv_path, "run", str(indexing_script), "build-index"],
+            [uv_path, "run", "--no-project", str(indexing_script), "build-index"],
             capture_output=True,
             text=True,
             timeout=30,

--- a/scripts/decay.py
+++ b/scripts/decay.py
@@ -6,9 +6,9 @@ Processes long-term memory files and:
 1. Archives learnings older than decay.ageDays (default: 30)
 2. Purges archive entries older than decay.archiveRetentionDays (default: 365)
 
-Usage:
-    uv run decay.py              # Run decay on all memory files
-    uv run decay.py --dry-run    # Show what would be archived/purged
+Usage (after install — these scripts live in ~/.claude/scripts/):
+    uv run --no-project $HOME/.claude/scripts/decay.py              # Run decay on all memory files
+    uv run --no-project $HOME/.claude/scripts/decay.py --dry-run    # Show what would be archived/purged
 
 Requirements: Python 3.9+ (uv-managed)
 """

--- a/scripts/decay.py
+++ b/scripts/decay.py
@@ -7,10 +7,10 @@ Processes long-term memory files and:
 2. Purges archive entries older than decay.archiveRetentionDays (default: 365)
 
 Usage:
-    python decay.py              # Run decay on all memory files
-    python decay.py --dry-run    # Show what would be archived/purged
+    uv run decay.py              # Run decay on all memory files
+    uv run decay.py --dry-run    # Show what would be archived/purged
 
-Requirements: Python 3.9+
+Requirements: Python 3.9+ (uv-managed)
 """
 
 import argparse

--- a/scripts/devtools.py
+++ b/scripts/devtools.py
@@ -4,10 +4,10 @@ Developer tools for Claude Code Memory System.
 
 Dev diagnostics and mark-routed dedup migration. Installed to ~/.claude/scripts/ via symlink.
 
-Usage:
-    uv run scripts/devtools.py verify-install [--mode all|install-only|verify-only|smoke-test]
-    uv run scripts/devtools.py memory-status [--mode all|pending|tokens|synthesis|decay|daily]
-    uv run scripts/devtools.py extract-debug [DAY] [--mode all|sessions|extract|state|content]
+Usage (after install — these scripts live in ~/.claude/scripts/):
+    uv run --no-project $HOME/.claude/scripts/devtools.py verify-install [--mode all|install-only|verify-only|smoke-test]
+    uv run --no-project $HOME/.claude/scripts/devtools.py memory-status [--mode all|pending|tokens|synthesis|decay|daily]
+    uv run --no-project $HOME/.claude/scripts/devtools.py extract-debug [DAY] [--mode all|sessions|extract|state|content]
 
 Requirements: Python 3.9+ (uv-managed)
 """

--- a/scripts/devtools.py
+++ b/scripts/devtools.py
@@ -5,11 +5,11 @@ Developer tools for Claude Code Memory System.
 Dev diagnostics and mark-routed dedup migration. Installed to ~/.claude/scripts/ via symlink.
 
 Usage:
-    python scripts/devtools.py verify-install [--mode all|install-only|verify-only|smoke-test]
-    python scripts/devtools.py memory-status [--mode all|pending|tokens|synthesis|decay|daily]
-    python scripts/devtools.py extract-debug [DAY] [--mode all|sessions|extract|state|content]
+    uv run scripts/devtools.py verify-install [--mode all|install-only|verify-only|smoke-test]
+    uv run scripts/devtools.py memory-status [--mode all|pending|tokens|synthesis|decay|daily]
+    uv run scripts/devtools.py extract-debug [DAY] [--mode all|sessions|extract|state|content]
 
-Requirements: Python 3.9+
+Requirements: Python 3.9+ (uv-managed)
 """
 
 import argparse

--- a/scripts/indexing.py
+++ b/scripts/indexing.py
@@ -8,12 +8,12 @@ Provides:
 
 Transcript extraction is in transcript_ops.py (split for smaller reads).
 
-Usage:
+Usage (after install — these scripts live in ~/.claude/scripts/):
     # Build/rebuild project index
-    uv run indexing.py build-index
+    uv run --no-project $HOME/.claude/scripts/indexing.py build-index
 
     # List days with recent transcripts
-    uv run indexing.py list-recent
+    uv run --no-project $HOME/.claude/scripts/indexing.py list-recent
 
 Requirements: Python 3.9+ (uv-managed)
 """
@@ -79,7 +79,7 @@ __all__ = [
 #   get_session_date(session) -> str
 # Project index:
 #   build_projects_index() -> dict
-# CLI: uv run indexing.py {build-index,list-recent}
+# CLI: uv run --no-project $HOME/.claude/scripts/indexing.py {build-index,list-recent}
 # =============================================================================
 
 
@@ -602,7 +602,7 @@ def build_projects_index(fix_paths: bool = False) -> dict:
                 else:
                     print("    No suggestion found", file=sys.stderr)
             if any(s["suggested_path"] for s in unfixed):
-                print("  Run `uv run indexing.py build-index --fix-paths` to apply suggestions.\n", file=sys.stderr)
+                print("  Run `uv run --no-project $HOME/.claude/scripts/indexing.py build-index --fix-paths` to apply suggestions.\n", file=sys.stderr)
             else:
                 print("  Consider using /projects to migrate or cleanup stale data.\n", file=sys.stderr)
 

--- a/scripts/indexing.py
+++ b/scripts/indexing.py
@@ -10,12 +10,12 @@ Transcript extraction is in transcript_ops.py (split for smaller reads).
 
 Usage:
     # Build/rebuild project index
-    python indexing.py build-index
+    uv run indexing.py build-index
 
     # List days with recent transcripts
-    python indexing.py list-recent
+    uv run indexing.py list-recent
 
-Requirements: Python 3.9+
+Requirements: Python 3.9+ (uv-managed)
 """
 
 import argparse
@@ -79,7 +79,7 @@ __all__ = [
 #   get_session_date(session) -> str
 # Project index:
 #   build_projects_index() -> dict
-# CLI: python indexing.py {build-index,list-recent}
+# CLI: uv run indexing.py {build-index,list-recent}
 # =============================================================================
 
 
@@ -602,7 +602,7 @@ def build_projects_index(fix_paths: bool = False) -> dict:
                 else:
                     print("    No suggestion found", file=sys.stderr)
             if any(s["suggested_path"] for s in unfixed):
-                print("  Run `python indexing.py build-index --fix-paths` to apply suggestions.\n", file=sys.stderr)
+                print("  Run `uv run indexing.py build-index --fix-paths` to apply suggestions.\n", file=sys.stderr)
             else:
                 print("  Consider using /projects to migrate or cleanup stale data.\n", file=sys.stderr)
 

--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -569,7 +569,7 @@ Every output uses ===PROJECT:name=== blocks and ends with ===END===. Nothing els
 Only use the Write and Bash tools — no other tools.
 
 1. Write(`{output_filename}`, <your structured output>)
-2. Bash: `uv run $HOME/.claude/scripts/synthesis.py apply {output_filename} --extracts {extracts_arg}`
+2. Bash: `uv run --no-project $HOME/.claude/scripts/synthesis.py apply {output_filename} --extracts {extracts_arg}`
 
 ## Synthesis Instructions
 

--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -569,7 +569,7 @@ Every output uses ===PROJECT:name=== blocks and ends with ===END===. Nothing els
 Only use the Write and Bash tools — no other tools.
 
 1. Write(`{output_filename}`, <your structured output>)
-2. Bash: `python3 $HOME/.claude/scripts/synthesis.py apply {output_filename} --extracts {extracts_arg}`
+2. Bash: `uv run $HOME/.claude/scripts/synthesis.py apply {output_filename} --extracts {extracts_arg}`
 
 ## Synthesis Instructions
 

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -254,7 +254,7 @@ DEFAULT_SETTINGS = {
         "tokenLimit": 3000,
     },
     "synthesis": {
-        "intervalHours": 1,
+        "intervalHours": 2,
         "model": "sonnet",
         "minSessionMessages": 5,
     },

--- a/scripts/synthesis.py
+++ b/scripts/synthesis.py
@@ -8,8 +8,8 @@ Parses structured output from the synthesis subagent and applies results:
 - Marks [routed] entries in daily files
 - Runs post-processing (state pruning, decay, validation, timestamp)
 
-Usage:
-    uv run synthesis.py apply <output_file> --extracts <path1> [<path2>...]
+Usage (after install — these scripts live in ~/.claude/scripts/):
+    uv run --no-project $HOME/.claude/scripts/synthesis.py apply <output_file> --extracts <path1> [<path2>...]
 
 Requirements: Python 3.9+ (uv-managed)
 """

--- a/scripts/synthesis.py
+++ b/scripts/synthesis.py
@@ -9,9 +9,9 @@ Parses structured output from the synthesis subagent and applies results:
 - Runs post-processing (state pruning, decay, validation, timestamp)
 
 Usage:
-    python3 synthesis.py apply <output_file> --extracts <path1> [<path2>...]
+    uv run synthesis.py apply <output_file> --extracts <path1> [<path2>...]
 
-Requirements: Python 3.9+
+Requirements: Python 3.9+ (uv-managed)
 """
 
 import argparse

--- a/scripts/synthesis_cron.py
+++ b/scripts/synthesis_cron.py
@@ -10,9 +10,9 @@ Invoked by:
 - launchd agent (macOS): com.claude.memory-synthesis
 - SessionEnd hook: fires on every session exit
 
-Usage:
-    uv run synthesis_cron.py           # Normal run (checks schedule)
-    uv run synthesis_cron.py --force   # Skip schedule check
+Usage (after install — these scripts live in ~/.claude/scripts/):
+    uv run --no-project $HOME/.claude/scripts/synthesis_cron.py           # Normal run (checks schedule)
+    uv run --no-project $HOME/.claude/scripts/synthesis_cron.py --force   # Skip schedule check
 """
 
 import argparse

--- a/scripts/synthesis_cron.py
+++ b/scripts/synthesis_cron.py
@@ -11,8 +11,8 @@ Invoked by:
 - SessionEnd hook: fires on every session exit
 
 Usage:
-    python3 synthesis_cron.py           # Normal run (checks schedule)
-    python3 synthesis_cron.py --force   # Skip schedule check
+    uv run synthesis_cron.py           # Normal run (checks schedule)
+    uv run synthesis_cron.py --force   # Skip schedule check
 """
 
 import argparse

--- a/skills/load-project-memory/SKILL.md
+++ b/skills/load-project-memory/SKILL.md
@@ -24,12 +24,12 @@ Inject a project's long-term memory and recent short-term history into the curre
 
    ```bash
    # No argument — uses cwd-based project detection
-   uv run $HOME/.claude/scripts/load_memory.py --project-memory
+   uv run --no-project $HOME/.claude/scripts/load_memory.py --project-memory
    ```
 
    ```bash
    # Explicit project name (substitute the user's argument; keep it quoted)
-   uv run $HOME/.claude/scripts/load_memory.py --project-memory "swyfft"
+   uv run --no-project $HOME/.claude/scripts/load_memory.py --project-memory "swyfft"
    ```
 
 3. The script prints a `<project-memory>...</project-memory>` block containing:

--- a/skills/load-project-memory/SKILL.md
+++ b/skills/load-project-memory/SKILL.md
@@ -24,12 +24,12 @@ Inject a project's long-term memory and recent short-term history into the curre
 
    ```bash
    # No argument — uses cwd-based project detection
-   python3 $HOME/.claude/scripts/load_memory.py --project-memory
+   uv run $HOME/.claude/scripts/load_memory.py --project-memory
    ```
 
    ```bash
    # Explicit project name (substitute the user's argument; keep it quoted)
-   python3 $HOME/.claude/scripts/load_memory.py --project-memory "swyfft"
+   uv run $HOME/.claude/scripts/load_memory.py --project-memory "swyfft"
    ```
 
 3. The script prints a `<project-memory>...</project-memory>` block containing:

--- a/skills/settings/SKILL.md
+++ b/skills/settings/SKILL.md
@@ -26,7 +26,7 @@ View, modify, and analyze the memory system configuration.
 
 Run the token usage script and display results:
 ```bash
-python3 $HOME/.claude/scripts/token_usage.py
+uv run $HOME/.claude/scripts/token_usage.py
 ```
 
 Display as a usage table with ~Tokens, Limit, % Used, and status indicator (within limit vs over limit).

--- a/skills/settings/SKILL.md
+++ b/skills/settings/SKILL.md
@@ -26,7 +26,7 @@ View, modify, and analyze the memory system configuration.
 
 Run the token usage script and display results:
 ```bash
-uv run $HOME/.claude/scripts/token_usage.py
+uv run --no-project $HOME/.claude/scripts/token_usage.py
 ```
 
 Display as a usage table with ~Tokens, Limit, % Used, and status indicator (within limit vs over limit).

--- a/skills/settings/SKILL.md
+++ b/skills/settings/SKILL.md
@@ -53,7 +53,7 @@ Reset to defaults from `_defaults` section of settings.json. Omit path to reset 
 | `globalShortTerm.workingDays` | int | 1-30 | 2 | Also updates tokenLimit |
 | `projectLongTerm.tokenLimit` | int | 1000-50000 | 3,000 | Fixed limit |
 | `projectShortTerm.workingDays` | int | 1-30 | 5 | Also updates tokenLimit |
-| `synthesis.intervalHours` | float | 0.25-24 | 0.5 | Hours between auto-synthesis |
+| `synthesis.intervalHours` | float | 0.25-24 | 2 | Hours between auto-synthesis |
 | `synthesis.model` | string | haiku/sonnet/opus | sonnet | Model for synthesis subagent |
 | `synthesis.minSessionMessages` | int | 0-100 | 5 | Skip sessions with fewer messages during synthesis |
 | `decay.ageDays` | int | 7-365 | 30 | Archive learnings older than this |

--- a/skills/synthesize/SKILL.md
+++ b/skills/synthesize/SKILL.md
@@ -14,7 +14,7 @@ Launch a subagent to process memory transcripts into daily summaries and selecti
 
 1. Get the synthesis prompt, model, and pre-extracted data:
    ```bash
-   uv run $HOME/.claude/scripts/load_memory.py --synthesis-prompt
+   uv run --no-project $HOME/.claude/scripts/load_memory.py --synthesis-prompt
    ```
    - If output says "No pending transcripts", inform the user and stop.
    - First line: `model=<model>`. Second line: `prompt_file=<path>`.

--- a/skills/synthesize/SKILL.md
+++ b/skills/synthesize/SKILL.md
@@ -14,7 +14,7 @@ Launch a subagent to process memory transcripts into daily summaries and selecti
 
 1. Get the synthesis prompt, model, and pre-extracted data:
    ```bash
-   python3 $HOME/.claude/scripts/load_memory.py --synthesis-prompt
+   uv run $HOME/.claude/scripts/load_memory.py --synthesis-prompt
    ```
    - If output says "No pending transcripts", inform the user and stop.
    - First line: `model=<model>`. Second line: `prompt_file=<path>`.

--- a/systemd/claude-memory-synthesis.service
+++ b/systemd/claude-memory-synthesis.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=__UV_PATH__ run %h/.claude/scripts/synthesis_cron.py
+ExecStart=__UV_PATH__ run --no-project %h/.claude/scripts/synthesis_cron.py
 Environment=CLAUDECODE=
 Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 TimeoutStartSec=300

--- a/systemd/claude-memory-synthesis.service
+++ b/systemd/claude-memory-synthesis.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/python3 %h/.claude/scripts/synthesis_cron.py
+ExecStart=__UV_PATH__ run %h/.claude/scripts/synthesis_cron.py
 Environment=CLAUDECODE=
 Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 TimeoutStartSec=300

--- a/systemd/claude-memory-synthesis.timer
+++ b/systemd/claude-memory-synthesis.timer
@@ -2,7 +2,7 @@
 Description=Run Claude Memory Synthesis periodically
 
 [Timer]
-OnCalendar=*-*-* 0/1:00:00
+OnCalendar=*-*-* 0/2:00:00
 Persistent=true
 RandomizedDelaySec=300
 

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -20,7 +20,7 @@
     "_comment": "project-memory/{project}-long-term-memory.md - project-specific learnings"
   },
   "synthesis": {
-    "intervalHours": 1,
+    "intervalHours": 2,
     "model": "sonnet",
     "minSessionMessages": 5,
     "_comment": "Minimum hours between auto-synthesis runs. Model: sonnet (default)|haiku|opus. minSessionMessages: skip sessions with fewer messages during synthesis."
@@ -50,7 +50,7 @@
     "globalLongTerm.tokenLimit": 3000,
     "projectShortTerm.workingDays": 5,
     "projectLongTerm.tokenLimit": 3000,
-    "synthesis.intervalHours": 1,
+    "synthesis.intervalHours": 2,
     "synthesis.model": "sonnet",
     "synthesis.minSessionMessages": 5,
     "decay.ageDays": 30,

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -308,7 +308,7 @@ class TestInstallSystemdUnits:
         systemd_src = script_dir / "systemd"
         systemd_src.mkdir(parents=True)
         (systemd_src / "claude-memory-synthesis.service").write_text(
-            "[Service]\nExecStart=__UV_PATH__ run %h/.claude/scripts/synthesis_cron.py"
+            "[Service]\nExecStart=__UV_PATH__ run --no-project %h/.claude/scripts/synthesis_cron.py"
         )
         (systemd_src / "claude-memory-synthesis.timer").write_text("[Timer]\nOnCalendar=*:0/15")
 
@@ -321,7 +321,7 @@ class TestInstallSystemdUnits:
 
         installed = (systemd_user_dir / "claude-memory-synthesis.service").read_text()
         assert "__UV_PATH__" not in installed
-        assert "ExecStart=/home/user/.local/bin/uv run" in installed
+        assert "ExecStart=/home/user/.local/bin/uv run --no-project" in installed
 
     def test_copies_timer_file(self, tmp_path):
         """Timer unit is installed verbatim to ~/.config/systemd/user/."""
@@ -527,6 +527,46 @@ class TestSessionEndHook:
         assert not any(c.startswith("python3 ") for c in commands)
         # All four matchers (startup/resume/clear/compact) added with uv run
         assert sum(1 for c in commands if "uv run" in c and "load_memory.py" in c) == 4
+
+    def test_migration_preserves_user_hook_bundled_with_memory_hook(self):
+        """A user-added hook in the same matcher entry as a memory-script hook
+        must survive the migration. The migration filters at the inner-hook
+        level — entry-level filtering would silently delete the user's hook."""
+        settings = {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "startup",
+                        "hooks": [
+                            # User's hook — has nothing to do with the memory system.
+                            {
+                                "type": "command",
+                                "command": "echo hello from user",
+                                "timeout": 5,
+                            },
+                            # Stale memory-script invocation that migration must drop.
+                            {
+                                "type": "command",
+                                "command": "python3 /home/u/.claude/scripts/load_memory.py",
+                                "timeout": 30,
+                            },
+                        ],
+                    }
+                ]
+            }
+        }
+        result = install.merge_hooks(settings, "uv")
+        commands = [
+            h.get("command", "")
+            for entry in result["hooks"]["SessionStart"]
+            for h in entry.get("hooks", [])
+        ]
+        # User's hook is intact.
+        assert any("echo hello from user" in c for c in commands)
+        # Old python3-based memory hook is gone.
+        assert not any("python3" in c and "load_memory.py" in c for c in commands)
+        # New uv-based memory hook(s) added.
+        assert any("uv run" in c and "load_memory.py" in c for c in commands)
 
     def test_migration_removes_old_systemctl_hook(self):
         """On macOS, old systemctl hook is replaced with launchctl."""
@@ -773,9 +813,9 @@ class TestInstallLaunchdAgent:
         assert plist["Label"] == install.LAUNCHD_LABEL
         assert plist["StartInterval"] == int(DEFAULT_SETTINGS["synthesis"]["intervalHours"] * 3600)
         assert plist["EnvironmentVariables"]["CLAUDECODE"] == ""
-        # ProgramArguments = [uv_path, "run", script_path]
-        assert plist["ProgramArguments"][1] == "run"
-        assert "synthesis_cron.py" in plist["ProgramArguments"][2]
+        # ProgramArguments = [uv_path, "run", "--no-project", script_path]
+        assert plist["ProgramArguments"][1:3] == ["run", "--no-project"]
+        assert "synthesis_cron.py" in plist["ProgramArguments"][3]
 
     def test_calls_bootout_then_bootstrap(self, tmp_path):
         """Calls launchctl bootout (cleanup) then bootstrap (load)."""
@@ -818,7 +858,7 @@ class TestInstallLaunchdAgent:
         with open(plist_path, "rb") as f:
             plist = plistlib.load(f)
         assert plist["ProgramArguments"][0] == "/opt/homebrew/bin/uv"
-        assert plist["ProgramArguments"][1] == "run"
+        assert plist["ProgramArguments"][1:3] == ["run", "--no-project"]
 
     def test_warns_on_bootstrap_failure(self, tmp_path, capsys):
         """Prints warning if launchctl bootstrap fails."""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -834,3 +834,43 @@ class TestInstallLaunchdAgent:
 
         output = capsys.readouterr().out
         assert "Warning: launchctl bootstrap failed" in output
+
+
+# ---------------------------------------------------------------------------
+# Repo-level constant consistency — guard against drift between
+# DEFAULT_SETTINGS and the files that get copied/installed verbatim.
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultsConsistency:
+    """Catch drift like the kind that motivated this test class:
+    DEFAULT_SETTINGS bumped to 2h, but templates/settings.json still said 1
+    and systemd .timer still fired hourly.
+    """
+
+    @staticmethod
+    def _repo_root():
+        from pathlib import Path
+        return Path(__file__).parent.parent
+
+    def test_template_settings_match_default_intervalhours(self):
+        """templates/settings.json (copied to ~/.claude/memory/settings.json
+        on first install) must agree with DEFAULT_SETTINGS so fresh installs
+        and the launchd StartInterval don't disagree."""
+        template = json.loads((self._repo_root() / "templates" / "settings.json").read_text())
+        expected = DEFAULT_SETTINGS["synthesis"]["intervalHours"]
+        assert template["synthesis"]["intervalHours"] == expected
+        # /settings reset reads from this _defaults block
+        assert template["_defaults"]["synthesis.intervalHours"] == expected
+
+    def test_systemd_timer_cadence_matches_default_intervalhours(self):
+        """systemd .timer's OnCalendar hour-step must agree with the launchd
+        StartInterval (which is derived from DEFAULT_SETTINGS), otherwise
+        Linux and macOS users get asymmetric cadences for the same default."""
+        import re
+        timer = (self._repo_root() / "systemd" / "claude-memory-synthesis.timer").read_text()
+        match = re.search(r"OnCalendar=\*-\*-\* 0/(\d+):00:00", timer)
+        assert match is not None, "OnCalendar line not found or malformed"
+        hour_step = int(match.group(1))
+        expected = int(DEFAULT_SETTINGS["synthesis"]["intervalHours"])
+        assert hour_step == expected

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -315,10 +315,9 @@ class TestInstallSystemdUnits:
         systemd_user_dir = tmp_path / ".config" / "systemd" / "user"
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
-             mock.patch("install.shutil.which", return_value="/home/user/.local/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_systemd_units(script_dir, "uv")
+            install.install_systemd_units(script_dir, "/home/user/.local/bin/uv")
 
         installed = (systemd_user_dir / "claude-memory-synthesis.service").read_text()
         assert "__UV_PATH__" not in installed
@@ -335,10 +334,9 @@ class TestInstallSystemdUnits:
         systemd_user_dir = tmp_path / ".config" / "systemd" / "user"
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
-             mock.patch("install.shutil.which", return_value="/home/user/.local/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_systemd_units(script_dir, "uv")
+            install.install_systemd_units(script_dir, "/home/user/.local/bin/uv")
 
         assert (systemd_user_dir / "claude-memory-synthesis.timer").exists()
         assert (systemd_user_dir / "claude-memory-synthesis.timer").read_text() == "[Timer]\nOnCalendar=*:0/15"
@@ -352,10 +350,9 @@ class TestInstallSystemdUnits:
         (systemd_src / "claude-memory-synthesis.timer").write_text("[Timer]")
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
-             mock.patch("install.shutil.which", return_value="/home/user/.local/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_systemd_units(script_dir, "uv")
+            install.install_systemd_units(script_dir, "/home/user/.local/bin/uv")
 
         # Expect 3 calls: version check, daemon-reload, enable --now
         assert mock_run.call_count == 3
@@ -376,7 +373,7 @@ class TestInstallSystemdUnits:
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
              mock.patch("install.subprocess.run", side_effect=FileNotFoundError):
-            install.install_systemd_units(script_dir, "uv")
+            install.install_systemd_units(script_dir, "/home/user/.local/bin/uv")
 
         output = capsys.readouterr().out
         assert "systemctl not available" in output
@@ -391,7 +388,7 @@ class TestInstallSystemdUnits:
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
              mock.patch("install.subprocess.run", side_effect=subprocess.TimeoutExpired("systemctl", 5)):
-            install.install_systemd_units(script_dir, "uv")
+            install.install_systemd_units(script_dir, "/home/user/.local/bin/uv")
 
         output = capsys.readouterr().out
         assert "systemctl not available" in output
@@ -402,10 +399,9 @@ class TestInstallSystemdUnits:
         # No systemd dir at all
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
-             mock.patch("install.shutil.which", return_value="/home/user/.local/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_systemd_units(script_dir, "uv")
+            install.install_systemd_units(script_dir, "/home/user/.local/bin/uv")
 
         # Systemd user dir created (mkdir) but no files copied
         systemd_user_dir = tmp_path / ".config" / "systemd" / "user"
@@ -764,10 +760,9 @@ class TestInstallLaunchdAgent:
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
              mock.patch("install.os.getuid", return_value=501), \
-             mock.patch("install.shutil.which", return_value="/opt/homebrew/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_launchd_agent("uv")
+            install.install_launchd_agent("/opt/homebrew/bin/uv")
 
         plist_path = tmp_path / "Library" / "LaunchAgents" / f"{install.LAUNCHD_LABEL}.plist"
         assert plist_path.exists()
@@ -786,10 +781,9 @@ class TestInstallLaunchdAgent:
         """Calls launchctl bootout (cleanup) then bootstrap (load)."""
         with mock.patch("install.Path.home", return_value=tmp_path), \
              mock.patch("install.os.getuid", return_value=501), \
-             mock.patch("install.shutil.which", return_value="/opt/homebrew/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_launchd_agent("uv")
+            install.install_launchd_agent("/opt/homebrew/bin/uv")
 
         calls = mock_run.call_args_list
         assert len(calls) == 2
@@ -804,23 +798,21 @@ class TestInstallLaunchdAgent:
         """Creates ~/Library/Logs/claude-memory/ for output."""
         with mock.patch("install.Path.home", return_value=tmp_path), \
              mock.patch("install.os.getuid", return_value=501), \
-             mock.patch("install.shutil.which", return_value="/opt/homebrew/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_launchd_agent("uv")
+            install.install_launchd_agent("/opt/homebrew/bin/uv")
 
         assert (tmp_path / "Library" / "Logs" / "claude-memory").is_dir()
 
-    def test_uses_resolved_uv_path(self, tmp_path):
-        """ProgramArguments uses shutil.which resolved path for uv."""
+    def test_uses_passed_uv_path(self, tmp_path):
+        """ProgramArguments uses the absolute uv path passed in."""
         import plistlib
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
              mock.patch("install.os.getuid", return_value=501), \
-             mock.patch("install.shutil.which", return_value="/opt/homebrew/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_launchd_agent("uv")
+            install.install_launchd_agent("/opt/homebrew/bin/uv")
 
         plist_path = tmp_path / "Library" / "LaunchAgents" / f"{install.LAUNCHD_LABEL}.plist"
         with open(plist_path, "rb") as f:
@@ -832,14 +824,13 @@ class TestInstallLaunchdAgent:
         """Prints warning if launchctl bootstrap fails."""
         with mock.patch("install.Path.home", return_value=tmp_path), \
              mock.patch("install.os.getuid", return_value=501), \
-             mock.patch("install.shutil.which", return_value="/opt/homebrew/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             # bootout succeeds, bootstrap fails
             mock_run.side_effect = [
                 mock.Mock(returncode=0),
                 mock.Mock(returncode=1),
             ]
-            install.install_launchd_agent("uv")
+            install.install_launchd_agent("/opt/homebrew/bin/uv")
 
         output = capsys.readouterr().out
         assert "Warning: launchctl bootstrap failed" in output

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -21,6 +21,7 @@ from memory_utils import load_json_file as utils_load_json_file
 from memory_utils import save_json_file as utils_save_json_file
 
 import install
+from memory_utils import DEFAULT_SETTINGS
 
 # ---------------------------------------------------------------------------
 # Shared import tests — install.py re-exports from memory_utils
@@ -72,21 +73,22 @@ class TestCheckPythonVersion:
 
 
 # ---------------------------------------------------------------------------
-# detect_python_command
+# detect_uv_command
 # ---------------------------------------------------------------------------
 
 
-class TestDetectPythonCommand:
-    def test_returns_string(self):
-        result = install.detect_python_command()
-        assert isinstance(result, str)
-        assert len(result) > 0
+class TestDetectUvCommand:
+    def test_returns_path_when_uv_present(self):
+        with mock.patch("install.shutil.which", return_value="/opt/homebrew/bin/uv"):
+            assert install.detect_uv_command() == "/opt/homebrew/bin/uv"
 
-    def test_fallback_to_executable(self):
-        """When no python3/python found, falls back to sys.executable."""
-        with mock.patch("install.subprocess.run", side_effect=FileNotFoundError):
-            result = install.detect_python_command()
-            assert result == sys.executable
+    def test_exits_when_uv_missing(self, capsys):
+        with mock.patch("install.shutil.which", return_value=None):
+            with pytest.raises(SystemExit):
+                install.detect_uv_command()
+        output = capsys.readouterr().out
+        assert "uv" in output
+        assert "astral.sh/uv" in output
 
 
 # ---------------------------------------------------------------------------
@@ -179,14 +181,14 @@ class TestHookEntryKey:
 
 class TestMergeHooks:
     def test_adds_hooks_to_empty_settings(self):
-        settings = install.merge_hooks({}, "python3")
+        settings = install.merge_hooks({}, "uv")
         assert "PreToolUse" in settings["hooks"]
         assert "SessionStart" in settings["hooks"]
 
     def test_does_not_duplicate_existing_hooks(self):
-        settings = install.merge_hooks({}, "python3")
+        settings = install.merge_hooks({}, "uv")
         count_before = len(settings["hooks"]["SessionStart"])
-        settings = install.merge_hooks(settings, "python3")
+        settings = install.merge_hooks(settings, "uv")
         count_after = len(settings["hooks"]["SessionStart"])
         assert count_before == count_after
 
@@ -300,26 +302,30 @@ class TestCopyTemplates:
 
 
 class TestInstallSystemdUnits:
-    def test_copies_service_file(self, tmp_path):
-        """Service unit is installed to ~/.config/systemd/user/."""
+    def test_copies_service_file_with_uv_path_substituted(self, tmp_path):
+        """Service unit is installed with __UV_PATH__ replaced by the resolved uv path."""
         script_dir = tmp_path / "repo"
         systemd_src = script_dir / "systemd"
         systemd_src.mkdir(parents=True)
-        (systemd_src / "claude-memory-synthesis.service").write_text("[Service]\nExecStart=/bin/true")
+        (systemd_src / "claude-memory-synthesis.service").write_text(
+            "[Service]\nExecStart=__UV_PATH__ run %h/.claude/scripts/synthesis_cron.py"
+        )
         (systemd_src / "claude-memory-synthesis.timer").write_text("[Timer]\nOnCalendar=*:0/15")
 
         systemd_user_dir = tmp_path / ".config" / "systemd" / "user"
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
+             mock.patch("install.shutil.which", return_value="/home/user/.local/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_systemd_units(script_dir)
+            install.install_systemd_units(script_dir, "uv")
 
-        assert (systemd_user_dir / "claude-memory-synthesis.service").exists()
-        assert (systemd_user_dir / "claude-memory-synthesis.service").read_text() == "[Service]\nExecStart=/bin/true"
+        installed = (systemd_user_dir / "claude-memory-synthesis.service").read_text()
+        assert "__UV_PATH__" not in installed
+        assert "ExecStart=/home/user/.local/bin/uv run" in installed
 
     def test_copies_timer_file(self, tmp_path):
-        """Timer unit is installed to ~/.config/systemd/user/."""
+        """Timer unit is installed verbatim to ~/.config/systemd/user/."""
         script_dir = tmp_path / "repo"
         systemd_src = script_dir / "systemd"
         systemd_src.mkdir(parents=True)
@@ -329,9 +335,10 @@ class TestInstallSystemdUnits:
         systemd_user_dir = tmp_path / ".config" / "systemd" / "user"
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
+             mock.patch("install.shutil.which", return_value="/home/user/.local/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_systemd_units(script_dir)
+            install.install_systemd_units(script_dir, "uv")
 
         assert (systemd_user_dir / "claude-memory-synthesis.timer").exists()
         assert (systemd_user_dir / "claude-memory-synthesis.timer").read_text() == "[Timer]\nOnCalendar=*:0/15"
@@ -345,9 +352,10 @@ class TestInstallSystemdUnits:
         (systemd_src / "claude-memory-synthesis.timer").write_text("[Timer]")
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
+             mock.patch("install.shutil.which", return_value="/home/user/.local/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_systemd_units(script_dir)
+            install.install_systemd_units(script_dir, "uv")
 
         # Expect 3 calls: version check, daemon-reload, enable --now
         assert mock_run.call_count == 3
@@ -368,7 +376,7 @@ class TestInstallSystemdUnits:
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
              mock.patch("install.subprocess.run", side_effect=FileNotFoundError):
-            install.install_systemd_units(script_dir)
+            install.install_systemd_units(script_dir, "uv")
 
         output = capsys.readouterr().out
         assert "systemctl not available" in output
@@ -383,7 +391,7 @@ class TestInstallSystemdUnits:
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
              mock.patch("install.subprocess.run", side_effect=subprocess.TimeoutExpired("systemctl", 5)):
-            install.install_systemd_units(script_dir)
+            install.install_systemd_units(script_dir, "uv")
 
         output = capsys.readouterr().out
         assert "systemctl not available" in output
@@ -394,9 +402,10 @@ class TestInstallSystemdUnits:
         # No systemd dir at all
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
+             mock.patch("install.shutil.which", return_value="/home/user/.local/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_systemd_units(script_dir)
+            install.install_systemd_units(script_dir, "uv")
 
         # Systemd user dir created (mkdir) but no files copied
         systemd_user_dir = tmp_path / ".config" / "systemd" / "user"
@@ -438,14 +447,14 @@ class TestSessionEndHook:
     def test_session_end_hook_added_to_settings(self):
         """merge_hooks adds a SessionEnd hook."""
         settings = {"hooks": {}}
-        result = install.merge_hooks(settings, "python3")
+        result = install.merge_hooks(settings, "uv")
         assert "SessionEnd" in result["hooks"]
         hooks = result["hooks"]["SessionEnd"]
         assert len(hooks) >= 1
 
     def test_session_end_hook_has_short_timeout(self):
         """SessionEnd hook has a short timeout since it's fire-and-forget."""
-        settings = install.merge_hooks({}, "python3")
+        settings = install.merge_hooks({}, "uv")
         hooks = settings["hooks"]["SessionEnd"]
         for entry in hooks:
             for h in entry.get("hooks", []):
@@ -455,11 +464,73 @@ class TestSessionEndHook:
 
     def test_session_end_hook_not_duplicated(self):
         """Running merge_hooks twice does not duplicate SessionEnd entries."""
-        settings = install.merge_hooks({}, "python3")
+        settings = install.merge_hooks({}, "uv")
         count_before = len(settings["hooks"]["SessionEnd"])
-        settings = install.merge_hooks(settings, "python3")
+        settings = install.merge_hooks(settings, "uv")
         count_after = len(settings["hooks"]["SessionEnd"])
         assert count_before == count_after
+
+    def test_migration_removes_old_python3_recall_hook(self):
+        """Old `python3 .../session_end_recall.py` entries are removed on re-install."""
+        settings = {
+            "hooks": {
+                "SessionEnd": [
+                    {
+                        "matcher": "",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "python3 /home/u/.claude/scripts/session_end_recall.py",
+                                "timeout": 10,
+                            },
+                            {
+                                "type": "command",
+                                "command": "systemctl --user start --no-block claude-memory-synthesis.service",
+                                "timeout": 5,
+                            },
+                        ],
+                    }
+                ]
+            }
+        }
+        result = install.merge_hooks(settings, "uv")
+        commands = [
+            h.get("command", "")
+            for entry in result["hooks"]["SessionEnd"]
+            for h in entry.get("hooks", [])
+        ]
+        # Old python3-invoked recall is gone
+        assert not any(c.startswith("python3 ") for c in commands)
+        # New uv-invoked recall is present
+        assert any("uv run" in c and "session_end_recall.py" in c for c in commands)
+
+    def test_migration_removes_old_python3_session_start_hook(self):
+        """Old `python3 .../load_memory.py` SessionStart entries are removed on re-install."""
+        settings = {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "startup",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "python3 /home/u/.claude/scripts/load_memory.py",
+                                "timeout": 30,
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        result = install.merge_hooks(settings, "uv")
+        commands = [
+            h.get("command", "")
+            for entry in result["hooks"]["SessionStart"]
+            for h in entry.get("hooks", [])
+        ]
+        assert not any(c.startswith("python3 ") for c in commands)
+        # All four matchers (startup/resume/clear/compact) added with uv run
+        assert sum(1 for c in commands if "uv run" in c and "load_memory.py" in c) == 4
 
     def test_migration_removes_old_systemctl_hook(self):
         """On macOS, old systemctl hook is replaced with launchctl."""
@@ -483,7 +554,7 @@ class TestSessionEndHook:
              mock.patch("install.os") as mock_os:
             mock_sys.platform = "darwin"
             mock_os.getuid.return_value = 501
-            result = install.merge_hooks(settings, "python3")
+            result = install.merge_hooks(settings, "uv")
 
         hooks = result["hooks"]["SessionEnd"]
         commands = [
@@ -514,7 +585,7 @@ class TestSessionEndHook:
         }
         with mock.patch("install.sys") as mock_sys:
             mock_sys.platform = "linux"
-            result = install.merge_hooks(settings, "python3")
+            result = install.merge_hooks(settings, "uv")
 
         hooks = result["hooks"]["SessionEnd"]
         commands = [
@@ -546,7 +617,7 @@ class TestSessionEndHook:
                 ]
             }
         }
-        result = install.merge_hooks(settings, "python3")
+        result = install.merge_hooks(settings, "uv")
         commands = [
             h.get("command", "")
             for entry in result["hooks"]["SessionEnd"]
@@ -561,7 +632,7 @@ class TestSessionEndRecallHook:
     def test_session_end_has_two_hooks(self):
         """SessionEnd hook has recall script first, then deferred synthesis."""
         settings = {"hooks": {}}
-        result = install.merge_hooks(settings, "python3")
+        result = install.merge_hooks(settings, "uv")
         session_end = result["hooks"]["SessionEnd"]
         assert len(session_end) == 1
         hooks = session_end[0]["hooks"]
@@ -587,14 +658,14 @@ class TestPreCompactHook:
     def test_precompact_hook_added_to_settings(self):
         """merge_hooks adds a PreCompact hook."""
         settings = {"hooks": {}}
-        result = install.merge_hooks(settings, "python3")
+        result = install.merge_hooks(settings, "uv")
         assert "PreCompact" in result["hooks"]
         hooks = result["hooks"]["PreCompact"]
         assert len(hooks) >= 1
 
     def test_precompact_hook_has_short_timeout(self):
         """PreCompact synthesis trigger has a short timeout since it's fire-and-forget."""
-        settings = install.merge_hooks({}, "python3")
+        settings = install.merge_hooks({}, "uv")
         hooks = settings["hooks"]["PreCompact"]
         for entry in hooks:
             for h in entry.get("hooks", []):
@@ -602,16 +673,16 @@ class TestPreCompactHook:
 
     def test_precompact_hook_not_duplicated(self):
         """Running merge_hooks twice does not duplicate PreCompact entries."""
-        settings = install.merge_hooks({}, "python3")
+        settings = install.merge_hooks({}, "uv")
         count_before = len(settings["hooks"]["PreCompact"])
-        settings = install.merge_hooks(settings, "python3")
+        settings = install.merge_hooks(settings, "uv")
         count_after = len(settings["hooks"]["PreCompact"])
         assert count_before == count_after
 
     def test_precompact_hook_has_two_hooks(self):
         """PreCompact hook has recall script first, then deferred synthesis."""
         settings = {"hooks": {}}
-        result = install.merge_hooks(settings, "python3")
+        result = install.merge_hooks(settings, "uv")
         precompact = result["hooks"]["PreCompact"]
         assert len(precompact) == 1
         hooks = precompact[0]["hooks"]
@@ -643,7 +714,7 @@ class TestPreCompactHook:
              mock.patch("install.os") as mock_os:
             mock_sys.platform = "darwin"
             mock_os.getuid.return_value = 501
-            result = install.merge_hooks(settings, "python3")
+            result = install.merge_hooks(settings, "uv")
         commands = [
             h.get("command", "")
             for entry in result["hooks"]["PreCompact"]
@@ -672,7 +743,7 @@ class TestPreCompactHook:
                 ]
             }
         }
-        result = install.merge_hooks(settings, "python3")
+        result = install.merge_hooks(settings, "uv")
         commands = [
             h.get("command", "")
             for entry in result["hooks"]["PreCompact"]
@@ -693,10 +764,10 @@ class TestInstallLaunchdAgent:
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
              mock.patch("install.os.getuid", return_value=501), \
-             mock.patch("install.shutil.which", return_value="/usr/bin/python3"), \
+             mock.patch("install.shutil.which", return_value="/opt/homebrew/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_launchd_agent("python3")
+            install.install_launchd_agent("uv")
 
         plist_path = tmp_path / "Library" / "LaunchAgents" / f"{install.LAUNCHD_LABEL}.plist"
         assert plist_path.exists()
@@ -705,18 +776,20 @@ class TestInstallLaunchdAgent:
             plist = plistlib.load(f)
 
         assert plist["Label"] == install.LAUNCHD_LABEL
-        assert plist["StartInterval"] == 7200
+        assert plist["StartInterval"] == int(DEFAULT_SETTINGS["synthesis"]["intervalHours"] * 3600)
         assert plist["EnvironmentVariables"]["CLAUDECODE"] == ""
-        assert "synthesis_cron.py" in plist["ProgramArguments"][1]
+        # ProgramArguments = [uv_path, "run", script_path]
+        assert plist["ProgramArguments"][1] == "run"
+        assert "synthesis_cron.py" in plist["ProgramArguments"][2]
 
     def test_calls_bootout_then_bootstrap(self, tmp_path):
         """Calls launchctl bootout (cleanup) then bootstrap (load)."""
         with mock.patch("install.Path.home", return_value=tmp_path), \
              mock.patch("install.os.getuid", return_value=501), \
-             mock.patch("install.shutil.which", return_value="/usr/bin/python3"), \
+             mock.patch("install.shutil.which", return_value="/opt/homebrew/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_launchd_agent("python3")
+            install.install_launchd_agent("uv")
 
         calls = mock_run.call_args_list
         assert len(calls) == 2
@@ -731,41 +804,42 @@ class TestInstallLaunchdAgent:
         """Creates ~/Library/Logs/claude-memory/ for output."""
         with mock.patch("install.Path.home", return_value=tmp_path), \
              mock.patch("install.os.getuid", return_value=501), \
-             mock.patch("install.shutil.which", return_value="/usr/bin/python3"), \
+             mock.patch("install.shutil.which", return_value="/opt/homebrew/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_launchd_agent("python3")
+            install.install_launchd_agent("uv")
 
         assert (tmp_path / "Library" / "Logs" / "claude-memory").is_dir()
 
-    def test_uses_resolved_python_path(self, tmp_path):
-        """ProgramArguments uses shutil.which resolved path."""
+    def test_uses_resolved_uv_path(self, tmp_path):
+        """ProgramArguments uses shutil.which resolved path for uv."""
         import plistlib
 
         with mock.patch("install.Path.home", return_value=tmp_path), \
              mock.patch("install.os.getuid", return_value=501), \
-             mock.patch("install.shutil.which", return_value="/opt/homebrew/bin/python3"), \
+             mock.patch("install.shutil.which", return_value="/opt/homebrew/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             mock_run.return_value = mock.Mock(returncode=0)
-            install.install_launchd_agent("python3")
+            install.install_launchd_agent("uv")
 
         plist_path = tmp_path / "Library" / "LaunchAgents" / f"{install.LAUNCHD_LABEL}.plist"
         with open(plist_path, "rb") as f:
             plist = plistlib.load(f)
-        assert plist["ProgramArguments"][0] == "/opt/homebrew/bin/python3"
+        assert plist["ProgramArguments"][0] == "/opt/homebrew/bin/uv"
+        assert plist["ProgramArguments"][1] == "run"
 
     def test_warns_on_bootstrap_failure(self, tmp_path, capsys):
         """Prints warning if launchctl bootstrap fails."""
         with mock.patch("install.Path.home", return_value=tmp_path), \
              mock.patch("install.os.getuid", return_value=501), \
-             mock.patch("install.shutil.which", return_value="/usr/bin/python3"), \
+             mock.patch("install.shutil.which", return_value="/opt/homebrew/bin/uv"), \
              mock.patch("install.subprocess.run") as mock_run:
             # bootout succeeds, bootstrap fails
             mock_run.side_effect = [
                 mock.Mock(returncode=0),
                 mock.Mock(returncode=1),
             ]
-            install.install_launchd_agent("python3")
+            install.install_launchd_agent("uv")
 
         output = capsys.readouterr().out
         assert "Warning: launchctl bootstrap failed" in output

--- a/uninstall.py
+++ b/uninstall.py
@@ -8,10 +8,10 @@ This script:
 3. Optionally deletes all memory data with --purge flag
 
 Usage:
-    python3 uninstall.py           # Remove hooks/permissions, keep data
-    python3 uninstall.py --purge   # Remove everything including memory data
+    uv run uninstall.py           # Remove hooks/permissions, keep data
+    uv run uninstall.py --purge   # Remove everything including memory data
 
-Requirements: Python 3.9+
+Requirements: Python 3.9+ (uninstaller), uv (https://docs.astral.sh/uv/)
 """
 
 import argparse
@@ -268,7 +268,7 @@ def print_cleanup_instructions() -> None:
     print("Memory data preserved at: ~/.claude/memory/")
     print()
     print("To fully remove all files, run:")
-    print("  python3 uninstall.py --purge")
+    print("  uv run uninstall.py --purge")
     print()
     print("Or manually:")
     print()


### PR DESCRIPTION
## Summary

- Switch all hook, launchd, and systemd invocations from bare `python3`/`python` to `uv run`. `install.py` now requires `uv` (no fallback) and bakes its absolute path into hooks, the launchd plist, and the systemd `.service` (templated via `__UV_PATH__`).
- `merge_hooks` aggressively strips any pre-existing memory-script hook entries before re-adding canonical ones, so re-installs stay idempotent regardless of prior invocation form.
- Bump `synthesis.intervalHours` default to 2h and align `templates/settings.json`, the systemd `.timer` cadence (`0/2:00:00`), README, CLAUDE.md, and the `/settings` reference table — all derived from `DEFAULT_SETTINGS` where possible.
- Drop redundant `shutil.which` calls in scheduler installers (path resolution already happens in `detect_uv_command`); rename their parameter to `uv_path` for an unambiguous contract.

## Test plan

- [x] 831 unit tests pass (`uv run --with pytest -m pytest tests/ -q`)
- [x] New `TestDefaultsConsistency` tests assert `templates/settings.json` and the systemd `.timer` cadence stay in sync with `DEFAULT_SETTINGS`
- [x] Migration test covers stripping legacy `python3 .../load_memory.py` and `.../session_end_recall.py` SessionStart/SessionEnd entries
- [x] Smoke install on macOS — re-running `uv run install.py` produces clean SessionStart entries (no duplicates), launchd `StartInterval=7200`, and `ProgramArguments=[/opt/homebrew/bin/uv, run, …]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)