### PR TITLE
refactor(synthesis): drop SessionEnd kickstart hook, set intervalHours default to 1h

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Source of truth: `DEFAULT_SETTINGS` in `scripts/memory_utils.py`.
 | `globalLongTerm.tokenLimit` | 3,000 |
 | `projectShortTerm.workingDays` | 5 |
 | `projectLongTerm.tokenLimit` | 3,000 |
-| `synthesis.intervalHours` | 2 |
+| `synthesis.intervalHours` | 1 |
 | `synthesis.model` | sonnet |
 | `synthesis.minSessionMessages` | 5 |
 | `decay.ageDays` | 30 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ uv run --no-project ~/.claude/scripts/decay.py --dry-run           # Test decay
 ### Hooks (defined in `install.py` `merge_hooks()`)
 - `SessionStart` — loads memory context via `load_memory.py`
 - `PreToolUse` — auto-approves operations targeting `.claude/memory` paths
-- `SessionEnd` — triggers deferred synthesis via systemd
+- `SessionEnd` / `PreCompact` — writes pending-recall via `session_end_recall.py`. Synthesis is NOT triggered here; the launchd/systemd timer is the only synthesis trigger.
 
 Transcripts are read directly from `~/.claude/projects/` (source of truth), not copied via hooks.
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Entries with dates older than `decay.ageDays` (default: 30) are moved to `.decay
 
 ### Synthesis
 
-A launchd/systemd user timer runs `synthesis_cron.py` outside active sessions via `claude -p`, on the cadence set by `synthesis.intervalHours`. When multiple dates are pending, each is processed as a separate LLM call.
+A launchd/systemd user timer runs `synthesis_cron.py` outside active sessions via `claude -p`. The timer cadence is fixed at install time from the default `synthesis.intervalHours` (whole hours only — sub-hour values aren't expressible in the static systemd timer). `synthesis.intervalHours` in user settings then acts as an in-script floor that can lengthen the effective cadence (a value of 4 with a 1-hour timer makes synthesis run every ~4 hours); values below the install-time cadence have no additional effect. When multiple dates are pending, each is processed as a separate LLM call.
 
 **Error handling**: Failures are logged to `.synthesis-errors.log` and surfaced as an alert on next session start. Eager timestamps are cleared on failure so the next timer interval can retry.
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Entries with dates older than `decay.ageDays` (default: 30) are moved to `.decay
 
 ### Synthesis
 
-A launchd/systemd user timer runs `synthesis_cron.py` outside active sessions via `claude -p`. SessionEnd hook triggers on session exit. When multiple dates are pending, each is processed as a separate LLM call.
+A launchd/systemd user timer runs `synthesis_cron.py` outside active sessions via `claude -p`, on the cadence set by `synthesis.intervalHours`. When multiple dates are pending, each is processed as a separate LLM call.
 
 **Error handling**: Failures are logged to `.synthesis-errors.log` and surfaced as an alert on next session start. Eager timestamps are cleared on failure so the next timer interval can retry.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Configure via `~/.claude/memory/settings.json` or `/settings set <path> <value>`
   "projectShortTerm": { "workingDays": 5 },
   "projectLongTerm": { "tokenLimit": 3000 },
   "synthesis": {
-    "intervalHours": 2,
+    "intervalHours": 1,
     "model": "sonnet",
     "minSessionMessages": 5
   },
@@ -162,7 +162,7 @@ Configure via `~/.claude/memory/settings.json` or `/settings set <path> <value>`
 | `globalLongTerm.tokenLimit` | 3,000 | Token limit for global long-term memory |
 | `projectShortTerm.workingDays` | 5 | Project-specific days to load |
 | `projectLongTerm.tokenLimit` | 3,000 | Token limit for project long-term memory |
-| `synthesis.intervalHours` | 2 | Hours between auto-synthesis checks |
+| `synthesis.intervalHours` | 1 | Hours between auto-synthesis checks |
 | `synthesis.model` | sonnet | Model for synthesis LLM calls |
 | `synthesis.minSessionMessages` | 5 | Skip sessions with fewer messages |
 | `decay.ageDays` | 30 | Archive global LTM entries older than N days |

