### PR TITLE
feat(synthesis): relax LTM routing to allow significant Actions/Decisions

### DIFF
--- a/scripts/load_memory.py
+++ b/scripts/load_memory.py
@@ -444,8 +444,10 @@ Group entries by project. The system handles section placement and scope injecti
 
 **Project names:** Use the project names from the session headers: {project_names_str}. Use `global` for entries not tied to a specific project.
 
-**[LTM] flag (VERY rare — most entries should NOT be routed):** Only prefix entries that would save significant time or prevent a real mistake if encountered again months from now. Route to LTM:
+**[LTM] flag (selective — most entries stay in short-term memory):** Only prefix entries that would save significant time or prevent a real mistake if encountered again months from now. Route to LTM:
 - Architecture choices or design tradeoffs with lasting impact across sessions
+- Scope decisions that constrain or shape future work ("we decided not to support X", "module Y owns this responsibility")
+- Significant implementations that establish a new pattern, subsystem, or capability future work will reference (not routine feature work)
 - Gotchas that caused >30 min of debugging and aren't googleable
 - Patterns proven across multiple sessions, not just discovered once
 Do NOT route:
@@ -453,7 +455,7 @@ Do NOT route:
 - Generic software patterns (DRY, separation of concerns, use env vars)
 - One-time fixes or bugs unlikely to recur
 - Tool-specific tips that are easily re-discoverable (man pages, --help, docs)
-- Implementation details (built X, fixed Y) — these belong in short-term memory
+- Routine implementation work (small features, bug fixes, refactors) without lasting architectural impact — belongs in short-term memory
 - Gotchas with obvious error messages that point to the solution
 - Version-specific notes or workarounds for known issues with tracked fixes
 Tag up to {ROUTE_CAP + 2} [LTM] candidates per project, ordered by importance (most important first). Only the top {ROUTE_CAP} will be kept — the rest are discarded. This means you must rank: put the entry most worth preserving long-term first.
@@ -553,7 +555,7 @@ Your output must follow this exact structure. Here is a complete realistic examp
 
 ===PROJECT:myproject===
 - [implement] Built REST API endpoints for user authentication
-- [design] JWT tokens over session cookies — stateless scales better
+- [LTM][design] JWT tokens over session cookies — stateless, scales horizontally without sticky sessions
 - [LTM][gotcha] SQLAlchemy async sessions need explicit await session.close() or connections leak
 - [LTM][GLOBAL][tip] git stash -u includes untracked files
 


### PR DESCRIPTION
## Summary
- The synthesis prompt previously excluded almost all Actions/Decisions from LTM ("VERY rare", "Implementation details … belong in short-term memory"). Relax this so durable architectural Decisions and pattern-establishing Actions can route, while keeping `ROUTE_CAP = 3` + keyword-overlap dedup as the anti-flood floor.
- Adds positive routing bullets for scope decisions and significant implementations; narrows the exclusion to *routine* implementation work; updates the prompt example to demonstrate `[LTM][design]` alongside the existing `[LTM][gotcha]` / `[LTM][tip]`.

## Test plan
- [x] `uv run --with pytest -m pytest tests/test_load_memory.py tests/test_synthesis.py -q` — 273 passed
- [ ] Observe next 1–2 synthesis runs to confirm Actions/Decisions begin appearing in LTM without crowding out Learnings/Lessons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal guidance and instructions for system processes, including refinements to routing criteria and example outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikhilsitaram/claude-memory-system/pull/145)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->