### PR TITLE
fix(projects): invert sessions-index.json primary/fallback to JSONL cwd (#146)

### DIFF
--- a/scripts/indexing.py
+++ b/scripts/indexing.py
@@ -104,10 +104,10 @@ class SessionInfo:
     file_mtime: datetime  # File modification time
     file_size: int  # Bytes
 
-    # From index (optional, may be None):
+    # Recovered from the transcript (or sessions-index.json when present):
     project_path: Optional[str] = None  # Original path like /home/nsitaram/project
-    created: Optional[datetime] = None  # Session creation time from index
-    summary: Optional[str] = None  # AI-generated summary
+    created: Optional[datetime] = None  # Real session start (first record timestamp)
+    summary: Optional[str] = None  # ai-title / first prompt (or index summary)
 
 
 def _parse_index_datetime(date_str: str) -> Optional[datetime]:
@@ -119,6 +119,101 @@ def _parse_index_datetime(date_str: str) -> Optional[datetime]:
         return from_iso_z(date_str)
     except ValueError:
         return None
+
+
+# Max lines to head-scan a transcript when recovering created/summary metadata.
+# Higher than _JSONL_SCAN_LIMIT because the ``ai-title`` record (best summary
+# source) can land after the cwd/timestamp-bearing records.
+_METADATA_SCAN_LIMIT = 50
+
+# Substantive-prompt detection: skip harness wrapper text that isn't a real prompt.
+_PROMPT_SKIP_PREFIXES = (
+    "<local-command",
+    "<command-name",
+    "<command-message",
+    "<system-reminder",
+)
+
+
+def _content_to_text(content: object) -> str:
+    """Flatten a message ``content`` (str or list of blocks) to plain text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+            elif isinstance(block, str):
+                parts.append(block)
+        return " ".join(p for p in parts if p)
+    return ""
+
+
+def _extract_session_metadata(
+    jsonl_file: Path,
+) -> tuple[Optional[datetime], Optional[str]]:
+    """
+    Recover a session's real created-date and a human-readable summary from its
+    transcript, head-scanning up to _METADATA_SCAN_LIMIT lines.
+
+    Current Claude Code no longer writes sessions-index.json, so this is how we
+    repopulate the metadata that used to come from the index:
+      - created: the earliest record ``timestamp`` (the real session start —
+        robust to file mtime changing on copy/migration).
+      - summary: the ``ai-title`` record's ``aiTitle`` when present, else the
+        first substantive ``user`` message (skipping ``isMeta`` records and
+        harness wrappers like ``<local-command…>`` / ``<command-name>`` /
+        ``<system-reminder>``), truncated to 150 chars.
+
+    Returns (created, summary); either element is None when unavailable.
+    """
+    created: Optional[datetime] = None
+    ai_title: Optional[str] = None
+    first_prompt: Optional[str] = None
+
+    try:
+        with open(jsonl_file, "r", encoding="utf-8") as f:
+            for _ in range(_METADATA_SCAN_LIMIT):
+                line = f.readline()
+                if not line:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                except (json.JSONDecodeError, AttributeError, TypeError):
+                    continue
+                if not isinstance(data, dict):
+                    continue
+
+                if created is None:
+                    ts = data.get("timestamp", "")
+                    if ts:
+                        try:
+                            created = from_iso_z(ts)
+                        except ValueError:
+                            pass
+
+                rec_type = data.get("type")
+                if rec_type == "ai-title" and ai_title is None:
+                    title = (data.get("aiTitle") or "").strip()
+                    if title:
+                        ai_title = title
+                elif rec_type == "user" and first_prompt is None and not data.get("isMeta"):
+                    text = _content_to_text(data.get("message", {}).get("content")).strip()
+                    if text and not text.startswith(_PROMPT_SKIP_PREFIXES):
+                        first_prompt = text[:150]
+
+                # ai-title is the preferred summary; stop early once we have it
+                # alongside the created date.
+                if created is not None and ai_title is not None:
+                    break
+    except IOError:
+        pass
+
+    return created, ai_title or first_prompt
 
 
 def _load_sessions_index(project_folder: Path) -> dict:
@@ -149,8 +244,12 @@ def list_all_sessions() -> list[SessionInfo]:
     """
     List all sessions from Claude Code's projects directory.
 
-    Primary: Scans all .jsonl files in ~/.claude/projects/
-    Secondary: Enriches with sessions-index.json metadata when available
+    Primary: Scans all .jsonl files in ~/.claude/projects/ and recovers each
+    session's created-date + summary from the transcript itself
+    (_extract_session_metadata). Current Claude Code no longer writes
+    sessions-index.json, so the transcript is the source of truth.
+    Secondary: When a sessions-index.json is present (legacy), its created /
+    summary / projectPath override the transcript-derived values for that session.
 
     Returns list of SessionInfo sorted by file modification time (newest first).
     """
@@ -185,11 +284,21 @@ def list_all_sessions() -> list[SessionInfo]:
             except OSError:
                 continue
 
-            # Enrich with index metadata if available
-            entry = index.get(session_id, {})
-            created = _parse_index_datetime(entry.get("created", ""))
-            project_path = entry.get("projectPath")
-            summary = entry.get("summary")
+            # Recover created-date + summary from the transcript (source of
+            # truth now that sessions-index.json is rarely written).
+            created, summary = _extract_session_metadata(jsonl_file)
+            project_path = None
+
+            # Override with sessions-index.json metadata when present (legacy).
+            entry = index.get(session_id)
+            if entry:
+                index_created = _parse_index_datetime(entry.get("created", ""))
+                if index_created is not None:
+                    created = index_created
+                if entry.get("projectPath"):
+                    project_path = entry.get("projectPath")
+                if entry.get("summary"):
+                    summary = entry.get("summary")
 
             sessions.append(
                 SessionInfo(
@@ -237,8 +346,9 @@ def list_recent_sessions(
     """
     List recent sessions eligible for synthesis.
 
-    Uses index.created (real session date) when available, falls back to
-    file mtime. This handles migrated sessions whose mtime changed on copy.
+    Uses the transcript-derived created date (real session start) when
+    available, falls back to file mtime. This handles migrated sessions whose
+    mtime changed on copy.
 
     Args:
         max_age_days: Only include sessions created/modified within this many days
@@ -269,7 +379,7 @@ def get_session_date(session: SessionInfo) -> str:
     """
     Get date string (YYYY-MM-DD) for a session.
 
-    Prefers index.created if available, falls back to file_mtime.
+    Prefers the transcript-derived created date, falls back to file_mtime.
     """
     if session.created:
         return utc_to_local_datestr(session.created)
@@ -418,10 +528,12 @@ def build_projects_index(fix_paths: bool = False) -> dict:
     """
     Build a project-to-work-days index from Claude Code's project data.
 
-    Scans sessions-index.json files and JSONL transcripts in ~/.claude/projects/
-    to build a mapping of projects to the dates they have work sessions.
-    JSONL files supplement sessions-index.json with missing work days and
-    serve as fallback when sessions-index.json doesn't exist.
+    The JSONL transcript ``cwd`` is the authoritative source for each project's
+    path and work days (see _extract_from_jsonl): current Claude Code no longer
+    reliably writes sessions-index.json, so the transcript is the source of
+    truth. When a sessions-index.json *is* present (legacy), its session entries
+    are read only as enrichment — adding any extra work days — but the path
+    still comes from the transcript cwd.
 
     Returns the index dict and also saves it to projects-index.json.
     """
@@ -451,17 +563,22 @@ def build_projects_index(fix_paths: bool = False) -> dict:
         if not project_folder.is_dir():
             continue
 
-        # Try sessions-index.json first
+        # Primary: derive the path + work days from the transcript cwd.
         original_path = ""
         work_days: set[str] = set()
 
+        jsonl_path, jsonl_days = _extract_from_jsonl(project_folder)
+        if jsonl_path:
+            resolved_jsonl = resolve_session_path(jsonl_path)
+            jsonl_paths[project_folder.name] = resolved_jsonl
+            original_path = resolved_jsonl
+        work_days.update(jsonl_days)
+
+        # Enrichment: read sessions-index.json only when present (legacy). It
+        # contributes extra work days; the path stays cwd-derived. Falls back to
+        # its originalPath only if the transcripts yielded no cwd at all.
         data = load_sessions_index(project_folder)
         if data:
-            original_path = get_sessions_original_path(data)
-            if original_path:
-                original_path = resolve_session_path(original_path)
-
-            # Extract work days from session entries
             for entry in data.get("entries", []):
                 created = entry.get("created")
                 if created:
@@ -471,16 +588,10 @@ def build_projects_index(fix_paths: bool = False) -> dict:
                     except ValueError:
                         continue
 
-        # Supplement with JSONL transcripts (fallback for path, additional work days)
-        jsonl_path, jsonl_days = _extract_from_jsonl(project_folder)
-        if jsonl_path:
-            resolved_jsonl = resolve_session_path(jsonl_path)
-            jsonl_paths[project_folder.name] = resolved_jsonl
-        if not original_path:
-            original_path = jsonl_path
-            if original_path:
-                original_path = resolve_session_path(original_path)
-        work_days.update(jsonl_days)
+            if not original_path:
+                index_path = get_sessions_original_path(data)
+                if index_path:
+                    original_path = resolve_session_path(index_path)
 
         if not original_path or not work_days:
             continue

--- a/scripts/indexing.py
+++ b/scripts/indexing.py
@@ -191,15 +191,18 @@ def _extract_session_metadata(
                 if not isinstance(data, dict):
                     continue
 
-                if created is None:
-                    ts = data.get("timestamp", "")
-                    if ts:
-                        # A malformed (non-string) timestamp raises TypeError/
-                        # AttributeError inside from_iso_z; treat like a bad date.
-                        try:
-                            created = from_iso_z(ts)
-                        except (ValueError, TypeError, AttributeError):
-                            pass
+                ts = data.get("timestamp", "")
+                if ts:
+                    # A malformed (non-string) timestamp raises TypeError/
+                    # AttributeError inside from_iso_z; treat like a bad date.
+                    try:
+                        parsed = from_iso_z(ts)
+                    except (ValueError, TypeError, AttributeError):
+                        parsed = None
+                    # Keep the earliest timestamp seen — records are usually
+                    # chronological, but don't assume the first one is the min.
+                    if parsed is not None and (created is None or parsed < created):
+                        created = parsed
 
                 if cwd is None:
                     folder = data.get("cwd")
@@ -219,10 +222,8 @@ def _extract_session_metadata(
                     if text and not text.startswith(_PROMPT_SKIP_PREFIXES):
                         first_prompt = text[:150]
 
-                # ai-title is the preferred summary; stop early once we have it
-                # alongside the created date.
-                if created is not None and ai_title is not None:
-                    break
+            # Scan the full window (no early break): `created` must be the
+            # earliest timestamp, so we cannot stop as soon as ai-title appears.
     except IOError:
         pass
 
@@ -359,9 +360,11 @@ def list_recent_sessions(
     """
     List recent sessions eligible for synthesis.
 
-    Uses the transcript-derived created date (real session start) when
-    available, falls back to file mtime. This handles migrated sessions whose
-    mtime changed on copy.
+    A session counts as recent if EITHER its transcript-derived created date
+    OR its file mtime falls within the window. The created date keeps migrated
+    sessions whose mtime jumped on copy; the mtime keeps long-lived sessions
+    that started before the window but are still being appended to. (Day
+    bucketing in get_session_date still prefers created.)
 
     Args:
         max_age_days: Only include sessions created/modified within this many days

--- a/scripts/indexing.py
+++ b/scripts/indexing.py
@@ -152,10 +152,10 @@ def _content_to_text(content: object) -> str:
 
 def _extract_session_metadata(
     jsonl_file: Path,
-) -> tuple[Optional[datetime], Optional[str]]:
+) -> tuple[Optional[datetime], Optional[str], Optional[str]]:
     """
-    Recover a session's real created-date and a human-readable summary from its
-    transcript, head-scanning up to _METADATA_SCAN_LIMIT lines.
+    Recover a session's real created-date, summary, and cwd from its transcript,
+    head-scanning up to _METADATA_SCAN_LIMIT lines.
 
     Current Claude Code no longer writes sessions-index.json, so this is how we
     repopulate the metadata that used to come from the index:
@@ -165,12 +165,15 @@ def _extract_session_metadata(
         first substantive ``user`` message (skipping ``isMeta`` records and
         harness wrappers like ``<local-command…>`` / ``<command-name>`` /
         ``<system-reminder>``), truncated to 150 chars.
+      - cwd: the first record's ``cwd`` field (the project path — same signal
+        build_projects_index keys on).
 
-    Returns (created, summary); either element is None when unavailable.
+    Returns (created, summary, cwd); any element is None when unavailable.
     """
     created: Optional[datetime] = None
     ai_title: Optional[str] = None
     first_prompt: Optional[str] = None
+    cwd: Optional[str] = None
 
     try:
         with open(jsonl_file, "r", encoding="utf-8") as f:
@@ -191,10 +194,17 @@ def _extract_session_metadata(
                 if created is None:
                     ts = data.get("timestamp", "")
                     if ts:
+                        # A malformed (non-string) timestamp raises TypeError/
+                        # AttributeError inside from_iso_z; treat like a bad date.
                         try:
                             created = from_iso_z(ts)
-                        except ValueError:
+                        except (ValueError, TypeError, AttributeError):
                             pass
+
+                if cwd is None:
+                    folder = data.get("cwd")
+                    if isinstance(folder, str) and folder:
+                        cwd = folder
 
                 rec_type = data.get("type")
                 if rec_type == "ai-title" and ai_title is None:
@@ -202,7 +212,10 @@ def _extract_session_metadata(
                     if title:
                         ai_title = title
                 elif rec_type == "user" and first_prompt is None and not data.get("isMeta"):
-                    text = _content_to_text(data.get("message", {}).get("content")).strip()
+                    # `message` may be explicitly null (parses to None), so the
+                    # `{}` default on .get() isn't enough — coalesce before .get.
+                    message = data.get("message") or {}
+                    text = _content_to_text(message.get("content")).strip()
                     if text and not text.startswith(_PROMPT_SKIP_PREFIXES):
                         first_prompt = text[:150]
 
@@ -213,7 +226,7 @@ def _extract_session_metadata(
     except IOError:
         pass
 
-    return created, ai_title or first_prompt
+    return created, ai_title or first_prompt, cwd
 
 
 def _load_sessions_index(project_folder: Path) -> dict:
@@ -284,10 +297,10 @@ def list_all_sessions() -> list[SessionInfo]:
             except OSError:
                 continue
 
-            # Recover created-date + summary from the transcript (source of
-            # truth now that sessions-index.json is rarely written).
-            created, summary = _extract_session_metadata(jsonl_file)
-            project_path = None
+            # Recover created-date, summary, and path from the transcript
+            # (source of truth now that sessions-index.json is rarely written).
+            created, summary, cwd = _extract_session_metadata(jsonl_file)
+            project_path = resolve_session_path(cwd) if cwd else None
 
             # Override with sessions-index.json metadata when present (legacy).
             entry = index.get(session_id)

--- a/scripts/project_manager.py
+++ b/scripts/project_manager.py
@@ -82,13 +82,10 @@ __all__ = [
     "restore_from_backup",
     "list_backups",
     # Index operations
-    "rebuild_sessions_index",
-    "merge_sessions_index",
     "rewrite_paths_in_file",
     "rewrite_cwd_in_transcripts",
     "refresh_synthesis_offsets",
     "get_memory_files_for_merge",
-    "update_session_index_paths",
     "rebuild_and_verify_index",
 ]
 
@@ -119,7 +116,7 @@ class OrphanInfo:
     folder_path: str
     decoded_path: Optional[str]  # Best-effort decode (may be lossy)
     sessions_index_path: Optional[str]  # If sessions-index.json exists
-    original_path_from_index: Optional[str]  # Authoritative path from sessions-index
+    original_path: Optional[str]  # Resolved path (transcript cwd, or legacy index when present)
     subdirs: list[str]  # Which CLAUDE_SUBDIRS exist
     file_count: int
     total_size_bytes: int
@@ -159,7 +156,8 @@ def encode_path(path: str) -> str:
     Example: /home/user/my-project -> -home-user-my-project
 
     Note: This encoding is LOSSY - you cannot reliably decode back to the
-    original path. Always use sessions-index.json for authoritative paths.
+    original path. Use get_folder_original_path() (transcript cwd) for the
+    authoritative path.
     """
     # Match Claude Code's encoding exactly
     return path.replace("/", "-").replace(".", "-")
@@ -171,11 +169,11 @@ def decode_path_best_effort(encoded: str) -> str:
 
     .. deprecated::
         This function is LOSSY and should NOT be used for path reconstruction.
-        Use get_original_path_from_folder() to read sessions-index.json instead.
-        This function exists only for display/debugging when no index is available.
+        Use get_folder_original_path() (transcript cwd) instead. This function
+        exists only for display/debugging when no transcript cwd is available.
 
     WARNING: This is LOSSY and should only be used for display purposes.
-    For authoritative paths, always read from sessions-index.json.
+    For authoritative paths, use get_folder_original_path() (transcript cwd).
 
     The encoding replaces both / and . with -, so we cannot distinguish:
     - /home/user/.config -> -home-user--config
@@ -200,13 +198,15 @@ def decode_path_best_effort(encoded: str) -> str:
 
 def get_original_path_from_folder(folder_path: Path) -> Optional[str]:
     """
-    Get the authoritative original path from a Claude Code project folder.
+    Read the original path from a folder's sessions-index.json, if one exists.
 
     Checks sessions-index.json for:
     1. Root-level 'originalPath' (legacy/manual format)
     2. entries[0].projectPath (Claude Code's actual format)
 
-    This is the only reliable way to get the original path since encoding is lossy.
+    Current Claude Code rarely writes this file, so this is the legacy
+    read-when-present path; prefer get_folder_original_path(), which falls back
+    to the transcript cwd. Returns None when no index is present.
     """
     data = load_sessions_index(folder_path)
     return get_sessions_original_path(data) or None
@@ -297,8 +297,9 @@ def find_orphaned_folders() -> list[OrphanInfo]:
     Find Claude Code folders that don't match any valid project in the index.
 
     An "orphan" is a folder in ~/.claude/projects/ where:
-    1. The originalPath in sessions-index.json doesn't exist on disk, OR
-    2. The folder is not tracked in our projects-index.json
+    1. The folder is not tracked in our projects-index.json, AND
+    2. Its resolved path (transcript cwd, or legacy sessions-index.json when
+       present) is missing or doesn't exist on disk.
 
     Returns information about each orphan for the skill to present to the user.
     """
@@ -335,11 +336,12 @@ def find_orphaned_folders() -> list[OrphanInfo]:
 
         is_orphan = False
         if original_path:
-            # Has sessions-index.json - check if path exists on disk
+            # Resolved a path (transcript cwd or legacy index) — orphan only if
+            # that path no longer exists on disk.
             if not Path(original_path).exists():
                 is_orphan = True
         else:
-            # No sessions-index.json and not tracked - orphan
+            # No resolvable path and not tracked - orphan
             is_orphan = True
 
         if not is_orphan:
@@ -370,7 +372,7 @@ def find_orphaned_folders() -> list[OrphanInfo]:
             folder_path=str(folder),
             decoded_path=decode_path_best_effort(folder_name) if not original_path else None,
             sessions_index_path=str(sessions_index_path) if sessions_index_path.exists() else None,
-            original_path_from_index=original_path,
+            original_path=original_path,
             subdirs=subdirs,
             file_count=file_count,
             total_size_bytes=total_size,
@@ -838,131 +840,6 @@ def restore_from_backup(backup_dir: Path) -> dict:
     }
 
 
-def rebuild_sessions_index(folder: Path, project_path: str) -> dict:
-    """
-    Rebuild sessions-index.json from .jsonl files in a folder.
-
-    Scans all .jsonl files and creates entries with basic metadata.
-    Returns the rebuilt index data.
-    """
-    entries = []
-
-    for jsonl_file in sorted(folder.glob("*.jsonl")):
-        session_id = jsonl_file.stem
-        try:
-            stat = jsonl_file.stat()
-        except OSError:
-            continue
-
-        mtime_ms = int(stat.st_mtime * 1000)
-        created_dt = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
-
-        # Try to extract first prompt for context
-        first_prompt = "(recovered session)"
-        try:
-            with open(jsonl_file, "r", encoding="utf-8") as f:
-                for line in f:
-                    try:
-                        msg = json.loads(line)
-                        if msg.get("type") == "human":
-                            content = msg.get("message", {}).get("content", "")
-                            first_prompt = content[:150] if content else "(no prompt)"
-                            break
-                    except json.JSONDecodeError:
-                        continue
-        except IOError:
-            pass
-
-        entries.append({
-            "sessionId": session_id,
-            "fullPath": str(jsonl_file),
-            "fileMtime": mtime_ms,
-            "firstPrompt": first_prompt,
-            "summary": "(recovered session)",
-            "messageCount": 0,
-            "created": to_iso_z(created_dt),
-            "modified": to_iso_z(created_dt),
-            "gitBranch": "",
-            "projectPath": project_path,
-            "isSidechain": False,
-        })
-
-    # Sort by created date
-    entries.sort(key=lambda e: e["created"])
-
-    return {
-        "version": 1,
-        "entries": entries,
-        "originalPath": project_path,
-    }
-
-
-def merge_sessions_index(source: Path, dest: Path, project_path: Optional[str] = None) -> int:
-    """
-    Merge sessions-index.json files.
-
-    Combines entries, dedupes by session ID, keeps newest for conflicts.
-    If source has no entries, scans source folder for .jsonl files.
-    Returns number of entries merged from source.
-    """
-    source_data = load_json_file(source, {})
-    dest_data = load_json_file(dest, {})
-
-    # If source has no entries, try to rebuild from .jsonl files
-    source_entries = source_data.get("entries", [])
-    if not source_entries and source.parent.is_dir():
-        rebuilt = rebuild_sessions_index(
-            source.parent,
-            project_path or dest_data.get("originalPath", "")
-        )
-        source_entries = rebuilt.get("entries", [])
-
-    if not source_entries:
-        return 0
-
-    # Build lookup of existing entries by session ID
-    # Note: Claude Code uses "sessionId", not "id"
-    dest_entries = {
-        e.get("sessionId", e.get("id")): e
-        for e in dest_data.get("entries", [])
-        if e.get("sessionId") or e.get("id")
-    }
-
-    merged_count = 0
-
-    for entry in source_entries:
-        session_id = entry.get("sessionId", entry.get("id"))
-        if not session_id:
-            continue
-
-        if session_id in dest_entries:
-            # Keep newer entry
-            existing = dest_entries[session_id]
-            existing_time = existing.get("modified", existing.get("lastActive", existing.get("created", "")))
-            new_time = entry.get("modified", entry.get("lastActive", entry.get("created", "")))
-            if new_time > existing_time:
-                dest_entries[session_id] = entry
-                merged_count += 1
-        else:
-            dest_entries[session_id] = entry
-            merged_count += 1
-
-    # Rebuild entries list sorted by modified/created (newest first)
-    dest_data["entries"] = sorted(
-        dest_entries.values(),
-        key=lambda e: e.get("modified", e.get("lastActive", e.get("created", ""))),
-        reverse=True,
-    )
-
-    # Ensure version is set
-    dest_data["version"] = 1
-
-    # Keep the dest's originalPath as it's the valid one
-
-    save_json_file(dest, dest_data)
-    return merged_count
-
-
 def rewrite_paths_in_file(filepath: Path, old_path: str, new_path: str) -> int:
     """
     Replace old_path with new_path in a file (streaming for large files).
@@ -1050,43 +927,6 @@ def get_memory_files_for_merge(source_name: str, dest_name: str) -> dict:
         "source_exists": source_file.exists(),
         "dest_exists": dest_file.exists(),
     }
-
-
-def update_session_index_paths(old_path: str, new_path: str) -> int:
-    """
-    Update originalPath in sessions-index.json files across all affected project folders.
-
-    When a project directory is renamed (e.g., ~/claude-code -> ~/swyfft),
-    the sessions-index.json files inside ~/.claude/projects/ still reference
-    the old path. This function updates them so find_orphaned_folders() doesn't
-    flag them as orphans.
-
-    Also updates sub-project folders (e.g., ~/claude-code/projects/foo).
-
-    Returns the number of files updated.
-    """
-    projects_dir = get_projects_dir()
-    if not projects_dir.exists():
-        return 0
-
-    updated = 0
-    for folder in projects_dir.iterdir():
-        if not folder.is_dir():
-            continue
-        sessions_file = folder / "sessions-index.json"
-        if not sessions_file.exists():
-            continue
-        try:
-            content = sessions_file.read_text(encoding="utf-8")
-            if old_path in content:
-                sessions_file.write_text(
-                    content.replace(old_path, new_path), encoding="utf-8"
-                )
-                updated += 1
-        except (IOError, UnicodeDecodeError):
-            continue
-
-    return updated
 
 
 def rewrite_cwd_in_transcripts(folder: Path, old_path: str, new_path: str) -> dict:
@@ -1298,21 +1138,15 @@ def execute_move(
             # Create backup
             backup_path = backup_files([Path(f) for f in plan.backups])
 
-            # Execute merges
+            # Execute merges. Transcripts are the source of truth; any legacy
+            # sessions-index.json is copied as an ordinary file (we never write
+            # or merge it — current Claude Code ignores it).
             for source, dest in plan.merges:
                 source_path = Path(source)
                 dest_path = Path(dest)
 
-                # Merge sessions-index.json if both exist
-                source_sessions = source_path / "sessions-index.json"
-                dest_sessions = dest_path / "sessions-index.json"
-                if source_sessions.exists() and dest_sessions.exists():
-                    merge_sessions_index(source_sessions, dest_sessions)
-
-                # Copy all other files from source to dest
+                # Copy all files from source to dest
                 for item in source_path.iterdir():
-                    if item.name == "sessions-index.json":
-                        continue  # Already merged
                     dest_item = dest_path / item.name
                     if item.is_file():
                         shutil.copy2(item, dest_item)
@@ -1365,9 +1199,6 @@ def execute_move(
             history_file = get_claude_dir() / "history.jsonl"
             if history_file.exists():
                 rewrite_paths_in_file(history_file, str(old_path), str(new_path))
-
-            # Update sessions-index.json files in all affected project folders
-            update_session_index_paths(str(old_path), str(new_path))
 
             # Move the actual project directory
             if old_path.exists() and not new_path.exists():
@@ -1449,53 +1280,20 @@ def execute_merge_orphan(
             orphan_original_path = get_folder_original_path(orphan_folder)
             orphan_project_name = Path(orphan_original_path).name if orphan_original_path else None
 
-            # Execute merges
+            # Execute merges. Copy transcripts (and any subdirs) into the target
+            # folder; a legacy sessions-index.json is copied as an ordinary file.
+            # We never rebuild or merge the index — the transcript cwd (rewritten
+            # below) is the only path signal the index rebuild reads.
             for source, dest in plan.merges:
                 source_path = Path(source)
                 dest_path = Path(dest)
 
-                # Copy .jsonl files and subdirs first
                 for item in source_path.iterdir():
-                    if item.name == "sessions-index.json":
-                        continue
                     dest_item = dest_path / item.name
                     if item.is_file() and not dest_item.exists():
                         shutil.copy2(item, dest_item)
                     elif item.is_dir() and not dest_item.exists():
                         shutil.copytree(item, dest_item)
-
-                # Now merge sessions-index.json (will scan .jsonl files if entries missing)
-                source_sessions = source_path / "sessions-index.json"
-                dest_sessions = dest_path / "sessions-index.json"
-                if source_sessions.exists():
-                    if dest_sessions.exists():
-                        merge_sessions_index(source_sessions, dest_sessions, str(target_path))
-                    else:
-                        # Copy sessions-index but update originalPath
-                        data = load_json_file(source_sessions, {})
-                        data["originalPath"] = str(target_path)
-                        save_json_file(dest_sessions, data)
-
-            # After all merges, rebuild the target's sessions-index to ensure all .jsonl files are indexed
-            target_folder = projects_dir / target_encoded
-            if target_folder.exists():
-                rebuilt = rebuild_sessions_index(target_folder, str(target_path))
-                target_sessions = target_folder / "sessions-index.json"
-                # Merge rebuilt entries with any existing entries
-                if target_sessions.exists():
-                    existing = load_json_file(target_sessions, {})
-                    existing_ids = {e.get("sessionId") for e in existing.get("entries", [])}
-                    for entry in rebuilt.get("entries", []):
-                        if entry.get("sessionId") not in existing_ids:
-                            existing.setdefault("entries", []).append(entry)
-                    existing["entries"].sort(
-                        key=lambda e: e.get("modified", e.get("created", "")),
-                        reverse=True
-                    )
-                    existing["originalPath"] = str(target_path)
-                    save_json_file(target_sessions, existing)
-                else:
-                    save_json_file(target_sessions, rebuilt)
 
             # Execute moves
             for source, dest in plan.moves:
@@ -1504,25 +1302,6 @@ def execute_merge_orphan(
                 if source_path.exists():
                     dest_path.parent.mkdir(parents=True, exist_ok=True)
                     shutil.move(str(source_path), str(dest_path))
-
-                    # Rebuild sessions-index.json with correct path and all .jsonl entries
-                    dest_sessions = dest_path / "sessions-index.json"
-                    rebuilt = rebuild_sessions_index(dest_path, str(target_path))
-                    if dest_sessions.exists():
-                        # Merge with existing entries
-                        existing = load_json_file(dest_sessions, {})
-                        existing_ids = {e.get("sessionId") for e in existing.get("entries", [])}
-                        for entry in rebuilt.get("entries", []):
-                            if entry.get("sessionId") not in existing_ids:
-                                existing.setdefault("entries", []).append(entry)
-                        existing["entries"].sort(
-                            key=lambda e: e.get("modified", e.get("created", "")),
-                            reverse=True
-                        )
-                        existing["originalPath"] = str(target_path)
-                        save_json_file(dest_sessions, existing)
-                    else:
-                        save_json_file(dest_sessions, rebuilt)
 
             # Execute safety renames
             for old_name, new_name in plan.renames:
@@ -1749,7 +1528,7 @@ if __name__ == "__main__":
             print(f"Orphaned folders ({len(orphans)}):")
             for o in orphans:
                 size_kb = o.total_size_bytes / 1024
-                orig = o.original_path_from_index or o.decoded_path or "unknown"
+                orig = o.original_path or o.decoded_path or "unknown"
                 print(f"  {o.folder_name}")
                 print(f"    Original: {orig}")
                 print(f"    Files: {o.file_count}, Size: {size_kb:.1f} KB")

--- a/scripts/project_manager.py
+++ b/scripts/project_manager.py
@@ -214,29 +214,29 @@ def get_original_path_from_folder(folder_path: Path) -> Optional[str]:
 
 def get_folder_original_path(folder_path: Path) -> Optional[str]:
     """
-    Resolve a project folder's original path, preferring whatever still exists.
+    Resolve a project folder's original path the same way the index does.
 
-    Tries ``sessions-index.json`` first (legacy/authoritative when present), then
-    falls back to the ``cwd`` recorded in the folder's newest ``.jsonl``
-    transcript. Current Claude Code no longer writes ``sessions-index.json``, so
-    the transcript ``cwd`` is the real source of truth.
+    Prefers the ``cwd`` recorded in the folder's newest ``.jsonl`` transcript,
+    falling back to ``sessions-index.json`` only when no transcript cwd exists.
+    Current Claude Code no longer writes ``sessions-index.json``, so the
+    transcript ``cwd`` is the real source of truth.
 
-    The fallback delegates to ``indexing._extract_from_jsonl`` rather than
+    The cwd lookup delegates to ``indexing._extract_from_jsonl`` rather than
     re-scanning, so this resolver uses the exact same newest-mtime ordering, scan
     limit, and ``cwd`` field as ``build_projects_index`` -- guaranteeing the path
-    we rewrite is the one the index will actually be rebuilt from.
+    we rewrite is the one the index will actually be rebuilt from, even when a
+    legacy ``sessions-index.json`` lingers with a stale, divergent path.
 
     Returns the path string, or None if neither source yields one.
     """
-    path = get_original_path_from_folder(folder_path)
-    if path:
-        return path
-
     # Local import: indexing depends only on memory_utils, so no import cycle.
     from indexing import _extract_from_jsonl
 
     cwd, _ = _extract_from_jsonl(Path(folder_path))
-    return cwd or None
+    if cwd:
+        return cwd
+
+    return get_original_path_from_folder(folder_path)
 
 
 # =============================================================================

--- a/skills/projects/SKILL.md
+++ b/skills/projects/SKILL.md
@@ -123,4 +123,4 @@ See `reference.md` for full function reference, additional workflow examples, an
 Claude Code encodes paths by replacing `/` and `.` with `-`:
 - `/home/user/my-project` → `-home-user-my-project`
 
-**Important**: This encoding is LOSSY (you cannot reliably decode it back). The authoritative original path is the `cwd` field inside the folder's `.jsonl` transcripts (`get_original_path_from_folder()` reads `sessions-index.json` when present, but current Claude Code no longer writes it, so `cwd` is the real source of truth).
+**Important**: This encoding is LOSSY (you cannot reliably decode it back). The authoritative original path is the `cwd` field inside the folder's `.jsonl` transcripts. Use `get_folder_original_path()` — it prefers the transcript `cwd` (the same signal `build_projects_index` keys on) and only falls back to `sessions-index.json` when no transcript cwd exists. (`get_original_path_from_folder()` is the legacy index-only reader.)

--- a/skills/projects/SKILL.md
+++ b/skills/projects/SKILL.md
@@ -14,6 +14,8 @@ Manage Claude Code project data (sessions, file history, memory) when projects a
 
 Consequence: a rename only sticks if the transcripts' `cwd` is updated. Change the index but leave the old `cwd` in the transcripts, and the next synthesis rebuild silently reverts your change. `execute_move` / `execute_merge_orphan` now rewrite `cwd` in the destination transcripts automatically — but **always confirm durability** with `rebuild_and_verify_index()` after executing.
 
+> Upstream: if Claude Code ships native session relocation (anthropics/claude-code#27967 — "Allow relocating active sessions to a new working directory"), parts of this move flow could defer to it. Until then, the `cwd` rewrite is the durable mechanism.
+
 ## Running
 
 Use a **3.10+ interpreter**. The system `python3` on macOS is 3.9 and crashes on this library's `X | None` type hints. Run snippets with `uv run --no-project python - <<'PY' … PY` (or an explicit `python3.12` / `python3.13`), never bare `python3`.

--- a/skills/projects/reference.md
+++ b/skills/projects/reference.md
@@ -44,7 +44,7 @@ for p in projects:
 
 if orphans:
     for o in orphans:
-        orig = o.original_path_from_index or "(unknown original path)"
+        orig = o.original_path or "(unknown original path)"
         print(f"  {o.folder_name} — Was: {orig}")
 ```
 

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -291,13 +291,14 @@ class TestExtractSessionMetadata:
     def test_ai_title_preferred_as_summary(self, tmp_path):
         f = self._write(
             tmp_path,
-            {"type": "user", "timestamp": "2026-03-01T09:00:00Z",
+            {"type": "user", "timestamp": "2026-03-01T09:00:00Z", "cwd": "/home/u/proj",
              "message": {"role": "user", "content": "first prompt text"}},
             {"type": "ai-title", "aiTitle": "Refactor the indexer"},
         )
-        created, summary = _extract_session_metadata(f)
+        created, summary, cwd = _extract_session_metadata(f)
         assert created == datetime(2026, 3, 1, 9, 0, tzinfo=timezone.utc)
         assert summary == "Refactor the indexer"
+        assert cwd == "/home/u/proj"
 
     def test_falls_back_to_first_user_prompt(self, tmp_path):
         f = self._write(
@@ -305,9 +306,10 @@ class TestExtractSessionMetadata:
             {"type": "user", "timestamp": "2026-03-02T08:30:00Z",
              "message": {"role": "user", "content": "investigate gh issue 146"}},
         )
-        created, summary = _extract_session_metadata(f)
+        created, summary, cwd = _extract_session_metadata(f)
         assert created == datetime(2026, 3, 2, 8, 30, tzinfo=timezone.utc)
         assert summary == "investigate gh issue 146"
+        assert cwd is None  # no cwd field present
 
     def test_skips_meta_and_wrapper_prompts(self, tmp_path):
         f = self._write(
@@ -321,7 +323,7 @@ class TestExtractSessionMetadata:
             {"type": "user",
              "message": {"role": "user", "content": "the real question"}},
         )
-        _created, summary = _extract_session_metadata(f)
+        _created, summary, _cwd = _extract_session_metadata(f)
         assert summary == "the real question"
 
     def test_list_content_blocks_flattened(self, tmp_path):
@@ -332,13 +334,39 @@ class TestExtractSessionMetadata:
                          "content": [{"type": "text", "text": "block one"},
                                      {"type": "text", "text": "block two"}]}},
         )
-        _created, summary = _extract_session_metadata(f)
+        _created, summary, _cwd = _extract_session_metadata(f)
         assert summary == "block one block two"
+
+    def test_non_string_timestamp_does_not_raise(self, tmp_path):
+        """A malformed (non-string) timestamp is tolerated, not an AttributeError."""
+        f = self._write(
+            tmp_path,
+            {"type": "user", "timestamp": 1770000000, "cwd": "/home/u/proj",
+             "message": {"role": "user", "content": "real prompt"}},
+        )
+        created, summary, cwd = _extract_session_metadata(f)
+        assert created is None  # bad timestamp ignored
+        assert summary == "real prompt"
+        assert cwd == "/home/u/proj"
+
+    def test_null_message_does_not_raise(self, tmp_path):
+        """A record with an explicit null `message` is tolerated (no AttributeError)."""
+        f = self._write(
+            tmp_path,
+            {"type": "user", "timestamp": "2026-03-05T08:00:00Z",
+             "cwd": "/home/u/proj", "message": None},
+            {"type": "user",
+             "message": {"role": "user", "content": "the next prompt"}},
+        )
+        created, summary, cwd = _extract_session_metadata(f)
+        assert created == datetime(2026, 3, 5, 8, 0, tzinfo=timezone.utc)
+        assert summary == "the next prompt"
+        assert cwd == "/home/u/proj"
 
     def test_empty_file_returns_none(self, tmp_path):
         f = tmp_path / "sess.jsonl"
         f.write_text("", encoding="utf-8")
-        assert _extract_session_metadata(f) == (None, None)
+        assert _extract_session_metadata(f) == (None, None, None)
 
 
 # =============================================================================
@@ -369,6 +397,8 @@ class TestListAllSessions:
         assert s.session_id == "abc"
         assert s.created == datetime(2026, 4, 1, 12, 0, tzinfo=timezone.utc)
         assert s.summary == "Do the thing"
+        # project_path is recovered from the transcript cwd even with no index.
+        assert s.project_path == "/home/user/proj"
 
     def test_index_overrides_transcript_when_present(self, tmp_path):
         projects_dir = tmp_path / "projects"

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -15,10 +15,12 @@ from helpers import make_jsonl_line, make_session_info  # noqa: I001
 from indexing import (
     DEFAULT_RECENCY_WINDOW_DAYS,
     MIN_SESSION_SIZE_BYTES,
+    _extract_session_metadata,
     _suggest_path_correction,
     build_projects_index,
     get_session_date,
     has_assistant_message,
+    list_all_sessions,
     list_recent_sessions,
 )
 from transcript_ops import (
@@ -271,6 +273,126 @@ class TestGetSessionDate:
         # mtime is set to now in the helper; get_session_date converts to local tz
         today = datetime.now().strftime("%Y-%m-%d")
         assert get_session_date(session) == today
+
+
+# =============================================================================
+# _extract_session_metadata Tests
+# =============================================================================
+
+
+class TestExtractSessionMetadata:
+    """Recover (created, summary) from a transcript without sessions-index.json."""
+
+    def _write(self, tmp_path, *records):
+        f = tmp_path / "sess.jsonl"
+        f.write_text("".join(json.dumps(r) + "\n" for r in records), encoding="utf-8")
+        return f
+
+    def test_ai_title_preferred_as_summary(self, tmp_path):
+        f = self._write(
+            tmp_path,
+            {"type": "user", "timestamp": "2026-03-01T09:00:00Z",
+             "message": {"role": "user", "content": "first prompt text"}},
+            {"type": "ai-title", "aiTitle": "Refactor the indexer"},
+        )
+        created, summary = _extract_session_metadata(f)
+        assert created == datetime(2026, 3, 1, 9, 0, tzinfo=timezone.utc)
+        assert summary == "Refactor the indexer"
+
+    def test_falls_back_to_first_user_prompt(self, tmp_path):
+        f = self._write(
+            tmp_path,
+            {"type": "user", "timestamp": "2026-03-02T08:30:00Z",
+             "message": {"role": "user", "content": "investigate gh issue 146"}},
+        )
+        created, summary = _extract_session_metadata(f)
+        assert created == datetime(2026, 3, 2, 8, 30, tzinfo=timezone.utc)
+        assert summary == "investigate gh issue 146"
+
+    def test_skips_meta_and_wrapper_prompts(self, tmp_path):
+        f = self._write(
+            tmp_path,
+            {"type": "user", "timestamp": "2026-03-03T08:00:00Z", "isMeta": True,
+             "message": {"role": "user", "content": "meta noise"}},
+            {"type": "user",
+             "message": {"role": "user", "content": "<command-name>/plugin</command-name>"}},
+            {"type": "user",
+             "message": {"role": "user", "content": "<local-command-caveat>x</local-command-caveat>"}},
+            {"type": "user",
+             "message": {"role": "user", "content": "the real question"}},
+        )
+        _created, summary = _extract_session_metadata(f)
+        assert summary == "the real question"
+
+    def test_list_content_blocks_flattened(self, tmp_path):
+        f = self._write(
+            tmp_path,
+            {"type": "user", "timestamp": "2026-03-04T08:00:00Z",
+             "message": {"role": "user",
+                         "content": [{"type": "text", "text": "block one"},
+                                     {"type": "text", "text": "block two"}]}},
+        )
+        _created, summary = _extract_session_metadata(f)
+        assert summary == "block one block two"
+
+    def test_empty_file_returns_none(self, tmp_path):
+        f = tmp_path / "sess.jsonl"
+        f.write_text("", encoding="utf-8")
+        assert _extract_session_metadata(f) == (None, None)
+
+
+# =============================================================================
+# list_all_sessions Tests
+# =============================================================================
+
+
+class TestListAllSessions:
+    """list_all_sessions recovers created/summary from transcripts (no index)."""
+
+    def test_recovers_created_and_summary_without_index(self, tmp_path):
+        projects_dir = tmp_path / "projects"
+        folder = projects_dir / "-home-user-proj"
+        folder.mkdir(parents=True)
+        (folder / "abc.jsonl").write_text(
+            json.dumps({"type": "user", "timestamp": "2026-04-01T12:00:00Z",
+                        "cwd": "/home/user/proj",
+                        "message": {"role": "user", "content": "do the thing"}}) + "\n"
+            + json.dumps({"type": "ai-title", "aiTitle": "Do the thing"}) + "\n",
+            encoding="utf-8",
+        )
+
+        with mock.patch("indexing.get_projects_dir", return_value=projects_dir):
+            sessions = list_all_sessions()
+
+        assert len(sessions) == 1
+        s = sessions[0]
+        assert s.session_id == "abc"
+        assert s.created == datetime(2026, 4, 1, 12, 0, tzinfo=timezone.utc)
+        assert s.summary == "Do the thing"
+
+    def test_index_overrides_transcript_when_present(self, tmp_path):
+        projects_dir = tmp_path / "projects"
+        folder = projects_dir / "-home-user-proj"
+        folder.mkdir(parents=True)
+        (folder / "abc.jsonl").write_text(
+            json.dumps({"type": "user", "timestamp": "2026-04-01T12:00:00Z",
+                        "cwd": "/home/user/proj",
+                        "message": {"role": "user", "content": "transcript prompt"}}) + "\n",
+            encoding="utf-8",
+        )
+        (folder / "sessions-index.json").write_text(json.dumps({
+            "originalPath": "/home/user/proj",
+            "entries": [{"sessionId": "abc", "created": "2026-04-01T08:00:00Z",
+                         "summary": "Index summary"}],
+        }), encoding="utf-8")
+
+        with mock.patch("indexing.get_projects_dir", return_value=projects_dir):
+            sessions = list_all_sessions()
+
+        s = sessions[0]
+        assert s.created == datetime(2026, 4, 1, 8, 0, tzinfo=timezone.utc)
+        assert s.summary == "Index summary"
+        assert s.project_path == "/home/user/proj"
 
 
 # =============================================================================
@@ -645,6 +767,32 @@ class TestBuildProjectsIndex:
         assert "2026-02-01" in data["workDays"]  # from sessions-index
         assert "2026-02-05" in data["workDays"]  # from JSONL
         assert "2026-02-10" in data["workDays"]  # from JSONL
+
+    def test_transcript_cwd_wins_over_stale_index_path(self, env):
+        """When both exist, the path comes from the transcript cwd, not the
+        (possibly stale) sessions-index.json originalPath; index work days are
+        still unioned in."""
+        projects_dir, memory_dir, index_file = env
+
+        # sessions-index.json records a STALE original path + one work day.
+        self._setup_project(
+            projects_dir,
+            "-home-user-proj",
+            "/home/user/STALE-old-path",
+            [_make_session_entry("s1", "2026-02-01T10:00:00Z")],
+        )
+        # The transcript carries the real current cwd + a different work day.
+        folder = projects_dir / "-home-user-proj"
+        self._make_jsonl_file(folder, "s2", "/home/user/proj", "2026-02-05T10:00:00Z")
+
+        result = build_projects_index()
+
+        assert len(result["projects"]) == 1
+        data = list(result["projects"].values())[0]
+        assert data["originalPath"] == "/home/user/proj"  # cwd wins
+        assert data["name"] == "proj"
+        assert "2026-02-01" in data["workDays"]  # index day still unioned
+        assert "2026-02-05" in data["workDays"]  # transcript day
 
     def test_jsonl_fallback_skips_empty_files(self, env):
         """Empty or tiny JSONL files are skipped."""
@@ -1076,25 +1224,26 @@ class TestBuildProjectsIndexFixPaths:
         return jsonl_path
 
     def test_fix_paths_corrects_stale_entry(self, env):
-        """--fix-paths replaces stale path with suggested correction."""
+        """--fix-paths replaces a stale transcript cwd with a suggested correction.
+
+        Post-inversion, a path is stale only when the transcript cwd itself
+        points at a missing dir (e.g. cross-machine migration). The home-
+        substitution strategy maps the stale /home/<user>/… cwd onto $HOME.
+        """
         projects_dir, memory_dir, index_file = env
 
-        # Create a live directory to match
-        live_dir = env[0].parent / "myproject"
+        # Simulate migration: real project now lives under a (mocked) $HOME.
+        fake_home = env[0].parent / "home"
+        live_dir = fake_home / "myproject"
         live_dir.mkdir(parents=True, exist_ok=True)
 
-        # Project folder with stale sessions-index but correct JSONL cwd
         folder = projects_dir / "-enc-myproject"
         folder.mkdir(parents=True)
-        sessions_index = {
-            "originalPath": "/home/stale/myproject",
-            "entries": [{"created": "2026-01-15T10:00:00Z",
-                         "projectPath": "/home/stale/myproject"}],
-        }
-        (folder / "sessions-index.json").write_text(json.dumps(sessions_index))
-        self._make_jsonl_file(folder, "s1", str(live_dir), "2026-01-15T10:00:00Z")
+        # Transcript still records the old machine's path (doesn't exist here).
+        self._make_jsonl_file(folder, "s1", "/home/olduser/myproject", "2026-01-15T10:00:00Z")
 
-        result = build_projects_index(fix_paths=True)
+        with mock.patch("indexing.Path.home", return_value=fake_home):
+            result = build_projects_index(fix_paths=True)
 
         projects = result["projects"]
         assert len(projects) == 1
@@ -1103,28 +1252,20 @@ class TestBuildProjectsIndexFixPaths:
         assert data["name"] == "myproject"
 
     def test_no_fix_without_flag(self, env):
-        """Without --fix-paths, stale entries are preserved with warnings."""
+        """Without --fix-paths, a stale transcript cwd is preserved (with warnings)."""
         projects_dir, memory_dir, index_file = env
-
-        live_dir = env[0].parent / "myproject"
-        live_dir.mkdir(parents=True, exist_ok=True)
 
         folder = projects_dir / "-enc-myproject"
         folder.mkdir(parents=True)
-        sessions_index = {
-            "originalPath": "/home/stale/myproject",
-            "entries": [{"created": "2026-01-15T10:00:00Z",
-                         "projectPath": "/home/stale/myproject"}],
-        }
-        (folder / "sessions-index.json").write_text(json.dumps(sessions_index))
-        self._make_jsonl_file(folder, "s1", str(live_dir), "2026-01-15T10:00:00Z")
+        # Stale cwd, no live directory to resolve to.
+        self._make_jsonl_file(folder, "s1", "/home/olduser/myproject", "2026-01-15T10:00:00Z")
 
         result = build_projects_index(fix_paths=False)
 
         projects = result["projects"]
         data = list(projects.values())[0]
-        # Path should still be stale
-        assert data["originalPath"] == "/home/stale/myproject"
+        # Path should still be the (stale) transcript cwd.
+        assert data["originalPath"] == "/home/olduser/myproject"
 
 
 if __name__ == "__main__":

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -349,6 +349,18 @@ class TestExtractSessionMetadata:
         assert summary == "real prompt"
         assert cwd == "/home/u/proj"
 
+    def test_tracks_earliest_timestamp_not_first(self, tmp_path):
+        """`created` is the minimum timestamp in the scan window, even if a
+        later record carries an earlier time than the first one."""
+        f = self._write(
+            tmp_path,
+            {"type": "file-history-snapshot", "timestamp": "2026-03-06T10:00:00Z"},
+            {"type": "user", "timestamp": "2026-03-06T09:00:00Z", "cwd": "/home/u/p",
+             "message": {"role": "user", "content": "go"}},
+        )
+        created, _summary, _cwd = _extract_session_metadata(f)
+        assert created == datetime(2026, 3, 6, 9, 0, tzinfo=timezone.utc)
+
     def test_null_message_does_not_raise(self, tmp_path):
         """A record with an explicit null `message` is tolerated (no AttributeError)."""
         f = self._write(

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -477,13 +477,24 @@ class TestGetFolderOriginalPath:
         f.write_text(json.dumps({"cwd": cwd, "timestamp": "2026-06-23T10:00:00.000Z"}) + "\n")
         return f
 
-    def test_prefers_sessions_index(self, tmp_path):
+    def test_prefers_transcript_cwd_over_index(self, tmp_path):
+        """The transcript cwd wins over a (possibly stale) sessions-index.json,
+        matching build_projects_index so the rewrite anchor is the indexed path."""
         folder = tmp_path / "folder"
         folder.mkdir()
         (folder / "sessions-index.json").write_text(json.dumps({
             "originalPath": "/from/index", "entries": [],
         }))
         self._write_transcript(folder, "sess1", "/from/cwd")
+        assert get_folder_original_path(folder) == "/from/cwd"
+
+    def test_falls_back_to_index_when_no_transcript_cwd(self, tmp_path):
+        """With only a legacy sessions-index.json (no transcript), use its path."""
+        folder = tmp_path / "folder"
+        folder.mkdir()
+        (folder / "sessions-index.json").write_text(json.dumps({
+            "originalPath": "/from/index", "entries": [],
+        }))
         assert get_folder_original_path(folder) == "/from/index"
 
     def test_falls_back_to_cwd_when_no_index(self, tmp_path):
@@ -610,6 +621,40 @@ class TestExecuteMergeOrphanEndToEnd:
         assert json.loads(merged.read_text().splitlines()[0])["cwd"] == str(target)
         # We never write sessions-index.json — current Claude Code ignores it.
         assert not (projects_dir / target_enc / "sessions-index.json").exists()
+
+    def test_rewrites_cwd_when_legacy_index_path_diverges(self, tmp_path):
+        """Seam contract: when a legacy sessions-index.json holds a path that
+        DIFFERS from the transcript cwd, the rewrite anchor must still be the
+        transcript cwd (what build_projects_index keys on) — otherwise the
+        rewrite matches nothing and the merge reverts on the next synthesis."""
+        _claude, projects_dir, index_file, patches = _fake_claude_env(tmp_path)
+
+        orphan_path = tmp_path / "work" / "orphan-proj"   # gone from disk
+        target = tmp_path / "work" / "target-proj"
+        target.mkdir(parents=True)
+
+        orphan_enc = encode_path(str(orphan_path))
+        target_enc = encode_path(str(target))
+        # Transcript records the REAL old path...
+        _write_cwd_transcript(projects_dir / orphan_enc, "osess", str(orphan_path))
+        # ...but a stale legacy sessions-index.json claims a DIFFERENT path.
+        (projects_dir / orphan_enc / "sessions-index.json").write_text(json.dumps({
+            "originalPath": "/stale/divergent/orphan-proj", "entries": [],
+        }))
+        _write_cwd_transcript(projects_dir / target_enc, "tsess", str(target))
+        index_file.write_text(json.dumps({"projects": {str(orphan_path).lower(): {
+            "name": "orphan-proj", "originalPath": str(orphan_path),
+            "encodedPaths": [orphan_enc], "workDays": ["2026-06-23"],
+        }}}))
+
+        with patches:
+            result = execute_merge_orphan(orphan_enc, target, confirmed=True)
+
+        assert result["success"] is True
+        # Anchored on the transcript cwd, not the stale index path → rewrite fires.
+        assert result["cwd_files_rewritten"] == 1
+        merged = projects_dir / target_enc / "osess.jsonl"
+        assert json.loads(merged.read_text().splitlines()[0])["cwd"] == str(target)
 
 
 class TestMoveDurabilityEndToEnd:

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -20,7 +20,6 @@ from project_manager import (  # noqa: I001
     get_folder_original_path,
     get_original_path_from_folder,
     list_projects,
-    merge_sessions_index,
     plan_cleanup,
     plan_merge_orphan,
     plan_move,
@@ -29,7 +28,6 @@ from project_manager import (  # noqa: I001
     restore_from_backup,
     rewrite_cwd_in_transcripts,
     rewrite_paths_in_file,
-    update_session_index_paths,
     validate_merge_orphan,
     validate_move,
 )
@@ -252,112 +250,6 @@ class TestPlanMergeOrphan:
 
         assert len(plan.merges) == 1, f"Expected 1 merge, got {plan.merges}"
         assert len(plan.renames) == 1, f"Expected 1 rename, got {plan.renames}"
-
-
-# =============================================================================
-# Merge Sessions Index Tests
-# =============================================================================
-
-
-class TestMergeSessionsIndex:
-    """Tests for merge_sessions_index function."""
-
-    def test_merge_disjoint_entries(self, tmp_path):
-        """Two files with different sessions should combine all."""
-        source = tmp_path / "source.json"
-        dest = tmp_path / "dest.json"
-
-        source.write_text(json.dumps({
-            "originalPath": "/old/path",
-            "entries": [
-                {"id": "session-1", "created": "2026-01-01T10:00:00Z"},
-                {"id": "session-2", "created": "2026-01-02T10:00:00Z"},
-            ]
-        }))
-
-        dest.write_text(json.dumps({
-            "originalPath": "/new/path",
-            "entries": [
-                {"id": "session-3", "created": "2026-01-03T10:00:00Z"},
-            ]
-        }))
-
-        merged_count = merge_sessions_index(source, dest)
-        assert merged_count == 2
-
-        result = json.loads(dest.read_text())
-        assert len(result["entries"]) == 3
-
-    def test_merge_duplicate_sessions_keeps_newer(self, tmp_path):
-        """Duplicate session IDs should keep the one with newer timestamp."""
-        source = tmp_path / "source.json"
-        dest = tmp_path / "dest.json"
-
-        source.write_text(json.dumps({
-            "originalPath": "/old/path",
-            "entries": [
-                {"id": "session-1", "created": "2026-01-01T10:00:00Z",
-                 "lastActive": "2026-01-01T15:00:00Z"},  # Newer
-            ]
-        }))
-
-        dest.write_text(json.dumps({
-            "originalPath": "/new/path",
-            "entries": [
-                {"id": "session-1", "created": "2026-01-01T10:00:00Z",
-                 "lastActive": "2026-01-01T12:00:00Z"},  # Older
-            ]
-        }))
-
-        merged_count = merge_sessions_index(source, dest)
-        assert merged_count == 1
-
-        result = json.loads(dest.read_text())
-        assert len(result["entries"]) == 1
-        assert result["entries"][0]["lastActive"] == "2026-01-01T15:00:00Z"
-
-    def test_merge_into_empty(self, tmp_path):
-        """Merging into file with no entries should work."""
-        source = tmp_path / "source.json"
-        dest = tmp_path / "dest.json"
-
-        source.write_text(json.dumps({
-            "originalPath": "/old/path",
-            "entries": [
-                {"id": "session-1", "created": "2026-01-01T10:00:00Z"},
-            ]
-        }))
-
-        dest.write_text(json.dumps({
-            "originalPath": "/new/path",
-            "entries": []
-        }))
-
-        merged_count = merge_sessions_index(source, dest)
-        assert merged_count == 1
-
-        result = json.loads(dest.read_text())
-        assert len(result["entries"]) == 1
-
-    def test_merge_empty_source(self, tmp_path):
-        """Merging from empty source should not change dest."""
-        source = tmp_path / "source.json"
-        dest = tmp_path / "dest.json"
-
-        source.write_text(json.dumps({
-            "originalPath": "/old/path",
-            "entries": []
-        }))
-
-        dest.write_text(json.dumps({
-            "originalPath": "/new/path",
-            "entries": [
-                {"id": "session-1", "created": "2026-01-01T10:00:00Z"},
-            ]
-        }))
-
-        merged_count = merge_sessions_index(source, dest)
-        assert merged_count == 0
 
 
 # =============================================================================
@@ -716,6 +608,8 @@ class TestExecuteMergeOrphanEndToEnd:
         merged = projects_dir / target_enc / "osess.jsonl"
         assert merged.exists()
         assert json.loads(merged.read_text().splitlines()[0])["cwd"] == str(target)
+        # We never write sessions-index.json — current Claude Code ignores it.
+        assert not (projects_dir / target_enc / "sessions-index.json").exists()
 
 
 class TestMoveDurabilityEndToEnd:
@@ -1014,100 +908,6 @@ class TestListProjects:
 
 
 # =============================================================================
-# Update Session Index Paths Tests
-# =============================================================================
-
-
-class TestUpdateSessionIndexPaths:
-    """Tests for update_session_index_paths function."""
-
-    def test_updates_matching_files(self, tmp_path):
-        """Should update sessions-index.json files containing old path."""
-        projects_dir = tmp_path / "projects"
-        projects_dir.mkdir()
-
-        # Create two project folders with sessions-index.json
-        folder1 = projects_dir / "-home-user-old-project"
-        folder1.mkdir()
-        (folder1 / "sessions-index.json").write_text(json.dumps({
-            "originalPath": "/home/user/old-project",
-            "entries": []
-        }))
-
-        folder2 = projects_dir / "-home-user-old-project-sub"
-        folder2.mkdir()
-        (folder2 / "sessions-index.json").write_text(json.dumps({
-            "originalPath": "/home/user/old-project/sub",
-            "entries": []
-        }))
-
-        with mock.patch("project_manager.get_projects_dir") as mock_dir:
-            mock_dir.return_value = projects_dir
-
-            count = update_session_index_paths(
-                "/home/user/old-project", "/home/user/new-project"
-            )
-
-        assert count == 2
-
-        data1 = json.loads((folder1 / "sessions-index.json").read_text())
-        assert data1["originalPath"] == "/home/user/new-project"
-
-        data2 = json.loads((folder2 / "sessions-index.json").read_text())
-        assert data2["originalPath"] == "/home/user/new-project/sub"
-
-    def test_skips_non_matching_files(self, tmp_path):
-        """Should not modify files that don't contain old path."""
-        projects_dir = tmp_path / "projects"
-        projects_dir.mkdir()
-
-        folder = projects_dir / "-home-user-other"
-        folder.mkdir()
-        original = json.dumps({
-            "originalPath": "/home/user/other",
-            "entries": []
-        })
-        (folder / "sessions-index.json").write_text(original)
-
-        with mock.patch("project_manager.get_projects_dir") as mock_dir:
-            mock_dir.return_value = projects_dir
-
-            count = update_session_index_paths(
-                "/home/user/old-project", "/home/user/new-project"
-            )
-
-        assert count == 0
-        assert (folder / "sessions-index.json").read_text() == original
-
-    def test_skips_folders_without_sessions_index(self, tmp_path):
-        """Should skip folders that don't have sessions-index.json."""
-        projects_dir = tmp_path / "projects"
-        projects_dir.mkdir()
-
-        folder = projects_dir / "-home-user-old-project"
-        folder.mkdir()
-        # No sessions-index.json created
-
-        with mock.patch("project_manager.get_projects_dir") as mock_dir:
-            mock_dir.return_value = projects_dir
-
-            count = update_session_index_paths(
-                "/home/user/old-project", "/home/user/new-project"
-            )
-
-        assert count == 0
-
-    def test_returns_zero_for_missing_projects_dir(self):
-        """Should return 0 if projects directory doesn't exist."""
-        with mock.patch("project_manager.get_projects_dir") as mock_dir:
-            mock_dir.return_value = Path("/nonexistent/projects")
-
-            count = update_session_index_paths("/old", "/new")
-
-        assert count == 0
-
-
-# =============================================================================
 # Find Orphaned Folders Tests
 # =============================================================================
 
@@ -1220,6 +1020,28 @@ class TestFindOrphanedFolders:
 
         orphans = self._find_orphans(tmp_path, index)
         assert len(orphans) == 0
+
+    def test_untracked_folder_resolves_path_from_transcript_cwd(self, tmp_path):
+        """With no sessions-index.json, an untracked folder whose transcript cwd
+        points at a missing path is an orphan, and original_path is the cwd."""
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
+
+        folder = projects_dir / "-home-user-gone-project"
+        folder.mkdir()
+        # No sessions-index.json — only a transcript carrying the cwd.
+        (folder / "sess.jsonl").write_text(json.dumps({
+            "cwd": "/home/user/gone-project",
+            "timestamp": "2026-01-01T10:00:00Z",
+        }) + "\n")
+
+        index = {"projects": {}}  # Not tracked
+
+        orphans = self._find_orphans(tmp_path, index)
+        assert len(orphans) == 1
+        assert orphans[0].folder_name == "-home-user-gone-project"
+        assert orphans[0].original_path == "/home/user/gone-project"
+        assert orphans[0].sessions_index_path is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Resolves #146. Inverts the long-standing `sessions-index.json`-primary / JSONL-`cwd`-fallback priority so the transcript `cwd` is the authoritative source for a project's path and metadata. Current Claude Code no longer reliably writes `sessions-index.json` (0/33 folders here; deprecated upstream), so the old "primary" branch was dead and the fallback did all the work. Builds on the cwd-rewrite durability mechanism from #147.

- **`indexing.py`** — `build_projects_index` derives path + work days from the transcript `cwd` first; `sessions-index.json` is read only as enrichment when present. New `_extract_session_metadata` recovers each session's real `created` date (earliest transcript timestamp — robust to mtime changing on copy) and a human-readable `summary` (`ai-title`, else first substantive user prompt), wired into `list_all_sessions`.
- **`project_manager.py`** — deletes the dead index-write helpers (`update_session_index_paths` no-op, `rebuild_sessions_index`, `merge_sessions_index`) and their call-sites; no code path writes `sessions-index.json` anymore. `get_folder_original_path` now prefers the transcript `cwd` (matching `build_projects_index`), so the orphan-merge rewrite anchor can't be thrown off by a lingering stale legacy index. Orphan detection resolves by `cwd`; `OrphanInfo.original_path_from_index` → `original_path`. Read-when-present support is kept for legacy Desktop/VS Code resume.
- **docs** — `/projects` skill points at `get_folder_original_path()`; notes upstream anthropics/claude-code#27967.

Net **−143 lines**.

## Test plan

- `uv run --with pytest -m pytest tests/ -q` → **855 passed** (incl. new `_extract_session_metadata`, `list_all_sessions` recovery, cwd-wins-over-stale-index, orphan-by-cwd, and a divergent-legacy-index boundary test for the merge-orphan rewrite seam).
- Real `build-index` against live `~/.claude/projects` resolves `investigation-plugin` cleanly (the project from the original revert bug); 202/275 sessions recovered a summary, 267/275 a real created date.
- Passed a standalone implementation review (3 findings, all fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session and project details now more reliably recover original paths, dates, and summaries directly from transcript content.
  * Orphaned project detection now uses the recovered original path for more accurate status reporting.

* **Bug Fixes**
  * Improved handling of stale or missing legacy index data during moves, merges, and path fixes.
  * Project listings now better preserve transcript-derived information while still using legacy data only as fallback/enrichment.

* **Documentation**
  * Clarified path recovery and move/rename behavior in project guidance and reference examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->