--- a/install.py
+++ b/install.py
@@ -328,13 +328,6 @@ def install_launchd_agent(uv_path: str) -> None:
     print(f"Installed launchd agent ({LAUNCHD_LABEL})")
 
 
-def _session_end_command() -> str:
-    """Return the platform-appropriate SessionEnd hook command."""
-    if sys.platform == "darwin":
-        return f"launchctl kickstart gui/{os.getuid()}/{LAUNCHD_LABEL}"
-    return "systemctl --user start --no-block claude-memory-synthesis.service"
-
-
 def hook_entry_key(entry: dict) -> tuple:
     """Generate a unique key for a hook entry based on matcher and commands."""
     matcher = entry.get("matcher", "")
@@ -427,7 +420,9 @@ def merge_hooks(settings: dict, uv_path: str) -> dict:
             }
             for matcher in ("startup", "resume", "clear", "compact")
         ],
-        # SessionEnd: recall writer first, then deferred synthesis trigger
+        # SessionEnd: recall writer only. Deferred synthesis runs on its own
+        # schedule (launchd StartInterval / systemd timer derived from
+        # synthesis.intervalHours), so no kickstart hook is needed.
         "SessionEnd": [
             {
                 "matcher": "",
@@ -437,15 +432,10 @@ def merge_hooks(settings: dict, uv_path: str) -> dict:
                         "command": recall_cmd,
                         "timeout": 10,
                     },
-                    {
-                        "type": "command",
-                        "command": _session_end_command(),
-                        "timeout": 5,
-                    },
                 ],
             }
         ],
-        # PreCompact: same as SessionEnd — synthesize and write recall before transcript is compacted
+        # PreCompact: same as SessionEnd — recall writer only.
         "PreCompact": [
             {
                 "matcher": "",
@@ -454,11 +444,6 @@ def merge_hooks(settings: dict, uv_path: str) -> dict:
                         "type": "command",
                         "command": recall_cmd,
                         "timeout": 10,
-                    },
-                    {
-                        "type": "command",
-                        "command": _session_end_command(),
-                        "timeout": 5,
                     },
                 ],
             }

--- a/scripts/memory_utils.py
+++ b/scripts/memory_utils.py
@@ -254,7 +254,7 @@ DEFAULT_SETTINGS = {
         "tokenLimit": 3000,
     },
     "synthesis": {
-        "intervalHours": 2,
+        "intervalHours": 1,
         "model": "sonnet",
         "minSessionMessages": 5,
     },

--- a/scripts/synthesis_cron.py
+++ b/scripts/synthesis_cron.py
@@ -8,7 +8,6 @@ headless ``claude -p`` to run synthesis outside active sessions.
 Invoked by:
 - systemd timer (Linux): claude-memory-synthesis.timer
 - launchd agent (macOS): com.claude.memory-synthesis
-- SessionEnd hook: fires on every session exit
 
 Usage (after install — these scripts live in ~/.claude/scripts/):
     uv run --no-project $HOME/.claude/scripts/synthesis_cron.py           # Normal run (checks schedule)

--- a/scripts/synthesis_cron.py
+++ b/scripts/synthesis_cron.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Deferred synthesis runner for systemd timer / launchd agent / SessionEnd hook.
+Deferred synthesis runner for systemd timer / launchd agent.
 
 Extracts transcripts, builds synthesis prompt, and invokes
 headless ``claude -p`` to run synthesis outside active sessions.

--- a/skills/settings/SKILL.md
+++ b/skills/settings/SKILL.md
@@ -53,7 +53,7 @@ Reset to defaults from `_defaults` section of settings.json. Omit path to reset 
 | `globalShortTerm.workingDays` | int | 1-30 | 2 | Also updates tokenLimit |
 | `projectLongTerm.tokenLimit` | int | 1000-50000 | 3,000 | Fixed limit |
 | `projectShortTerm.workingDays` | int | 1-30 | 5 | Also updates tokenLimit |
