### PR TITLE
fix(projects): make project move/rename durable against index rebuild

### DIFF
--- a/scripts/project_manager.py
+++ b/scripts/project_manager.py
@@ -60,6 +60,7 @@ __all__ = [
     "encode_path",
     "decode_path_best_effort",
     "get_original_path_from_folder",
+    "get_folder_original_path",
     # Discovery
     "list_projects",
     "find_orphaned_folders",
@@ -208,6 +209,51 @@ def get_original_path_from_folder(folder_path: Path) -> Optional[str]:
     """
     data = load_sessions_index(folder_path)
     return get_sessions_original_path(data) or None
+
+
+def get_folder_original_path(folder_path: Path) -> Optional[str]:
+    """
+    Resolve a project folder's original path, preferring whatever still exists.
+
+    Tries ``sessions-index.json`` first (legacy/authoritative when present), then
+    falls back to the ``cwd`` recorded in the folder's newest ``.jsonl``
+    transcript. Current Claude Code no longer writes ``sessions-index.json``, so
+    the transcript ``cwd`` is the real source of truth -- mirrors how
+    ``indexing._extract_from_jsonl`` resolves the path (newest mtime wins).
+
+    Returns the path string, or None if neither source yields one.
+    """
+    path = get_original_path_from_folder(folder_path)
+    if path:
+        return path
+
+    folder_path = Path(folder_path)
+    if not folder_path.is_dir():
+        return None
+
+    # Newest transcript wins (matches indexing._extract_from_jsonl ordering).
+    transcripts = sorted(
+        folder_path.glob("*.jsonl"),
+        key=lambda p: p.stat().st_mtime if p.exists() else 0.0,
+        reverse=True,
+    )
+    for jsonl_file in transcripts:
+        try:
+            with open(jsonl_file, "r", encoding="utf-8") as f:
+                for _ in range(50):  # cwd may trail prepended bookkeeping records
+                    line = f.readline()
+                    if not line:
+                        break
+                    try:
+                        cwd = json.loads(line).get("cwd")
+                    except (json.JSONDecodeError, AttributeError, TypeError):
+                        continue
+                    if cwd:
+                        return cwd
+        except (IOError, UnicodeDecodeError):
+            continue
+
+    return None
 
 
 # =============================================================================
@@ -1070,9 +1116,11 @@ def rewrite_cwd_in_transcripts(folder: Path, old_path: str, new_path: str) -> di
     transcripts still record the old cwd, so the next index rebuild silently
     reverts the rename. Rewriting cwd here is what makes a move durable.
 
-    Only the ``cwd`` field is touched -- the old path as an exact value or as
-    the prefix of a deeper cwd (a session run in a subdirectory) -- so
-    conversation text and tool I/O elsewhere in the transcript are left intact.
+    Only the ``cwd`` field is touched, and only when ``old_path`` is followed by
+    a path boundary -- the exact value (closing quote follows) or a deeper cwd
+    for a session run in a subdirectory ("/" follows). A sibling project that
+    merely shares a prefix (``/p/old`` vs ``/p/old-other``) is left untouched, as
+    is conversation text and tool I/O elsewhere in the transcript.
 
     Returns ``{"files_modified": int, "session_ids": list[str]}`` (session_ids
     are the stems of the modified ``*.jsonl`` files, for offset bookkeeping).
@@ -1083,9 +1131,10 @@ def rewrite_cwd_in_transcripts(folder: Path, old_path: str, new_path: str) -> di
         return result
 
     # Anchor on the cwd field so only the working-directory value is rewritten.
-    # Captures any JSON spacing around the colon; matches old_path exactly or as
-    # a path prefix (the trailing "/" or closing quote is left untouched).
-    pattern = re.compile(r'("cwd"\s*:\s*")' + re.escape(old_path))
+    # Captures any JSON spacing around the colon; the trailing lookahead requires
+    # old_path to end at a path boundary ("/" for a subdir cwd, or the closing
+    # quote for an exact match) so a sibling project sharing a prefix is skipped.
+    pattern = re.compile(r'("cwd"\s*:\s*")' + re.escape(old_path) + r'(?=/|")')
 
     def _repl(m: "re.Match") -> str:
         return m.group(1) + new_path
@@ -1402,9 +1451,12 @@ def execute_merge_orphan(
             projects_dir = get_projects_dir()
             target_encoded = encode_path(str(target_path))
 
-            # Get original path from orphan for memory file lookup
+            # Get original path from orphan for memory file lookup and the cwd
+            # rewrite. Fall back to the transcript cwd when sessions-index.json
+            # is absent (current Claude Code no longer writes it) — otherwise the
+            # cwd rewrite below would be skipped and the merge would revert.
             orphan_folder = projects_dir / orphan_name
-            orphan_original_path = get_original_path_from_folder(orphan_folder)
+            orphan_original_path = get_folder_original_path(orphan_folder)
             orphan_project_name = Path(orphan_original_path).name if orphan_original_path else None
 
             # Execute merges

--- a/scripts/project_manager.py
+++ b/scripts/project_manager.py
@@ -17,6 +17,7 @@ Usage (from Claude Code):
 import dataclasses
 import json
 import os
+import re
 import shutil
 import sys
 from dataclasses import dataclass, field
@@ -39,8 +40,10 @@ from memory_utils import (
     get_sessions_original_path,
     load_json_file,
     load_sessions_index,
+    load_synthesis_state,
     project_name_to_filename,
     save_json_file,
+    save_synthesis_state,
     to_iso_z,
 )
 
@@ -80,8 +83,11 @@ __all__ = [
     "rebuild_sessions_index",
     "merge_sessions_index",
     "rewrite_paths_in_file",
+    "rewrite_cwd_in_transcripts",
+    "refresh_synthesis_offsets",
     "get_memory_files_for_merge",
     "update_session_index_paths",
+    "rebuild_and_verify_index",
 ]
 
 
@@ -1051,6 +1057,163 @@ def update_session_index_paths(old_path: str, new_path: str) -> int:
     return updated
 
 
+def rewrite_cwd_in_transcripts(folder: Path, old_path: str, new_path: str) -> dict:
+    """
+    Rewrite the ``cwd`` field (old_path -> new_path) inside every ``*.jsonl``
+    transcript in a Claude Code project folder.
+
+    Why this matters: indexing.build_projects_index rebuilds the entire
+    projects index from scratch and derives each project's path from the
+    newest transcript's ``cwd`` field (see indexing._extract_from_jsonl).
+    Current Claude Code no longer writes ``sessions-index.json``, so the JSONL
+    ``cwd`` is the authoritative path signal. After a move/rename the
+    transcripts still record the old cwd, so the next index rebuild silently
+    reverts the rename. Rewriting cwd here is what makes a move durable.
+
+    Only the ``cwd`` field is touched -- the old path as an exact value or as
+    the prefix of a deeper cwd (a session run in a subdirectory) -- so
+    conversation text and tool I/O elsewhere in the transcript are left intact.
+
+    Returns ``{"files_modified": int, "session_ids": list[str]}`` (session_ids
+    are the stems of the modified ``*.jsonl`` files, for offset bookkeeping).
+    """
+    folder = Path(folder)
+    result: dict[str, Any] = {"files_modified": 0, "session_ids": []}
+    if not folder.is_dir():
+        return result
+
+    # Anchor on the cwd field so only the working-directory value is rewritten.
+    # Captures any JSON spacing around the colon; matches old_path exactly or as
+    # a path prefix (the trailing "/" or closing quote is left untouched).
+    pattern = re.compile(r'("cwd"\s*:\s*")' + re.escape(old_path))
+
+    def _repl(m: "re.Match") -> str:
+        return m.group(1) + new_path
+
+    for jsonl_file in sorted(folder.glob("*.jsonl")):
+        if _stream_regex_replace(jsonl_file, pattern, _repl) > 0:
+            result["files_modified"] += 1
+            result["session_ids"].append(jsonl_file.stem)
+
+    return result
+
+
+def _stream_regex_replace(filepath: Path, pattern: "re.Pattern", repl) -> int:
+    """
+    Apply a compiled-regex substitution to a file line-by-line (streaming).
+
+    Writes to a temp file and atomically replaces the original only if at least
+    one substitution was made. Returns the total number of substitutions.
+    """
+    filepath = Path(filepath)
+    if not filepath.exists():
+        return 0
+
+    temp_path = filepath.with_suffix(filepath.suffix + ".tmp")
+    total = 0
+    try:
+        with open(filepath, "r", encoding="utf-8") as infile, \
+             open(temp_path, "w", encoding="utf-8") as outfile:
+            for line in infile:
+                new_line, n = pattern.subn(repl, line)
+                total += n
+                outfile.write(new_line)
+        if total > 0:
+            temp_path.replace(filepath)
+        elif temp_path.exists():
+            temp_path.unlink()
+    except (IOError, UnicodeDecodeError):
+        if temp_path.exists():
+            temp_path.unlink()
+        return 0
+
+    return total
+
+
+def refresh_synthesis_offsets(session_ids: list[str], folder: Path) -> int:
+    """
+    Refresh stored synthesis byte-offsets for the given sessions to the current
+    file size.
+
+    Rewriting ``cwd`` inside a transcript changes its byte size but not its line
+    count. Synthesis tracks a per-session high-water mark as ``offset`` (bytes);
+    a grown file looks like it has new content, so the next synthesis run would
+    re-enter delta mode for it. Resetting ``offset`` to the new size (line count
+    is unchanged, so ``lines`` is left as-is) keeps those sessions marked as
+    fully processed. Best-effort: sessions absent from state are skipped.
+
+    Returns the number of sessions updated.
+    """
+    folder = Path(folder)
+    state = load_synthesis_state()
+    sessions = state.get("sessions")
+    if not isinstance(sessions, dict):
+        return 0
+
+    updated = 0
+    for sid in session_ids:
+        entry = sessions.get(sid)
+        if not isinstance(entry, dict):
+            continue
+        jsonl_file = folder / f"{sid}.jsonl"
+        if jsonl_file.exists():
+            entry["offset"] = jsonl_file.stat().st_size
+            updated += 1
+
+    if updated:
+        save_synthesis_state(state)
+
+    return updated
+
+
+def rebuild_and_verify_index(expected_original_path: str) -> dict:
+    """
+    Rebuild the projects index from transcripts and verify a move is durable.
+
+    Run this after execute_move / execute_merge_orphan. It calls
+    indexing.build_projects_index() -- the same full rebuild synthesis performs
+    hourly -- and confirms the project now resolves to ``expected_original_path``
+    on disk. If ``durable`` is False, the cwd rewrite was incomplete and the
+    rename would otherwise revert on the next synthesis pass.
+
+    Returns ``{"durable": bool, "entry": dict|None, "stale_paths": list[str],
+    "message": str}``.
+    """
+    # Local import: indexing depends on memory_utils only, so this avoids any
+    # import-order coupling with project_manager at module load time.
+    from indexing import build_projects_index
+
+    index = build_projects_index()
+    projects = index.get("projects", {})
+    canonical = str(expected_original_path).lower()
+    entry = projects.get(canonical)
+
+    stale_paths = [
+        data.get("originalPath", cp)
+        for cp, data in projects.items()
+        if data.get("originalPath") and not Path(data["originalPath"]).exists()
+    ]
+
+    durable = bool(entry) and Path(expected_original_path).exists()
+    if durable:
+        message = f"Durable: '{entry['name']}' resolves to {expected_original_path}"
+    elif entry is None:
+        message = (
+            f"NOT durable: no index entry for {expected_original_path} after "
+            "rebuild — cwd rewrite was likely incomplete and the rename will "
+            "revert on the next synthesis run"
+        )
+    else:
+        message = f"NOT durable: {expected_original_path} does not exist on disk"
+
+    return {
+        "durable": durable,
+        "entry": entry,
+        "stale_paths": stale_paths,
+        "message": message,
+    }
+
+
 # =============================================================================
 # Execution Functions
 # =============================================================================
@@ -1129,6 +1292,20 @@ def execute_move(
                 if source_path.exists():
                     shutil.move(str(source_path), str(dest_path))
 
+            # Rewrite cwd inside the destination transcripts so the rename
+            # survives the next index rebuild (build_projects_index derives a
+            # project's path from the transcript cwd, not from history.jsonl or
+            # sessions-index.json). Without this the move reverts on the next
+            # synthesis pass. Then refresh synthesis offsets, since the rewrite
+            # grows each file's byte size without adding lines.
+            new_encoded = encode_path(str(new_path))
+            new_project_folder = get_projects_dir() / new_encoded
+            cwd_rewrite = rewrite_cwd_in_transcripts(
+                new_project_folder, str(old_path), str(new_path)
+            )
+            if cwd_rewrite["session_ids"]:
+                refresh_synthesis_offsets(cwd_rewrite["session_ids"], new_project_folder)
+
             # Update projects-index.json
             index_file = get_projects_index_file()
             index = load_json_file(index_file, {"projects": {}})
@@ -1161,6 +1338,7 @@ def execute_move(
                 "success": True,
                 "message": f"Successfully moved project from {old_path} to {new_path}",
                 "backup_path": str(backup_path),
+                "cwd_files_rewritten": cwd_rewrite["files_modified"],
             }
 
     except TimeoutError:
@@ -1312,6 +1490,18 @@ def execute_merge_orphan(
                     old_path_rename.rename(new_path_rename)
                     renamed_folders.append(str(new_path_rename))
 
+            # Rewrite cwd inside the target's transcripts (now including the
+            # merged-in orphan transcripts) so the merge survives the next index
+            # rebuild, then refresh synthesis offsets for the rewritten files.
+            cwd_rewrite: dict[str, Any] = {"files_modified": 0, "session_ids": []}
+            if orphan_original_path:
+                target_folder = projects_dir / target_encoded
+                cwd_rewrite = rewrite_cwd_in_transcripts(
+                    target_folder, orphan_original_path, str(target_path)
+                )
+                if cwd_rewrite["session_ids"]:
+                    refresh_synthesis_offsets(cwd_rewrite["session_ids"], target_folder)
+
             # Update projects-index.json
             index_file = get_projects_index_file()
             index = load_json_file(index_file, {"projects": {}})
@@ -1351,6 +1541,7 @@ def execute_merge_orphan(
                 "renamed_folders": renamed_folders,
                 "orphan_project_name": orphan_project_name,
                 "target_project_name": target_path.name,
+                "cwd_files_rewritten": cwd_rewrite["files_modified"],
             }
 
     except TimeoutError:

--- a/scripts/project_manager.py
+++ b/scripts/project_manager.py
@@ -42,6 +42,7 @@ from memory_utils import (
     load_sessions_index,
     load_synthesis_state,
     project_name_to_filename,
+    resolve_session_path,
     save_json_file,
     save_synthesis_state,
     to_iso_z,
@@ -218,8 +219,12 @@ def get_folder_original_path(folder_path: Path) -> Optional[str]:
     Tries ``sessions-index.json`` first (legacy/authoritative when present), then
     falls back to the ``cwd`` recorded in the folder's newest ``.jsonl``
     transcript. Current Claude Code no longer writes ``sessions-index.json``, so
-    the transcript ``cwd`` is the real source of truth -- mirrors how
-    ``indexing._extract_from_jsonl`` resolves the path (newest mtime wins).
+    the transcript ``cwd`` is the real source of truth.
+
+    The fallback delegates to ``indexing._extract_from_jsonl`` rather than
+    re-scanning, so this resolver uses the exact same newest-mtime ordering, scan
+    limit, and ``cwd`` field as ``build_projects_index`` -- guaranteeing the path
+    we rewrite is the one the index will actually be rebuilt from.
 
     Returns the path string, or None if neither source yields one.
     """
@@ -227,33 +232,11 @@ def get_folder_original_path(folder_path: Path) -> Optional[str]:
     if path:
         return path
 
-    folder_path = Path(folder_path)
-    if not folder_path.is_dir():
-        return None
+    # Local import: indexing depends only on memory_utils, so no import cycle.
+    from indexing import _extract_from_jsonl
 
-    # Newest transcript wins (matches indexing._extract_from_jsonl ordering).
-    transcripts = sorted(
-        folder_path.glob("*.jsonl"),
-        key=lambda p: p.stat().st_mtime if p.exists() else 0.0,
-        reverse=True,
-    )
-    for jsonl_file in transcripts:
-        try:
-            with open(jsonl_file, "r", encoding="utf-8") as f:
-                for _ in range(50):  # cwd may trail prepended bookkeeping records
-                    line = f.readline()
-                    if not line:
-                        break
-                    try:
-                        cwd = json.loads(line).get("cwd")
-                    except (json.JSONDecodeError, AttributeError, TypeError):
-                        continue
-                    if cwd:
-                        return cwd
-        except (IOError, UnicodeDecodeError):
-            continue
-
-    return None
+    cwd, _ = _extract_from_jsonl(Path(folder_path))
+    return cwd or None
 
 
 # =============================================================================
@@ -340,8 +323,9 @@ def find_orphaned_folders() -> list[OrphanInfo]:
 
         folder_name = folder.name
 
-        # Get authoritative original path from sessions-index.json
-        original_path = get_original_path_from_folder(folder)
+        # Original path: sessions-index.json if present, else the transcript cwd
+        # (current Claude Code no longer writes sessions-index.json).
+        original_path = get_folder_original_path(folder)
 
         # Determine if this is an orphan
         # First check: if folder is tracked in our index, it's not an orphan
@@ -648,8 +632,10 @@ def plan_merge_orphan(orphan_name: str, target_path: Path) -> OperationPlan:
     if history_file.exists():
         backups.append(str(history_file))
 
-    # Check for orphan's memory file (need to detect project name)
-    original_path = get_original_path_from_folder(orphan_folder)
+    # Check for orphan's memory file (need to detect project name). Use the cwd
+    # fallback so plan and execute_merge_orphan resolve the orphan identically —
+    # otherwise plan omits the orphan memory file that execute then merges.
+    original_path = get_folder_original_path(orphan_folder)
     if original_path:
         orphan_project_name = Path(original_path).name
         orphan_memory_filename = project_name_to_filename(orphan_project_name)
@@ -1234,7 +1220,11 @@ def rebuild_and_verify_index(expected_original_path: str) -> dict:
 
     index = build_projects_index()
     projects = index.get("projects", {})
-    canonical = str(expected_original_path).lower()
+    # build_projects_index keys projects by resolve_session_path(cwd).lower()
+    # (collapsing git worktrees / subdirs to the repo root), so resolve the
+    # lookup key the same way — otherwise a worktree/subdir project would miss
+    # and falsely report NOT durable even though the move succeeded.
+    canonical = resolve_session_path(str(expected_original_path)).lower()
     entry = projects.get(canonical)
 
     stale_paths = [

--- a/skills/projects/SKILL.md
+++ b/skills/projects/SKILL.md
@@ -8,6 +8,18 @@ user-invokable: true
 
 Manage Claude Code project data (sessions, file history, memory) when projects are moved, renamed, or need cleanup.
 
+## How the index is built (read this first)
+
+`projects-index.json` is **rebuilt from scratch hourly** by synthesis (`indexing.build_projects_index`). It derives each project's path from the **`cwd` field recorded inside the newest `.jsonl` transcript** in each `~/.claude/projects/<encoded>/` folder. Current Claude Code does **not** write `sessions-index.json` — the transcript `cwd` is the authoritative path signal.
+
+Consequence: a rename only sticks if the transcripts' `cwd` is updated. Change the index but leave the old `cwd` in the transcripts, and the next synthesis rebuild silently reverts your change. `execute_move` / `execute_merge_orphan` now rewrite `cwd` in the destination transcripts automatically — but **always confirm durability** with `rebuild_and_verify_index()` after executing.
+
+## Running
+
+Use a **3.10+ interpreter**. The system `python3` on macOS is 3.9 and crashes on this library's `X | None` type hints. Run snippets with `uv run --no-project python - <<'PY' … PY` (or an explicit `python3.12` / `python3.13`), never bare `python3`.
+
+Do **not** run a move from a live session whose cwd *is* the project being moved — that session keeps appending the old path to `history.jsonl` and its transcript after the move, re-polluting the data. Run from `~`, and ideally close other open sessions in that project first.
+
 ## When to Use
 
 - User asks about project status or health
@@ -27,6 +39,7 @@ from project_manager import (
     validate_move, validate_merge_orphan,
     plan_move, plan_merge_orphan, plan_cleanup,
     execute_move, execute_merge_orphan, execute_cleanup,
+    rebuild_and_verify_index,
     restore_from_backup, list_backups, get_memory_files_for_merge,
 )
 ```
@@ -34,13 +47,22 @@ from project_manager import (
 ## Decision Tree
 
 ```
-START: list_projects() + find_orphaned_folders()
+START: list_projects() + find_orphaned_folders() + find_stale_entries()
 
 Source directory EXISTS → move flow (validate_move → plan_move → execute_move)
 Source directory GONE, orphaned folders exist → merge-orphan flow (most common)
 Stale index entries → cleanup flow (plan_cleanup → execute_cleanup)
 Something went wrong → restore_from_backup()
+
+ALWAYS after any execute_move / execute_merge_orphan:
+  rebuild_and_verify_index(new_path)  → check result["durable"] is True
 ```
+
+**Hybrid state** (seen when a rename was done partly by hand): source gone **and** the new
+location already has its own transcript folder **and** the index already merged both encoded
+paths under one name. The move/merge tools handle the files, but the rename still won't stick
+until the old `cwd` is gone from every transcript — run `rebuild_and_verify_index()` and, if
+`durable` is False, rewrite the lingering `cwd`s (`rewrite_cwd_in_transcripts`) and re-verify.
 
 ## Example: Merge Orphan (Most Common Case)
 
@@ -63,7 +85,12 @@ print(plan.summary)  # Show to user, get confirmation
 result = execute_merge_orphan(orphan_folder, target, confirmed=True)
 # result includes backup_path, renamed_folders
 
-# 4. If both had memory files, merge them intelligently
+# 4. Verify the rename is durable (survives the next synthesis rebuild)
+check = rebuild_and_verify_index(str(target))
+print(check["message"])          # warn the user if not durable
+assert check["durable"], "rename will revert — see lingering cwd in transcripts"
+
+# 5. If both had memory files, merge them intelligently
 files = get_memory_files_for_merge(
     result["orphan_project_name"], result["target_project_name"]
 )
@@ -76,14 +103,17 @@ See `reference.md` for full function reference, additional workflow examples, an
 
 1. **Always show plan before executing** — users must understand what will happen
 2. **Never pass `confirmed=True` without explicit user approval**
-3. **Backups are automatic** — tell user where they're stored (result includes `backup_path`)
-4. **Orphaned folders are renamed, not deleted** — renamed to `.merged.bak` for safety
-5. **Memory files need intelligent merge** — deduplicate, combine sections, preserve unique content
+3. **Always verify durability** — after `execute_move`/`execute_merge_orphan`, call `rebuild_and_verify_index(new_path)` and confirm `result["durable"]`; the index is rebuilt from transcript `cwd` hourly, so an unverified rename can silently revert
+4. **Backups are automatic** — tell user where they're stored (result includes `backup_path`)
+5. **Orphaned folders are renamed, not deleted** — renamed to `.merged.bak` for safety
+6. **Memory files need intelligent merge** — deduplicate, combine sections, preserve unique content
 
 ## Common Mistakes
 
 - **Executing without showing plan** — Always call `plan_*()` and display before `execute_*()`
-- **Assuming encoded path can be decoded** — Encoding is lossy (`/` and `.` both become `-`). Use `sessions-index.json` for authoritative original path.
+- **Skipping the durability check** — A move can report `success: True` yet revert on the next hourly synthesis if any transcript still records the old `cwd`. Always `rebuild_and_verify_index()`.
+- **Running the move from inside the project's own live session** — that session re-pollutes `history.jsonl`/transcripts with the old path after the move. Run from `~`.
+- **Assuming encoded path can be decoded** — Encoding is lossy (`/` and `.` both become `-`). Read the authoritative path from the transcript `cwd`, not by decoding the folder name.
 - **Concatenating memory files** — Memory merges require intelligent dedup, not concatenation
 
 ## Path Encoding
@@ -91,4 +121,4 @@ See `reference.md` for full function reference, additional workflow examples, an
 Claude Code encodes paths by replacing `/` and `.` with `-`:
 - `/home/user/my-project` → `-home-user-my-project`
 
-**Important**: This encoding is LOSSY. Always use `sessions-index.json` for the authoritative original path.
+**Important**: This encoding is LOSSY (you cannot reliably decode it back). The authoritative original path is the `cwd` field inside the folder's `.jsonl` transcripts (`get_original_path_from_folder()` reads `sessions-index.json` when present, but current Claude Code no longer writes it, so `cwd` is the real source of truth).

--- a/skills/projects/reference.md
+++ b/skills/projects/reference.md
@@ -12,12 +12,18 @@
 | `plan_move(old, new, mode)` | Show what move will do | `OperationPlan` |
 | `plan_merge_orphan(orphan, target)` | Show what merge will do | `OperationPlan` |
 | `plan_cleanup()` | Show what cleanup will do | `OperationPlan` |
-| `execute_move(...)` | Perform move (needs `confirmed=True`) | `dict` |
-| `execute_merge_orphan(...)` | Merge orphaned data (needs `confirmed=True`) | `dict` |
+| `execute_move(...)` | Perform move (needs `confirmed=True`); rewrites transcript `cwd` | `dict` |
+| `execute_merge_orphan(...)` | Merge orphaned data (needs `confirmed=True`); rewrites transcript `cwd` | `dict` |
 | `execute_cleanup(...)` | Remove stale entries (needs `confirmed=True`) | `dict` |
+| `rebuild_and_verify_index(path)` | Rebuild index from transcripts; confirm rename is durable | `dict` |
+| `rewrite_cwd_in_transcripts(folder, old, new)` | Rewrite `cwd` field in a folder's `.jsonl` transcripts | `dict` |
+| `refresh_synthesis_offsets(session_ids, folder)` | Reset synthesis byte-offsets after a `cwd` rewrite | `int` |
 | `restore_from_backup(path)` | Undo last operation | `dict` |
 | `list_backups()` | List available backups | `list[dict]` |
 | `get_memory_files_for_merge(src, dst)` | Get memory files for intelligent merge | `dict` |
+
+`execute_move` / `execute_merge_orphan` return an extra `cwd_files_rewritten` count.
+`rebuild_and_verify_index` returns `{"durable": bool, "entry": dict|None, "stale_paths": list[str], "message": str}` — check `durable` before declaring a move complete.
 
 ## Additional Workflow Examples
 
@@ -59,6 +65,13 @@ plan = plan_move(old, new, merge_mode="merge")
 print(plan.summary)
 
 result = execute_move(old, new, merge_mode="merge", confirmed=True)
+
+# Durability check — the index is rebuilt from transcript cwd hourly, so a
+# move that doesn't update cwd silently reverts. execute_move now rewrites cwd,
+# but always confirm:
+check = rebuild_and_verify_index(str(new))
+print(check["message"])
+assert check["durable"]
 ```
 
 ### Cleanup Stale Entries
@@ -86,7 +99,7 @@ result = restore_from_backup(backups[0]["path"])
 
 | Subdirectory | Contents |
 |--------------|----------|
-| `projects/{encoded}/` | Session folders, `sessions-index.json`, `.jsonl` files |
+| `projects/{encoded}/` | `.jsonl` session transcripts (each records `cwd` — the authoritative project path). `sessions-index.json` may be absent; current Claude Code no longer writes it |
 | `file-history/{encoded}/` | File edit history |
 | `todos/{encoded}/` | TODO items |
 | `shell-snapshots/{encoded}/` | Shell state |

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -21,7 +21,10 @@ from project_manager import (  # noqa: I001
     plan_cleanup,
     plan_merge_orphan,
     plan_move,
+    rebuild_and_verify_index,
+    refresh_synthesis_offsets,
     restore_from_backup,
+    rewrite_cwd_in_transcripts,
     rewrite_paths_in_file,
     update_session_index_paths,
     validate_merge_orphan,
@@ -404,6 +407,144 @@ class TestRewritePathsInFile:
             "/new"
         )
         assert count == 0
+
+
+# =============================================================================
+# Transcript cwd Rewrite Tests (move durability)
+# =============================================================================
+
+
+class TestRewriteCwdInTranscripts:
+    """Tests for rewrite_cwd_in_transcripts — makes a move survive index rebuild."""
+
+    OLD = "/home/user/old-project"
+    NEW = "/home/user/new-project"
+
+    def _write_transcript(self, folder, session_id, cwd, extra_lines=None):
+        folder.mkdir(parents=True, exist_ok=True)
+        f = folder / f"{session_id}.jsonl"
+        lines = [json.dumps({
+            "type": "user", "cwd": cwd, "timestamp": "2026-06-23T10:00:00.000Z",
+        })]
+        for entry in (extra_lines or []):
+            lines.append(json.dumps(entry))
+        f.write_text("\n".join(lines) + "\n")
+        return f
+
+    def test_rewrites_exact_cwd(self, tmp_path):
+        f = self._write_transcript(tmp_path / "folder", "sess1", self.OLD)
+        result = rewrite_cwd_in_transcripts(tmp_path / "folder", self.OLD, self.NEW)
+        assert result["files_modified"] == 1
+        assert result["session_ids"] == ["sess1"]
+        assert json.loads(f.read_text().splitlines()[0])["cwd"] == self.NEW
+
+    def test_rewrites_cwd_prefix_for_subdir_session(self, tmp_path):
+        """A session run in a subdirectory has cwd under the project root."""
+        f = self._write_transcript(tmp_path / "folder", "sess1", self.OLD + "/sub")
+        rewrite_cwd_in_transcripts(tmp_path / "folder", self.OLD, self.NEW)
+        assert json.loads(f.read_text().splitlines()[0])["cwd"] == self.NEW + "/sub"
+
+    def test_leaves_non_cwd_occurrences_untouched(self, tmp_path):
+        """The old path inside message content must NOT be rewritten."""
+        extra = {"type": "assistant", "content": f"see {self.OLD}/file.py"}
+        f = self._write_transcript(tmp_path / "folder", "sess1", self.OLD, [extra])
+        rewrite_cwd_in_transcripts(tmp_path / "folder", self.OLD, self.NEW)
+        lines = f.read_text().splitlines()
+        assert json.loads(lines[0])["cwd"] == self.NEW
+        assert f"{self.OLD}/file.py" in lines[1]  # content preserved verbatim
+
+    def test_no_match_returns_zero(self, tmp_path):
+        self._write_transcript(tmp_path / "folder", "sess1", "/home/user/other")
+        result = rewrite_cwd_in_transcripts(tmp_path / "folder", self.OLD, self.NEW)
+        assert result == {"files_modified": 0, "session_ids": []}
+
+    def test_missing_folder_returns_zero(self, tmp_path):
+        result = rewrite_cwd_in_transcripts(tmp_path / "nope", self.OLD, self.NEW)
+        assert result == {"files_modified": 0, "session_ids": []}
+
+    def test_indexer_reads_rewritten_cwd(self, tmp_path):
+        """Regression: the cwd build_projects_index reads must reflect the new path."""
+        from indexing import _extract_from_jsonl
+
+        folder = tmp_path / "folder"
+        self._write_transcript(folder, "sess1", self.OLD)
+        assert _extract_from_jsonl(folder)[0] == self.OLD
+        rewrite_cwd_in_transcripts(folder, self.OLD, self.NEW)
+        assert _extract_from_jsonl(folder)[0] == self.NEW
+
+
+class TestRefreshSynthesisOffsets:
+    """Tests for refresh_synthesis_offsets — keeps synthesis state consistent."""
+
+    def test_updates_offset_to_file_size_preserving_lines(self, tmp_path):
+        folder = tmp_path / "folder"
+        folder.mkdir()
+        f = folder / "sess1.jsonl"
+        f.write_text("x" * 100)
+        state = {"sessions": {"sess1": {"offset": 40, "lines": 5, "last_synthesized": "old"}}}
+        with mock.patch("project_manager.load_synthesis_state", return_value=state), \
+             mock.patch("project_manager.save_synthesis_state") as save:
+            n = refresh_synthesis_offsets(["sess1"], folder)
+        assert n == 1
+        assert state["sessions"]["sess1"]["offset"] == 100
+        assert state["sessions"]["sess1"]["lines"] == 5  # line count unchanged
+        save.assert_called_once()
+
+    def test_skips_session_not_in_state(self, tmp_path):
+        folder = tmp_path / "folder"
+        folder.mkdir()
+        (folder / "sess1.jsonl").write_text("data")
+        with mock.patch("project_manager.load_synthesis_state", return_value={"sessions": {}}), \
+             mock.patch("project_manager.save_synthesis_state") as save:
+            n = refresh_synthesis_offsets(["sess1"], folder)
+        assert n == 0
+        save.assert_not_called()
+
+    def test_skips_missing_transcript_file(self, tmp_path):
+        folder = tmp_path / "folder"
+        folder.mkdir()
+        state = {"sessions": {"sess1": {"offset": 1, "lines": 1}}}
+        with mock.patch("project_manager.load_synthesis_state", return_value=state), \
+             mock.patch("project_manager.save_synthesis_state") as save:
+            n = refresh_synthesis_offsets(["sess1"], folder)
+        assert n == 0
+        save.assert_not_called()
+
+
+class TestRebuildAndVerifyIndex:
+    """Tests for rebuild_and_verify_index — post-move durability check."""
+
+    def test_durable_when_entry_resolves(self, tmp_path):
+        import indexing
+
+        proj = tmp_path / "new-project"
+        proj.mkdir()
+        fake = {"projects": {str(proj).lower(): {"name": "new-project", "originalPath": str(proj)}}}
+        with mock.patch.object(indexing, "build_projects_index", return_value=fake):
+            result = rebuild_and_verify_index(str(proj))
+        assert result["durable"] is True
+        assert result["entry"]["name"] == "new-project"
+        assert result["stale_paths"] == []
+
+    def test_not_durable_when_entry_missing(self, tmp_path):
+        import indexing
+
+        proj = tmp_path / "new-project"
+        proj.mkdir()
+        with mock.patch.object(indexing, "build_projects_index", return_value={"projects": {}}):
+            result = rebuild_and_verify_index(str(proj))
+        assert result["durable"] is False
+        assert "NOT durable" in result["message"]
+
+    def test_not_durable_when_path_absent_on_disk(self, tmp_path):
+        import indexing
+
+        proj = tmp_path / "gone"  # never created
+        fake = {"projects": {str(proj).lower(): {"name": "gone", "originalPath": str(proj)}}}
+        with mock.patch.object(indexing, "build_projects_index", return_value=fake):
+            result = rebuild_and_verify_index(str(proj))
+        assert result["durable"] is False
+        assert str(proj) in result["stale_paths"]
 
 
 # =============================================================================

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -557,6 +557,24 @@ class TestRebuildAndVerifyIndex:
         assert result["durable"] is False
         assert str(proj) in result["stale_paths"]
 
+    def test_lookup_key_resolved_like_build_projects_index(self, tmp_path):
+        """The lookup must apply resolve_session_path (worktree/subdir collapse),
+        matching how build_projects_index keys entries — else a worktree/subdir
+        project falsely reports NOT durable."""
+        import indexing
+
+        proj = tmp_path / "worktree-checkout"
+        proj.mkdir()
+        resolved = tmp_path / "main-repo"
+        resolved.mkdir()
+        # build_projects_index would key under the *resolved* path
+        fake = {"projects": {str(resolved).lower(): {"name": "main-repo", "originalPath": str(resolved)}}}
+        with mock.patch("project_manager.resolve_session_path", side_effect=lambda p: str(resolved)), \
+             mock.patch.object(indexing, "build_projects_index", return_value=fake):
+            result = rebuild_and_verify_index(str(proj))
+        assert result["durable"] is True
+        assert result["entry"]["name"] == "main-repo"
+
 
 class TestGetFolderOriginalPath:
     """Tests for get_folder_original_path — cwd fallback when no sessions-index."""
@@ -698,6 +716,34 @@ class TestExecuteMergeOrphanEndToEnd:
         merged = projects_dir / target_enc / "osess.jsonl"
         assert merged.exists()
         assert json.loads(merged.read_text().splitlines()[0])["cwd"] == str(target)
+
+
+class TestPlanMergeOrphanCwdFallback:
+    """plan_merge_orphan must resolve the orphan via cwd fallback too, so its
+    backup set covers the memory file execute_merge_orphan will merge."""
+
+    def test_plan_backs_up_orphan_memory_without_sessions_index(self, tmp_path):
+        from memory_utils import project_name_to_filename
+
+        claude, projects_dir, _index_file, patches = _fake_claude_env(tmp_path)
+        proj_mem = claude / "memory" / "project-memory"
+
+        orphan_path = tmp_path / "work" / "orphan-proj"   # gone from disk
+        target = tmp_path / "work" / "target-proj"
+        target.mkdir(parents=True)
+        orphan_enc = encode_path(str(orphan_path))
+        # Orphan folder has only a transcript (no sessions-index.json)
+        _write_cwd_transcript(projects_dir / orphan_enc, "osess", str(orphan_path))
+        # Orphan's project-memory file exists and must be backed up
+        orphan_mem = proj_mem / project_name_to_filename("orphan-proj")
+        orphan_mem.write_text("# orphan memory\n")
+
+        with patches:
+            plan = plan_merge_orphan(orphan_enc, target)
+
+        assert any(str(orphan_mem) == b for b in plan.backups), (
+            f"orphan memory file not in backup set: {plan.backups}"
+        )
 
 
 # =============================================================================

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -718,6 +718,45 @@ class TestExecuteMergeOrphanEndToEnd:
         assert json.loads(merged.read_text().splitlines()[0])["cwd"] == str(target)
 
 
+class TestMoveDurabilityEndToEnd:
+    """The headline contract: a move survives a REAL build_projects_index rebuild."""
+
+    def test_execute_move_then_real_rebuild_reports_durable(self, tmp_path):
+        import indexing
+
+        _claude, projects_dir, index_file, patches = _fake_claude_env(tmp_path)
+        memory_dir = _claude / "memory"
+
+        old = tmp_path / "work" / "old-project"
+        new = tmp_path / "work" / "new-project"
+        old.mkdir(parents=True)
+        old_enc = encode_path(str(old))
+        _write_cwd_transcript(projects_dir / old_enc, "sess1", str(old))
+        index_file.write_text(json.dumps({"projects": {str(old).lower(): {
+            "name": "old-project", "originalPath": str(old),
+            "encodedPaths": [old_enc], "workDays": ["2026-06-23"],
+        }}}))
+
+        # Patch indexing's OWN path-helper bindings too, so the real
+        # build_projects_index (invoked by rebuild_and_verify_index) scans the
+        # fake projects dir instead of the real ~/.claude.
+        with patches, \
+             mock.patch.object(indexing, "get_projects_dir", return_value=projects_dir), \
+             mock.patch.object(indexing, "get_memory_dir", return_value=memory_dir), \
+             mock.patch.object(indexing, "get_projects_index_file", return_value=index_file):
+            move = execute_move(old, new, confirmed=True)
+            assert move["success"] is True
+            # No mock of build_projects_index — this runs the real hourly rebuild.
+            verify = rebuild_and_verify_index(str(new))
+
+        assert verify["durable"] is True, verify["message"]
+        assert verify["entry"]["originalPath"] == str(new)
+        # The rebuilt-from-transcripts index agrees: old path is gone.
+        rebuilt = json.loads(index_file.read_text())["projects"]
+        assert str(new).lower() in rebuilt
+        assert str(old).lower() not in rebuilt
+
+
 class TestPlanMergeOrphanCwdFallback:
     """plan_merge_orphan must resolve the orphan via cwd fallback too, so its
     backup set covers the memory file execute_merge_orphan will merge."""

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -14,7 +14,10 @@ from project_manager import (  # noqa: I001
     backup_files,
     decode_path_best_effort,
     encode_path,
+    execute_merge_orphan,
+    execute_move,
     find_orphaned_folders,
+    get_folder_original_path,
     get_original_path_from_folder,
     list_projects,
     merge_sessions_index,
@@ -444,6 +447,14 @@ class TestRewriteCwdInTranscripts:
         rewrite_cwd_in_transcripts(tmp_path / "folder", self.OLD, self.NEW)
         assert json.loads(f.read_text().splitlines()[0])["cwd"] == self.NEW + "/sub"
 
+    def test_leaves_sibling_prefix_untouched(self, tmp_path):
+        """A sibling project sharing a path prefix must NOT be rewritten."""
+        sibling = self.OLD + "-other"  # /home/user/old-project-other
+        f = self._write_transcript(tmp_path / "folder", "sess1", sibling)
+        result = rewrite_cwd_in_transcripts(tmp_path / "folder", self.OLD, self.NEW)
+        assert result["files_modified"] == 0
+        assert json.loads(f.read_text().splitlines()[0])["cwd"] == sibling
+
     def test_leaves_non_cwd_occurrences_untouched(self, tmp_path):
         """The old path inside message content must NOT be rewritten."""
         extra = {"type": "assistant", "content": f"see {self.OLD}/file.py"}
@@ -545,6 +556,148 @@ class TestRebuildAndVerifyIndex:
             result = rebuild_and_verify_index(str(proj))
         assert result["durable"] is False
         assert str(proj) in result["stale_paths"]
+
+
+class TestGetFolderOriginalPath:
+    """Tests for get_folder_original_path — cwd fallback when no sessions-index."""
+
+    def _write_transcript(self, folder, session_id, cwd):
+        folder.mkdir(parents=True, exist_ok=True)
+        f = folder / f"{session_id}.jsonl"
+        f.write_text(json.dumps({"cwd": cwd, "timestamp": "2026-06-23T10:00:00.000Z"}) + "\n")
+        return f
+
+    def test_prefers_sessions_index(self, tmp_path):
+        folder = tmp_path / "folder"
+        folder.mkdir()
+        (folder / "sessions-index.json").write_text(json.dumps({
+            "originalPath": "/from/index", "entries": [],
+        }))
+        self._write_transcript(folder, "sess1", "/from/cwd")
+        assert get_folder_original_path(folder) == "/from/index"
+
+    def test_falls_back_to_cwd_when_no_index(self, tmp_path):
+        folder = tmp_path / "folder"
+        self._write_transcript(folder, "sess1", "/from/cwd")
+        assert get_folder_original_path(folder) == "/from/cwd"
+
+    def test_newest_transcript_cwd_wins(self, tmp_path):
+        import os
+
+        folder = tmp_path / "folder"
+        older = self._write_transcript(folder, "old", "/path/older")
+        newer = self._write_transcript(folder, "new", "/path/newer")
+        os.utime(older, (1000, 1000))
+        os.utime(newer, (2000, 2000))
+        assert get_folder_original_path(folder) == "/path/newer"
+
+    def test_returns_none_for_empty_folder(self, tmp_path):
+        folder = tmp_path / "folder"
+        folder.mkdir()
+        assert get_folder_original_path(folder) is None
+
+    def test_returns_none_for_missing_folder(self, tmp_path):
+        assert get_folder_original_path(tmp_path / "nope") is None
+
+
+# =============================================================================
+# Execute Move / Merge-Orphan End-to-End Tests (cwd-rewrite wiring)
+# =============================================================================
+
+
+def _fake_claude_env(tmp_path):
+    """Build an isolated ~/.claude layout and the project_manager patch map."""
+    claude = tmp_path / ".claude"
+    projects_dir = claude / "projects"
+    memory_dir = claude / "memory"
+    proj_mem = memory_dir / "project-memory"
+    for d in (projects_dir, memory_dir, proj_mem):
+        d.mkdir(parents=True)
+    (claude / "history.jsonl").write_text("")
+    index_file = memory_dir / "projects-index.json"
+    patches = mock.patch.multiple(
+        "project_manager",
+        get_projects_dir=mock.MagicMock(return_value=projects_dir),
+        get_memory_dir=mock.MagicMock(return_value=memory_dir),
+        get_claude_dir=mock.MagicMock(return_value=claude),
+        get_project_memory_dir=mock.MagicMock(return_value=proj_mem),
+        get_projects_index_file=mock.MagicMock(return_value=index_file),
+        load_synthesis_state=mock.MagicMock(return_value={"sessions": {}}),
+    )
+    return claude, projects_dir, index_file, patches
+
+
+def _write_cwd_transcript(folder, session_id, cwd):
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / f"{session_id}.jsonl").write_text(
+        json.dumps({"type": "user", "cwd": cwd, "timestamp": "2026-06-23T10:00:00.000Z"}) + "\n"
+    )
+
+
+class TestExecuteMoveEndToEnd:
+    """End-to-end: execute_move must rewrite the destination transcript cwd."""
+
+    def test_rewrites_dest_cwd_and_updates_index(self, tmp_path):
+        _claude, projects_dir, index_file, patches = _fake_claude_env(tmp_path)
+
+        old = tmp_path / "work" / "old-project"
+        new = tmp_path / "work" / "new-project"
+        old.mkdir(parents=True)
+        old_enc = encode_path(str(old))
+        _write_cwd_transcript(projects_dir / old_enc, "sess1", str(old))
+        index_file.write_text(json.dumps({"projects": {str(old).lower(): {
+            "name": "old-project", "originalPath": str(old),
+            "encodedPaths": [old_enc], "workDays": ["2026-06-23"],
+        }}}))
+
+        with patches:
+            result = execute_move(old, new, confirmed=True)
+
+        assert result["success"] is True
+        assert result["cwd_files_rewritten"] == 1
+
+        new_enc = encode_path(str(new))
+        dest = projects_dir / new_enc / "sess1.jsonl"
+        assert dest.exists()
+        assert json.loads(dest.read_text().splitlines()[0])["cwd"] == str(new)
+
+        idx = json.loads(index_file.read_text())["projects"]
+        assert str(new).lower() in idx
+        assert str(old).lower() not in idx
+
+
+class TestExecuteMergeOrphanEndToEnd:
+    """End-to-end: merge-orphan must rewrite cwd even with no sessions-index.json."""
+
+    def test_rewrites_cwd_via_jsonl_fallback(self, tmp_path):
+        _claude, projects_dir, index_file, patches = _fake_claude_env(tmp_path)
+
+        orphan_path = tmp_path / "work" / "orphan-proj"   # gone from disk
+        target = tmp_path / "work" / "target-proj"
+        target.mkdir(parents=True)
+
+        orphan_enc = encode_path(str(orphan_path))
+        target_enc = encode_path(str(target))
+        # Orphan folder: only a transcript (no sessions-index.json) -> cwd fallback
+        _write_cwd_transcript(projects_dir / orphan_enc, "osess", str(orphan_path))
+        # Target folder already exists with its own transcript on the new path
+        _write_cwd_transcript(projects_dir / target_enc, "tsess", str(target))
+        index_file.write_text(json.dumps({"projects": {str(orphan_path).lower(): {
+            "name": "orphan-proj", "originalPath": str(orphan_path),
+            "encodedPaths": [orphan_enc], "workDays": ["2026-06-23"],
+        }}}))
+
+        with patches:
+            result = execute_merge_orphan(orphan_enc, target, confirmed=True)
+
+        assert result["success"] is True
+        # cwd rewrite fired despite no sessions-index.json (the bug we fixed)
+        assert result["cwd_files_rewritten"] == 1
+        assert result["orphan_project_name"] == "orphan-proj"
+
+        merged = projects_dir / target_enc / "osess.jsonl"
+        assert merged.exists()
+        assert json.loads(merged.read_text().splitlines()[0])["cwd"] == str(target)
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

`/projects` moves/renames silently reverted. `execute_move`/`execute_merge_orphan` rewrote `history.jsonl` and `sessions-index.json` but **never the `cwd` field inside session `.jsonl` transcripts** — and `indexing.build_projects_index` (run hourly by synthesis) rebuilds the whole index from that `cwd`. Since current Claude Code no longer writes `sessions-index.json` (see #146), the transcript `cwd` is the only authoritative path signal, so every rename reverted on the next synthesis pass. Observed live on an `outlook-plugin → investigation-plugin` rename: `execute_move` succeeded, synthesis reverted it ~18 min later.

## Fix

- **`rewrite_cwd_in_transcripts`** — boundary-anchored (`(?=/|")`) rewrite of the `cwd` field in a folder's transcripts; wired into both execute paths. Sibling-prefix paths (`/p/old` vs `/p/old-other`) are left untouched.
- **`refresh_synthesis_offsets`** — resets synthesis byte-offsets after the rewrite (it grows file bytes without changing line count), so synthesis doesn't re-process.
- **`get_folder_original_path`** — resolves a folder's path from `sessions-index.json` when present, else the newest transcript's `cwd` (delegating to `indexing._extract_from_jsonl` for identical ordering/scan-limit). Used by `find_orphaned_folders`, `plan_merge_orphan`, and `execute_merge_orphan` for parity, so the merge-orphan rewrite actually fires without `sessions-index.json` and the plan backs up the file execute merges.
- **`rebuild_and_verify_index`** — rebuilds from transcripts and confirms the move is durable; keyed via `resolve_session_path` to match `build_projects_index` (handles worktree/subdir projects). The `/projects` skill now calls it after every execute and asserts `durable`.
- **Skill/reference docs** — document `cwd` as source of truth (sessions-index.json is gone), require `uv run --no-project` (3.10+), warn against running a move from the project's own live session, add the hybrid-state branch + durability check.

## Testing

20 new tests including an end-to-end test that runs the **real** `build_projects_index` rebuild after `execute_move` and asserts the entry is durable under the new path (would fail on pre-fix code). Full suite **852 passing**.

## Review

Hardened through three `/implementation-review` rounds (10 findings total, all fixed): regex boundary, execute-path E2E coverage, merge-orphan resolver inertness without sessions-index, verify-key resolution parity, plan/execute backup divergence, scan-depth coupling, and the real-rebuild test gap.

Related: #146 (broader inversion away from `sessions-index.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved project path resolution with automatic fallback mechanisms for folder detection.
  * Added durability verification for project moves and merges to prevent unintended reversions.

* **Bug Fixes**
  * Project moves and merges now automatically maintain internal path integrity across transcript files.

* **Documentation**
  * Expanded operational guidance with clearer durability verification procedures for project management workflows.

* **Tests**
  * Added comprehensive test coverage for project operations and durability guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->