-| `synthesis.intervalHours` | float | 0.25-24 | 1 | Hours between auto-synthesis |
+| `synthesis.intervalHours` | float | 0.25-24 | 1 | In-script rate-limit floor (hours). Timer cadence is fixed at install time from the default, so values below the default only affect the floor; values above lengthen the effective cadence. |
 | `synthesis.model` | string | haiku/sonnet/opus | sonnet | Model for synthesis subagent |
 | `synthesis.minSessionMessages` | int | 0-100 | 5 | Skip sessions with fewer messages during synthesis |
 | `decay.ageDays` | int | 7-365 | 30 | Archive learnings older than this |

--- a/skills/settings/SKILL.md
+++ b/skills/settings/SKILL.md
@@ -53,7 +53,7 @@ Reset to defaults from `_defaults` section of settings.json. Omit path to reset 
 | `globalShortTerm.workingDays` | int | 1-30 | 2 | Also updates tokenLimit |
 | `projectLongTerm.tokenLimit` | int | 1000-50000 | 3,000 | Fixed limit |
 | `projectShortTerm.workingDays` | int | 1-30 | 5 | Also updates tokenLimit |
-| `synthesis.intervalHours` | float | 0.25-24 | 2 | Hours between auto-synthesis |
+| `synthesis.intervalHours` | float | 0.25-24 | 1 | Hours between auto-synthesis |
 | `synthesis.model` | string | haiku/sonnet/opus | sonnet | Model for synthesis subagent |
 | `synthesis.minSessionMessages` | int | 0-100 | 5 | Skip sessions with fewer messages during synthesis |
 | `decay.ageDays` | int | 7-365 | 30 | Archive learnings older than this |

--- a/systemd/claude-memory-synthesis.timer
+++ b/systemd/claude-memory-synthesis.timer
@@ -2,7 +2,7 @@
 Description=Run Claude Memory Synthesis periodically
 
 [Timer]
-OnCalendar=*-*-* 0/2:00:00
+OnCalendar=*-*-* 0/1:00:00
 Persistent=true
 RandomizedDelaySec=300
 

--- a/systemd/claude-memory-synthesis.timer
+++ b/systemd/claude-memory-synthesis.timer
@@ -2,8 +2,11 @@
 Description=Run Claude Memory Synthesis periodically
 
 [Timer]
-OnCalendar=*-*-* 0/1:00:00
-Persistent=true
+# Monotonic timer: fires 1h after each previous activation. Avoids the
+# OnCalendar race where a clock-aligned tick could fire <1h after the
+# eager `.last-synthesis` write, causing should_synthesize() to skip.
+OnBootSec=5min
+OnUnitActiveSec=1h
 RandomizedDelaySec=300
 
 [Install]

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -20,7 +20,7 @@
     "_comment": "project-memory/{project}-long-term-memory.md - project-specific learnings"
   },
   "synthesis": {
-    "intervalHours": 2,
+    "intervalHours": 1,
     "model": "sonnet",
     "minSessionMessages": 5,
     "_comment": "Minimum hours between auto-synthesis runs. Model: sonnet (default)|haiku|opus. minSessionMessages: skip sessions with fewer messages during synthesis."
@@ -50,7 +50,7 @@
     "globalLongTerm.tokenLimit": 3000,
     "projectShortTerm.workingDays": 5,
     "projectLongTerm.tokenLimit": 3000,
-    "synthesis.intervalHours": 2,
+    "synthesis.intervalHours": 1,
     "synthesis.model": "sonnet",
     "synthesis.minSessionMessages": 5,
     "decay.ageDays": 30,

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -411,30 +411,6 @@ class TestInstallSystemdUnits:
 
 
 # ---------------------------------------------------------------------------
-# _session_end_command
-# ---------------------------------------------------------------------------
-
-
-class TestSessionEndCommand:
-    def test_returns_launchctl_on_darwin(self):
-        with mock.patch("install.sys") as mock_sys, \
-             mock.patch("install.os") as mock_os:
-            mock_sys.platform = "darwin"
-            mock_os.getuid.return_value = 501
-            result = install._session_end_command()
-        assert "launchctl kickstart" in result
-        assert "gui/501/" in result
-        assert install.LAUNCHD_LABEL in result
-
-    def test_returns_systemctl_on_linux(self):
-        with mock.patch("install.sys") as mock_sys:
-            mock_sys.platform = "linux"
-            result = install._session_end_command()
-        assert "systemctl" in result
-        assert "--no-block" in result
-
-
-# ---------------------------------------------------------------------------
 # SessionEnd hook
 # ---------------------------------------------------------------------------
 
@@ -447,16 +423,6 @@ class TestSessionEndHook:
         assert "SessionEnd" in result["hooks"]
         hooks = result["hooks"]["SessionEnd"]
         assert len(hooks) >= 1
-
-    def test_session_end_hook_has_short_timeout(self):
-        """SessionEnd hook has a short timeout since it's fire-and-forget."""
-        settings = install.merge_hooks({}, "uv")
-        hooks = settings["hooks"]["SessionEnd"]
-        for entry in hooks:
-            for h in entry.get("hooks", []):
-                cmd = h.get("command", "")
-                if "claude-memory-synthesis" in cmd:
-                    assert h.get("timeout", 999) <= 5
 
     def test_session_end_hook_not_duplicated(self):
         """Running merge_hooks twice does not duplicate SessionEnd entries."""
@@ -568,8 +534,8 @@ class TestSessionEndHook:
         # New uv-based memory hook(s) added.
         assert any("uv run" in c and "load_memory.py" in c for c in commands)
 
-    def test_migration_removes_old_systemctl_hook(self):
-        """On macOS, old systemctl hook is replaced with launchctl."""
+    def test_migration_removes_old_systemctl_kickstart_hook(self):
+        """Old systemctl kickstart entry is stripped on re-install (no replacement)."""
         settings = {
             "hooks": {
                 "SessionEnd": [
@@ -586,23 +552,17 @@ class TestSessionEndHook:
                 ]
             }
         }
-        with mock.patch("install.sys") as mock_sys, \
-             mock.patch("install.os") as mock_os:
-            mock_sys.platform = "darwin"
-            mock_os.getuid.return_value = 501
-            result = install.merge_hooks(settings, "uv")
-
-        hooks = result["hooks"]["SessionEnd"]
+        result = install.merge_hooks(settings, "uv")
         commands = [
             h.get("command", "")
-            for entry in hooks
+            for entry in result["hooks"]["SessionEnd"]
             for h in entry.get("hooks", [])
         ]
         assert not any("systemctl" in c for c in commands)
-        assert any("launchctl" in c for c in commands)
+        assert not any("launchctl" in c for c in commands)
 
-    def test_migration_removes_old_launchctl_hook(self):
-        """On Linux, old launchctl hook is replaced with systemctl."""
+    def test_migration_removes_old_launchctl_kickstart_hook(self):
+        """Old launchctl kickstart entry is stripped on re-install (no replacement)."""
         settings = {
             "hooks": {
                 "SessionEnd": [
@@ -619,18 +579,14 @@ class TestSessionEndHook:
                 ]
             }
         }
-        with mock.patch("install.sys") as mock_sys:
-            mock_sys.platform = "linux"
-            result = install.merge_hooks(settings, "uv")
-
-        hooks = result["hooks"]["SessionEnd"]
+        result = install.merge_hooks(settings, "uv")
         commands = [
             h.get("command", "")
-            for entry in hooks
+            for entry in result["hooks"]["SessionEnd"]
             for h in entry.get("hooks", [])
         ]
         assert not any("launchctl" in c for c in commands)
-        assert any("systemctl" in c for c in commands)
+        assert not any("systemctl" in c for c in commands)
 
     def test_preserves_non_synthesis_session_end_hooks(self):
         """Migration only removes synthesis hooks, not other SessionEnd hooks."""
@@ -665,18 +621,22 @@ class TestSessionEndHook:
 class TestSessionEndRecallHook:
     """Tests for the session_end_recall.py SessionEnd hook."""
 
-    def test_session_end_has_two_hooks(self):
-        """SessionEnd hook has recall script first, then deferred synthesis."""
+    def test_session_end_has_recall_hook_only(self):
+        """SessionEnd hook runs the recall writer only.
+
+        Synthesis is triggered by the launchd/systemd timer on its own
+        schedule, not by a SessionEnd kickstart — kickstart hooks got
+        cancelled when the CLI exited abruptly, and the timer covers the
+        same cadence anyway.
+        """
         settings = {"hooks": {}}
         result = install.merge_hooks(settings, "uv")
         session_end = result["hooks"]["SessionEnd"]
         assert len(session_end) == 1
         hooks = session_end[0]["hooks"]
-        assert len(hooks) == 2
+        assert len(hooks) == 1
         assert "session_end_recall.py" in hooks[0]["command"]
         assert hooks[0]["timeout"] == 10
-        assert "memory-synthesis" in hooks[1]["command"]
-        assert hooks[1]["timeout"] == 5
 
     def test_recall_script_in_link_scripts(self):
         """session_end_recall.py is in the scripts to link."""
@@ -700,7 +660,7 @@ class TestPreCompactHook:
         assert len(hooks) >= 1
 
     def test_precompact_hook_has_short_timeout(self):
-        """PreCompact synthesis trigger has a short timeout since it's fire-and-forget."""
+        """PreCompact recall hook caps at 10s to avoid blocking compaction."""
         settings = install.merge_hooks({}, "uv")
         hooks = settings["hooks"]["PreCompact"]
         for entry in hooks:
@@ -715,18 +675,16 @@ class TestPreCompactHook:
         count_after = len(settings["hooks"]["PreCompact"])
         assert count_before == count_after
 
-    def test_precompact_hook_has_two_hooks(self):
-        """PreCompact hook has recall script first, then deferred synthesis."""
+    def test_precompact_has_recall_hook_only(self):
+        """PreCompact hook runs the recall writer only (matches SessionEnd)."""
         settings = {"hooks": {}}
         result = install.merge_hooks(settings, "uv")
         precompact = result["hooks"]["PreCompact"]
         assert len(precompact) == 1
         hooks = precompact[0]["hooks"]
-        assert len(hooks) == 2
+        assert len(hooks) == 1
         assert "session_end_recall.py" in hooks[0]["command"]
         assert hooks[0]["timeout"] == 10
-        assert "memory-synthesis" in hooks[1]["command"]
-        assert hooks[1]["timeout"] == 5
 
     def test_migration_removes_old_synthesis_precompact_hook(self):
         """Existing PreCompact synthesis hooks are replaced on re-install."""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -534,8 +534,13 @@ class TestSessionEndHook:
         # New uv-based memory hook(s) added.
         assert any("uv run" in c and "load_memory.py" in c for c in commands)
 
-    def test_migration_removes_old_systemctl_kickstart_hook(self):
-        """Old systemctl kickstart entry is stripped on re-install (no replacement)."""
+    @pytest.mark.parametrize("legacy_command", [
+        "systemctl --user start --no-block claude-memory-synthesis.service",
+        "launchctl kickstart gui/501/com.claude.memory-synthesis",
+    ])
+    def test_migration_removes_old_kickstart_hook(self, legacy_command):
+        """Old SessionEnd kickstart entry (either platform variant) is stripped on
+        re-install with no replacement."""
         settings = {
             "hooks": {
                 "SessionEnd": [
@@ -544,7 +549,7 @@ class TestSessionEndHook:
                         "hooks": [
                             {
                                 "type": "command",
-                                "command": "systemctl --user start --no-block claude-memory-synthesis.service",
+                                "command": legacy_command,
                                 "timeout": 5,
                             }
                         ],
@@ -560,33 +565,6 @@ class TestSessionEndHook:
         ]
         assert not any("systemctl" in c for c in commands)
         assert not any("launchctl" in c for c in commands)
-
-    def test_migration_removes_old_launchctl_kickstart_hook(self):
-        """Old launchctl kickstart entry is stripped on re-install (no replacement)."""
-        settings = {
-            "hooks": {
-                "SessionEnd": [
-                    {
-                        "matcher": "",
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "launchctl kickstart gui/501/com.claude.memory-synthesis",
-                                "timeout": 5,
-                            }
-                        ],
-                    }
-                ]
-            }
-        }
-        result = install.merge_hooks(settings, "uv")
-        commands = [
-            h.get("command", "")
-            for entry in result["hooks"]["SessionEnd"]
-            for h in entry.get("hooks", [])
-        ]
-        assert not any("launchctl" in c for c in commands)
-        assert not any("systemctl" in c for c in commands)
 
     def test_preserves_non_synthesis_session_end_hooks(self):
         """Migration only removes synthesis hooks, not other SessionEnd hooks."""
@@ -858,26 +836,26 @@ class TestDefaultsConsistency:
         assert template["_defaults"]["synthesis.intervalHours"] == expected
 
     def test_systemd_timer_cadence_matches_default_intervalhours(self):
-        """systemd .timer's OnCalendar hour-step must agree with the launchd
+        """systemd .timer's OnUnitActiveSec interval must agree with the launchd
         StartInterval (which is derived from DEFAULT_SETTINGS), otherwise
         Linux and macOS users get asymmetric cadences for the same default.
 
         The .timer file is static (not templated at install time) and its
-        OnCalendar=*-*-* 0/N:00:00 can only express integer N, so the default
+        OnUnitActiveSec=Nh suffix can only express integer N, so the default
         must be a whole hour or the platforms will diverge silently. The
         macOS launchd plist uses StartInterval=hours*3600 which can encode
         sub-hour intervals, so this guard fails loudly on the .timer side.
         """
         import re
         default_hours = DEFAULT_SETTINGS["synthesis"]["intervalHours"]
-        assert default_hours == int(default_hours), (
-            "synthesis.intervalHours default must be a whole hour because the "
-            "systemd .timer's OnCalendar field can't encode fractional hours. "
-            "Either change the default to an integer or template the .timer "
-            "file at install time."
+        assert isinstance(default_hours, int), (
+            "synthesis.intervalHours default must be a whole hour (int) because "
+            "the systemd .timer's OnUnitActiveSec field is static-text "
+            "Nh and can't encode fractional hours. Either change the default "
+            "to an integer or template the .timer file at install time."
         )
         timer = (self._repo_root() / "systemd" / "claude-memory-synthesis.timer").read_text()
-        match = re.search(r"OnCalendar=\*-\*-\* 0/(\d+):00:00", timer)
-        assert match is not None, "OnCalendar line not found or malformed"
-        hour_step = int(match.group(1))
-        assert hour_step == int(default_hours)
+        match = re.search(r"OnUnitActiveSec=(\d+)h", timer)
+        assert match is not None, "OnUnitActiveSec line not found or malformed"
+        interval_hours = int(match.group(1))
+        assert interval_hours == default_hours

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -704,11 +704,7 @@ class TestPreCompactHook:
                 ]
             }
         }
-        with mock.patch("install.sys") as mock_sys, \
-             mock.patch("install.os") as mock_os:
-            mock_sys.platform = "darwin"
-            mock_os.getuid.return_value = 501
-            result = install.merge_hooks(settings, "uv")
+        result = install.merge_hooks(settings, "uv")
         commands = [
             h.get("command", "")
             for entry in result["hooks"]["PreCompact"]
@@ -864,11 +860,24 @@ class TestDefaultsConsistency:
     def test_systemd_timer_cadence_matches_default_intervalhours(self):
         """systemd .timer's OnCalendar hour-step must agree with the launchd
         StartInterval (which is derived from DEFAULT_SETTINGS), otherwise
-        Linux and macOS users get asymmetric cadences for the same default."""
+        Linux and macOS users get asymmetric cadences for the same default.
+
+        The .timer file is static (not templated at install time) and its
+        OnCalendar=*-*-* 0/N:00:00 can only express integer N, so the default
+        must be a whole hour or the platforms will diverge silently. The
+        macOS launchd plist uses StartInterval=hours*3600 which can encode
+        sub-hour intervals, so this guard fails loudly on the .timer side.
+        """
         import re
+        default_hours = DEFAULT_SETTINGS["synthesis"]["intervalHours"]
+        assert default_hours == int(default_hours), (
+            "synthesis.intervalHours default must be a whole hour because the "
+            "systemd .timer's OnCalendar field can't encode fractional hours. "
+            "Either change the default to an integer or template the .timer "
+            "file at install time."
+        )
         timer = (self._repo_root() / "systemd" / "claude-memory-synthesis.timer").read_text()
         match = re.search(r"OnCalendar=\*-\*-\* 0/(\d+):00:00", timer)
         assert match is not None, "OnCalendar line not found or malformed"
         hour_step = int(match.group(1))
-        expected = int(DEFAULT_SETTINGS["synthesis"]["intervalHours"])
-        assert hour_step == expected
+        assert hour_step == int(default_hours)

--- a/tests/test_synthesis_cron.py
+++ b/tests/test_synthesis_cron.py
@@ -5,6 +5,7 @@ import sys
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
+from memory_utils import DEFAULT_SETTINGS
 from synthesis_cron import (
     LOG_ROTATION_BYTES,
     _append_stats,
@@ -18,6 +19,8 @@ from synthesis_cron import (
     should_run_deferred_synthesis,
 )
 
+DEFAULT_INTERVAL_HOURS = DEFAULT_SETTINGS["synthesis"]["intervalHours"]
+
 
 class TestShouldRunDeferredSynthesis:
     """Tests for the scheduling check."""
@@ -27,7 +30,7 @@ class TestShouldRunDeferredSynthesis:
         last_synth = tmp_path / ".last-synthesis"
         last_synth.write_text(datetime.now(timezone.utc).isoformat())
         with patch("synthesis_cron.load_settings", return_value={
-            "synthesis": {"intervalHours": 2}
+            "synthesis": {"intervalHours": DEFAULT_INTERVAL_HOURS}
         }), patch("load_memory.get_last_synthesis_file", return_value=last_synth):
             assert should_run_deferred_synthesis() is False
 
@@ -35,17 +38,17 @@ class TestShouldRunDeferredSynthesis:
         """If enough time passed, should run."""
         last_synth = tmp_path / ".last-synthesis"
         with patch("synthesis_cron.load_settings", return_value={
-            "synthesis": {"intervalHours": 2}
+            "synthesis": {"intervalHours": DEFAULT_INTERVAL_HOURS}
         }), patch("load_memory.get_last_synthesis_file", return_value=last_synth):
             assert should_run_deferred_synthesis() is True
 
     def test_returns_true_when_old_timestamp(self, tmp_path):
         """If timestamp is old enough, should run."""
         last_synth = tmp_path / ".last-synthesis"
-        old_time = datetime.now(timezone.utc) - timedelta(hours=3)
+        old_time = datetime.now(timezone.utc) - timedelta(hours=DEFAULT_INTERVAL_HOURS * 2)
         last_synth.write_text(old_time.isoformat())
         with patch("synthesis_cron.load_settings", return_value={
-            "synthesis": {"intervalHours": 2}
+            "synthesis": {"intervalHours": DEFAULT_INTERVAL_HOURS}
         }), patch("load_memory.get_last_synthesis_file", return_value=last_synth):
             assert should_run_deferred_synthesis() is True
 

--- a/tests/test_synthesis_cron.py
+++ b/tests/test_synthesis_cron.py
@@ -5,6 +5,8 @@ import sys
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from memory_utils import DEFAULT_SETTINGS
 from synthesis_cron import (
     LOG_ROTATION_BYTES,
@@ -25,32 +27,22 @@ DEFAULT_INTERVAL_HOURS = DEFAULT_SETTINGS["synthesis"]["intervalHours"]
 class TestShouldRunDeferredSynthesis:
     """Tests for the scheduling check."""
 
-    def test_returns_false_when_recently_synthesized(self, tmp_path):
-        """If .last-synthesis is recent, should not run."""
+    # last_synth_age: hours-since-now to stamp into .last-synthesis.
+    # None = leave file missing (never synthesized).
+    @pytest.mark.parametrize("last_synth_age,expected", [
+        (0, False),  # just synthesized -> not due
+        (None, True),  # no timestamp file -> always due
+        (DEFAULT_INTERVAL_HOURS * 2, True),  # well past interval -> due
+    ])
+    def test_schedule_check(self, tmp_path, last_synth_age, expected):
         last_synth = tmp_path / ".last-synthesis"
-        last_synth.write_text(datetime.now(timezone.utc).isoformat())
+        if last_synth_age is not None:
+            stamp = datetime.now(timezone.utc) - timedelta(hours=last_synth_age)
+            last_synth.write_text(stamp.isoformat())
         with patch("synthesis_cron.load_settings", return_value={
             "synthesis": {"intervalHours": DEFAULT_INTERVAL_HOURS}
         }), patch("load_memory.get_last_synthesis_file", return_value=last_synth):
-            assert should_run_deferred_synthesis() is False
-
-    def test_returns_true_when_due(self, tmp_path):
-        """If enough time passed, should run."""
-        last_synth = tmp_path / ".last-synthesis"
-        with patch("synthesis_cron.load_settings", return_value={
-            "synthesis": {"intervalHours": DEFAULT_INTERVAL_HOURS}
-        }), patch("load_memory.get_last_synthesis_file", return_value=last_synth):
-            assert should_run_deferred_synthesis() is True
-
-    def test_returns_true_when_old_timestamp(self, tmp_path):
-        """If timestamp is old enough, should run."""
-        last_synth = tmp_path / ".last-synthesis"
-        old_time = datetime.now(timezone.utc) - timedelta(hours=DEFAULT_INTERVAL_HOURS * 2)
-        last_synth.write_text(old_time.isoformat())
-        with patch("synthesis_cron.load_settings", return_value={
-            "synthesis": {"intervalHours": DEFAULT_INTERVAL_HOURS}
-        }), patch("load_memory.get_last_synthesis_file", return_value=last_synth):
-            assert should_run_deferred_synthesis() is True
+            assert should_run_deferred_synthesis() is expected
 
 
 class TestBuildClaudeCommand:

--- a/uninstall.py
+++ b/uninstall.py
@@ -59,7 +59,7 @@ def remove_hooks(settings: dict) -> dict:
         "save_session.py",
         "pretooluse-allow-memory.sh",
         "session_end_recall.py",
-        "memory-synthesis",  # SessionEnd/PreCompact hook: matches both systemctl and launchctl commands
+        "memory-synthesis",  # Legacy SessionEnd/PreCompact kickstart (removed 2026-05): matches systemctl and launchctl. Kept for migration from older installs.
     ]
 
     removed_count = 0


### PR DESCRIPTION
## Summary

- Drop the `launchctl kickstart` / `systemctl --user start` second hook from `SessionEnd` and `PreCompact`. Claude Code cancelled these when the CLI exited abruptly (Ctrl+C / `/exit` / terminal close), surfacing as "Hook cancelled" warnings. Since hooks under one matcher run sequentially, the kickstart (always second, after `session_end_recall.py`) was the one that got cut.
- Synthesis is now triggered only by the launchd `StartInterval` (macOS) / systemd `OnCalendar` timer (Linux). `synthesis_cron.py`'s own `should_run_deferred_synthesis()` already rate-limits by `synthesis.intervalHours` regardless of trigger source, so the kickstart provided no additional cadence.
- Bump default `synthesis.intervalHours` 2h → 1h so the timer-driven cadence covers the typical session-end use case. macOS plist `StartInterval` is derived from this; systemd `.timer`'s `OnCalendar` is updated to match.
- Existing `merge_hooks()` migration (`memory_substrings` substring filter) automatically strips legacy kickstart entries from user `settings.json` on re-install.

## Test plan

- [x] All 829 existing unit tests pass (`uv run --with pytest -m pytest tests/ -q`)
- [x] New integer-default guard in `test_systemd_timer_cadence_matches_default_intervalhours` rejects fractional defaults (which the `.timer` file can't express)
- [x] Re-ran `install.py` locally — kickstart entries stripped from `~/.claude/settings.json`, plist `StartInterval` regenerated to 3600
- [x] Implementation review (subagent): 6 issues found and fixed in fixup commit, re-review verdict pass with 0 findings
- [x] Verified `~/.claude/settings.json` SessionEnd/PreCompact each contain only the recall hook after re-install

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that session end only saves recall data and does not trigger synthesis
  * Updated Synthesis description to reflect timer-driven deferred synthesis

* **Configuration Changes**
  * Default synthesis interval changed from 2 hours to 1 hour across settings and templates
  * Scheduling converted to monotonic activation (timer now uses boot/interval cadence rather than clock-aligned runs)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikhilsitaram/claude-memory-system/pull/144)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->